### PR TITLE
ci(deploy): 接入 HTTPS 入口和数据库冒烟测试

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,15 +90,15 @@ jobs:
             mkdir -p "${{ secrets.DEPLOY_PATH }}"
             docker network inspect clubhub-net >/dev/null 2>&1 || docker network create clubhub-net
 
-      # ---- 上传 docker-compose.yml 到服务器 ----
-      - name: 上传 docker-compose.yml
+      # ---- 上传部署编排文件到服务器 ----
+      - name: 上传部署编排文件
         uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
           port: ${{ secrets.SERVER_PORT }}
-          source: docker-compose.yml
+          source: docker-compose.yml,Caddyfile
           target: ${{ secrets.DEPLOY_PATH }}
 
       # ---- 服务器上拉取镜像并重启 ----
@@ -113,6 +113,12 @@ jobs:
             set -e
             cd "${{ secrets.DEPLOY_PATH }}"
 
+            if [ -z "${{ secrets.APP_HOST }}" ]; then
+              echo "!!! APP_HOST Secret 未配置，无法申请 HTTPS 证书 !!!"
+              exit 1
+            fi
+            printf 'APP_HOST=%s\n' "${{ secrets.APP_HOST }}" > .env
+
             echo "=== 登录 ghcr.io ==="
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
@@ -120,11 +126,16 @@ jobs:
             docker compose pull
 
             echo "=== 启动服务 ==="
-            docker compose up -d
+            docker compose up -d --remove-orphans
 
             echo "=== 等待服务启动 ==="
             sleep 10
             docker compose ps
+            if ! docker compose ps --services --status running | grep -q "^caddy$"; then
+              echo "!!! HTTPS 入口服务未运行 !!!"
+              docker compose logs --tail 80 caddy
+              exit 1
+            fi
             if ! docker compose ps --services --status running | grep -q "^backend$"; then
               echo "!!! 后端服务未运行 !!!"
               docker compose logs --tail 50
@@ -136,8 +147,20 @@ jobs:
               exit 1
             fi
 
-            echo "=== 应用健康检查 ==="
-            curl -fsS http://127.0.0.1/api/health
+            echo "=== HTTPS 健康检查 ==="
+            health_ok=0
+            for i in $(seq 1 30); do
+              if curl -fsS --resolve "${{ secrets.APP_HOST }}:443:127.0.0.1" "https://${{ secrets.APP_HOST }}/api/health"; then
+                health_ok=1
+                break
+              fi
+              sleep 5
+            done
+            if [ "$health_ok" -ne 1 ]; then
+              echo "!!! HTTPS 健康检查失败 !!!"
+              docker compose logs --tail 100 caddy frontend backend
+              exit 1
+            fi
 
             echo "=== 部署成功 ==="
             docker compose ps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,7 @@ feat(club): 新增社团成员角色管理
 
 - 表结构基线是 `database/schema.sql`。
 - 验证脚本是 `database/verify.sql`。
+- 连通性冒烟测试脚本是 `database/smoke_test.sql`。
 - 新增演示数据放 `database/seeds/`。
 - 新增统计视图放 `database/views/`。
 - 新增结构变更放 `database/migrations/`。
@@ -269,8 +270,11 @@ CI 内部三个 Job：
 | `SERVER_USER` | 部署用户 `deploy`，不用 root。 |
 | `SERVER_SSH_KEY` | GitHub Actions 专用 SSH 私钥。 |
 | `DEPLOY_PATH` | 服务器部署目录，例如 `/opt/clubhub`。 |
+| `APP_HOST` | HTTPS 访问域名，例如 `47-116-31-246.sslip.io`。 |
 
 服务器已创建 `deploy` 用户，将其加入 `docker` 组，并保证该用户可以写入 `DEPLOY_PATH`。生产 `docker-compose.yml` 使用 `clubhub-net` 外部网络；Oracle 容器和应用容器应连接到同一个网络。不把 Oracle 1521 端口直接暴露到公网。
+
+生产入口由 Caddy 容器负责：公网只开放 `80` 和 `443`，Caddy 自动申请 HTTPS 证书并反向代理到前端容器。前端和后端只在 Docker 网络内部通信，不直接暴露 `5000` 或 Oracle `1521` 到公网。
 
 ### PR 门禁（feature → dev）
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,4 @@
+{$APP_HOST} {
+    encode gzip
+    reverse_proxy frontend:80
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ClubHub 是《数据库课程设计》项目，面向高校社团日常运营场
 - 前端：Vue 3 / Vite
 - 数据库：Oracle Database 18c 或更高版本
 - 数据访问：Oracle Managed Data Access / ODP.NET，必要时使用 Oracle EF Core Provider
+- 部署：Docker Compose / Caddy HTTPS / GitHub Actions
 - 协作：GitHub Issues / Pull Requests / GitHub Actions
 
 ## 目录结构

--- a/database/README.md
+++ b/database/README.md
@@ -4,6 +4,7 @@
 
 - `schema.sql`：第一次数据库设计作业形成的建表脚本。
 - `verify.sql`：验证当前用户、表数量和表名。
+- `smoke_test.sql`：验证应用用户可以 SELECT、INSERT 并回滚。
 - `seeds/`：后续放演示数据。
 - `views/`：后续放统计视图。
 - `migrations/`：后续放表结构演进说明或迁移脚本。
@@ -17,6 +18,8 @@
 ## 验证
 
 在 SQL Developer 中打开并执行 `verify.sql`。
+
+如果需要确认数据库账号具有基本读写能力，执行 `smoke_test.sql`。该脚本会插入一条临时数据并立即回滚，正常情况下不会留下测试数据。
 
 当前已验证 `CLUBHUB` 用户下共有 22 张表。
 

--- a/database/smoke_test.sql
+++ b/database/smoke_test.sql
@@ -1,0 +1,66 @@
+-- ClubHub 数据库连通性冒烟测试。
+-- 使用方式：以 CLUBHUB 应用用户连接 Oracle 后执行本脚本。
+-- 本脚本会插入一条临时角色数据，然后立即回滚，不应留下测试数据。
+
+SET SERVEROUTPUT ON;
+SET VERIFY OFF;
+
+SELECT USER AS current_user FROM dual;
+
+SELECT COUNT(*) AS table_count
+FROM user_tables;
+
+DECLARE
+  v_before_count NUMBER;
+  v_after_insert_count NUMBER;
+  v_after_rollback_count NUMBER;
+BEGIN
+  SELECT COUNT(*)
+  INTO v_before_count
+  FROM roles
+  WHERE role_code = 'CLUBHUB_SMOKE_TEST';
+
+  SAVEPOINT clubhub_smoke_test;
+
+  INSERT INTO roles (
+    role_id,
+    role_code,
+    role_name,
+    role_scope,
+    permission_desc,
+    created_at
+  )
+  SELECT
+    NVL(MIN(role_id), 0) - 1,
+    'CLUBHUB_SMOKE_TEST',
+    '数据库连通性测试角色',
+    'SYSTEM',
+    '临时插入测试，脚本结束前回滚。',
+    SYSDATE
+  FROM roles;
+
+  SELECT COUNT(*)
+  INTO v_after_insert_count
+  FROM roles
+  WHERE role_code = 'CLUBHUB_SMOKE_TEST';
+
+  IF v_after_insert_count <> v_before_count + 1 THEN
+    RAISE_APPLICATION_ERROR(-20001, '数据库插入测试失败。');
+  END IF;
+
+  ROLLBACK TO clubhub_smoke_test;
+
+  SELECT COUNT(*)
+  INTO v_after_rollback_count
+  FROM roles
+  WHERE role_code = 'CLUBHUB_SMOKE_TEST';
+
+  IF v_after_rollback_count <> v_before_count THEN
+    RAISE_APPLICATION_ERROR(-20002, '数据库回滚测试失败。');
+  END IF;
+
+  DBMS_OUTPUT.PUT_LINE('数据库 SELECT / INSERT / ROLLBACK 冒烟测试通过。');
+END;
+/
+
+ROLLBACK;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,23 @@
 # 服务器上运行：docker compose up -d
 
 services:
+  caddy:
+    image: caddy:2-alpine
+    environment:
+      APP_HOST: ${APP_HOST}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - frontend
+    networks:
+      - clubhub-net
+    restart: unless-stopped
+
   backend:
     image: ghcr.io/palind-rome/clubhub-backend:latest
     environment:
@@ -17,8 +34,8 @@ services:
 
   frontend:
     image: ghcr.io/palind-rome/clubhub-frontend:latest
-    ports:
-      - "80:80"
+    expose:
+      - "80"
     depends_on:
       - backend
     networks:
@@ -28,3 +45,7 @@ services:
 networks:
   clubhub-net:
     external: true
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
* 做了什么：新增 Caddy HTTPS 入口配置，部署工作流同步上传 Caddyfile 并做 HTTPS 健康检查。
* 做了什么：新增 database/smoke_test.sql，用应用用户验证 SELECT、INSERT 和 ROLLBACK。
* 影响范围：部署编排、GitHub Actions 部署流程、数据库验证说明。
* 注意事项：服务器安全组需要开放 443，Oracle 1521 和后端 5000 仍不对公网开放。

## 修改摘要

-

## 课程功能点

- Issue Closes #
- 对应功能点：
- 覆盖的业务规则：

## 影响范围

- [ ] 后端
- [ ] 前端
- [ ] 数据库
- [ ] 课程文档
- [ ] CI/CD 或部署

## 验证

- [ ] 已本地构建
- [ ] 已手工测试
- [ ] 已新增或更新自动化测试
- [ ] 如有需要，已更新数据库脚本或课程文档

## 数据库影响

- [ ] 无表结构变化
- [ ] 表结构变化已写入 `database/`
- [ ] 新增或调整了种子数据、视图、索引、触发器、存储过程
- [ ] 需要人工执行迁移脚本

## 部署影响

- [ ] 不影响部署
- [ ] 需要新增或修改 GitHub Secrets
- [ ] 需要修改服务器配置
- [ ] 需要手动执行数据库迁移
