### PR TITLE
feat: 最小前后端基础框架（stub 接口 + Vue 页面）

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16,7 +16,6 @@ paths:
   /api/health:
     get:
       summary: 健康检查
-      description: 返回 API 服务运行状态。
       operationId: healthCheck
       responses:
         "200":
@@ -26,6 +25,70 @@ paths:
               schema:
                 $ref: "#/components/schemas/HealthStatus"
 
+  /api/clubs:
+    get:
+      summary: 获取社团列表
+      operationId: getClubs
+      responses:
+        "200":
+          description: 社团列表
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Club"
+
+  /api/clubs/{clubId}:
+    get:
+      summary: 获取社团详情
+      operationId: getClubById
+      parameters:
+        - name: clubId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: 社团详情
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Club"
+
+  /api/activities:
+    get:
+      summary: 获取活动列表
+      operationId: getActivities
+      responses:
+        "200":
+          description: 活动列表
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Activity"
+
+  /api/activities/{activityId}:
+    get:
+      summary: 获取活动详情
+      operationId: getActivityById
+      parameters:
+        - name: activityId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: 活动详情
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Activity"
+
 components:
   schemas:
     HealthStatus:
@@ -33,12 +96,71 @@ components:
       properties:
         status:
           type: string
-          description: 服务状态
           example: healthy
         timestamp:
           type: string
           format: date-time
-          description: 当前时间
       required:
         - status
         - timestamp
+
+    Club:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        category:
+          type: string
+        memberCount:
+          type: integer
+        presidentName:
+          type: string
+        establishedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - category
+        - memberCount
+        - presidentName
+
+    Activity:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        clubName:
+          type: string
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+        location:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [draft, published, ongoing, finished, cancelled]
+        maxParticipants:
+          type: integer
+          nullable: true
+        currentParticipants:
+          type: integer
+      required:
+        - id
+        - title
+        - clubName
+        - startTime
+        - endTime
+        - status
+        - currentParticipants

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClubHub.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ActivitiesController : ControllerBase
+{
+    private static readonly List<ActivityDto> Activities =
+    [
+        new(1, "2025 秋季 Hackathon", "计算机协会", new DateTime(2025, 10, 15, 9, 0, 0), new DateTime(2025, 10, 15, 18, 0, 0), "大学生活动中心 301", "published", 60, 38),
+        new(2, "校园摄影大赛作品展", "摄影社", new DateTime(2025, 11, 1, 10, 0, 0), new DateTime(2025, 11, 3, 17, 0, 0), "图书馆一楼展厅", "published", null, 12),
+        new(3, "羽毛球新生杯", "羽毛球协会", new DateTime(2025, 10, 20, 14, 0, 0), new DateTime(2025, 10, 20, 17, 0, 0), "体育馆羽毛球场", "draft", 32, 0),
+    ];
+
+    [HttpGet]
+    public IActionResult GetAll() => Ok(Activities);
+
+    [HttpGet("{activityId:int}")]
+    public IActionResult GetById(int activityId)
+    {
+        var activity = Activities.FirstOrDefault(a => a.Id == activityId);
+        return activity is null ? NotFound() : Ok(activity);
+    }
+}
+
+public record ActivityDto(
+    int Id,
+    string Title,
+    string ClubName,
+    DateTime StartTime,
+    DateTime EndTime,
+    string? Location,
+    string Status,
+    int? MaxParticipants,
+    int CurrentParticipants
+);

--- a/backend/Controllers/ClubsController.cs
+++ b/backend/Controllers/ClubsController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClubHub.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ClubsController : ControllerBase
+{
+    private static readonly List<ClubDto> Clubs =
+    [
+        new(1, "计算机协会", "编程竞赛、技术分享、黑客松组织", "学术科技", 42, "张三", new DateTime(2024, 9, 1)),
+        new(2, "摄影社", "校园摄影采风、人像摄影教学、作品展览", "文化艺术", 28, "李四", new DateTime(2024, 9, 15)),
+        new(3, "羽毛球协会", "每周训练、校内联赛、校际交流赛", "体育竞技", 35, "王五", new DateTime(2024, 3, 10)),
+    ];
+
+    [HttpGet]
+    public IActionResult GetAll() => Ok(Clubs);
+
+    [HttpGet("{clubId:int}")]
+    public IActionResult GetById(int clubId)
+    {
+        var club = Clubs.FirstOrDefault(c => c.Id == clubId);
+        return club is null ? NotFound() : Ok(club);
+    }
+}
+
+public record ClubDto(
+    int Id,
+    string Name,
+    string? Description,
+    string Category,
+    int MemberCount,
+    string PresidentName,
+    DateTime? EstablishedAt
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.39"
+    "vue": "^3.5.39",
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@6.0.3)
+      vue-router:
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.39(typescript@6.0.3))
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -202,6 +205,9 @@ packages:
 
   '@vue/compiler-ssr@3.5.39':
     resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/language-core@3.3.6':
     resolution: {integrity: sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==}
@@ -434,6 +440,11 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
   vue-tsc@3.3.6:
     resolution: {integrity: sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==}
     hasBin: true
@@ -597,6 +608,8 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.39
       '@vue/shared': 3.5.39
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/language-core@3.3.6':
     dependencies:
@@ -770,6 +783,11 @@ snapshots:
       fsevents: 2.3.3
 
   vscode-uri@3.1.0: {}
+
+  vue-router@4.6.4(vue@3.5.39(typescript@6.0.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.39(typescript@6.0.3)
 
   vue-tsc@3.3.6(typescript@6.0.3):
     dependencies:

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,7 +13,6 @@ const error = ref("");
 async function checkHealth() {
   loading.value = true;
   error.value = "";
-  health.value = null;
   try {
     const res = await fetch("/api/health");
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -27,47 +26,41 @@ async function checkHealth() {
 </script>
 
 <template>
-  <div class="container">
+  <header>
     <h1>ClubHub</h1>
-    <p>高校社团运营与协同管理平台</p>
+    <nav>
+      <router-link to="/clubs">社团</router-link>
+      <router-link to="/activities">活动</router-link>
+      <button class="health-btn" @click="checkHealth" :disabled="loading">
+        {{ loading ? "…" : "health" }}
+      </button>
+    </nav>
+  </header>
 
-    <button @click="checkHealth" :disabled="loading">
-      {{ loading ? "检查中…" : "检查后端连接" }}
-    </button>
+  <div v-if="health" class="banner ok">后端连接正常</div>
+  <div v-if="error" class="banner error">{{ error }}</div>
 
-    <div v-if="health" class="result ok">
-      <p>状态：{{ health.status }}</p>
-      <p>时间：{{ new Date(health.timestamp).toLocaleString() }}</p>
-    </div>
-    <div v-if="error" class="result error">
-      <p>连接失败：{{ error }}</p>
-    </div>
-  </div>
+  <main>
+    <router-view />
+  </main>
 </template>
 
 <style scoped>
-.container {
-  max-width: 480px;
-  margin: 80px auto;
-  text-align: center;
-  font-family: system-ui, sans-serif;
+header {
+  background: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  padding: 12px 24px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
 }
-button {
-  padding: 10px 24px;
-  font-size: 16px;
-  cursor: pointer;
-}
-.result {
-  margin-top: 24px;
-  padding: 16px;
-  border-radius: 8px;
-}
-.ok {
-  background: #e8f5e9;
-  color: #2e7d32;
-}
-.error {
-  background: #fce4ec;
-  color: #c62828;
-}
+header h1 { font-size: 20px; margin: 0; }
+nav { display: flex; gap: 16px; align-items: center; }
+nav a { color: #333; text-decoration: none; font-size: 15px; }
+nav a:hover { color: #1976d2; }
+.health-btn { font-size: 12px; padding: 2px 8px; cursor: pointer; }
+.banner { text-align: center; padding: 8px; font-size: 14px; }
+.ok { background: #e8f5e9; color: #2e7d32; }
+.error { background: #fce4ec; color: #c62828; }
+main { padding: 24px; }
 </style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,8 @@
-import { createApp } from 'vue'
-import './style.css'
-import App from './App.vue'
+import { createApp } from "vue";
+import "./style.css";
+import App from "./App.vue";
+import router from "./router";
 
-createApp(App).mount('#app')
+const app = createApp(App);
+app.use(router);
+app.mount("#app");

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,0 +1,14 @@
+import { createRouter, createWebHistory } from "vue-router";
+import ClubList from "../views/ClubList.vue";
+import ActivityList from "../views/ActivityList.vue";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: "/", redirect: "/clubs" },
+    { path: "/clubs", component: ClubList },
+    { path: "/activities", component: ActivityList },
+  ],
+});
+
+export default router;

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+
+interface Activity {
+  id: number;
+  title: string;
+  clubName: string;
+  startTime: string;
+  endTime: string;
+  location: string | null;
+  status: string;
+  maxParticipants: number | null;
+  currentParticipants: number;
+}
+
+const activities = ref<Activity[]>([]);
+const loading = ref(true);
+
+const statusLabel: Record<string, string> = {
+  draft: "草稿",
+  published: "报名中",
+  ongoing: "进行中",
+  finished: "已结束",
+  cancelled: "已取消",
+};
+
+onMounted(async () => {
+  try {
+    const res = await fetch("/api/activities");
+    activities.value = await res.json();
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="page">
+    <h2>活动列表</h2>
+    <div v-if="loading">加载中…</div>
+    <div v-else class="grid">
+      <div v-for="act in activities" :key="act.id" class="card">
+        <h3>{{ act.title }}</h3>
+        <div class="meta">{{ act.clubName }}</div>
+        <div class="meta">{{ new Date(act.startTime).toLocaleString() }} — {{ new Date(act.endTime).toLocaleString() }}</div>
+        <div v-if="act.location" class="meta">地点：{{ act.location }}</div>
+        <div class="meta">
+          <span class="tag">{{ statusLabel[act.status] || act.status }}</span>
+          参与人数：{{ act.currentParticipants }}{{ act.maxParticipants ? ' / ' + act.maxParticipants : '' }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.page { max-width: 720px; margin: 0 auto; }
+.grid { display: flex; flex-direction: column; gap: 16px; margin-top: 16px; }
+.card { background: #fff; border-radius: 8px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+.card h3 { margin: 0 0 8px; }
+.meta { font-size: 14px; color: #666; margin-bottom: 4px; }
+.tag { background: #e3f2fd; color: #1976d2; padding: 1px 8px; border-radius: 4px; font-size: 12px; margin-right: 8px; }
+</style>

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+
+interface Club {
+  id: number;
+  name: string;
+  description: string | null;
+  category: string;
+  memberCount: number;
+  presidentName: string;
+}
+
+const clubs = ref<Club[]>([]);
+const loading = ref(true);
+
+onMounted(async () => {
+  try {
+    const res = await fetch("/api/clubs");
+    clubs.value = await res.json();
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="page">
+    <h2>社团列表</h2>
+    <div v-if="loading">加载中…</div>
+    <div v-else class="grid">
+      <div v-for="club in clubs" :key="club.id" class="card">
+        <h3>{{ club.name }}</h3>
+        <div class="meta">{{ club.category }} · {{ club.memberCount }} 人</div>
+        <div class="meta">社长：{{ club.presidentName }}</div>
+        <p v-if="club.description">{{ club.description }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.page { max-width: 720px; margin: 0 auto; }
+.grid { display: flex; flex-direction: column; gap: 16px; margin-top: 16px; }
+.card { background: #fff; border-radius: 8px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+.card h3 { margin: 0 0 8px; }
+.meta { font-size: 14px; color: #666; margin-bottom: 4px; }
+</style>


### PR DESCRIPTION
## 修改摘要

- api/openapi.yaml 新增 4 个端点（GET /api/clubs、/api/clubs/{id}、/api/activities、/api/activities/{id}）
- 新增 ClubsController + ActivitiesController（硬编码 mock 数据，不连数据库）
- 前端安装 vue-router，新增 ClubList.vue + ActivityList.vue 页面
- App.vue 改为导航 + router-view 布局

## 验证

```
curl localhost:5000/api/clubs              → 3 个社团 JSON ✅
curl localhost:5000/api/clubs/1            → 计算机协会 ✅
curl localhost:5000/api/activities         → 3 个活动 JSON ✅
curl localhost:5000/api/activities/1       → 秋季 Hackathon ✅
dotnet build --configuration Release       → 0 errors ✅
pnpm run build                             → 通过 ✅
```

## 影响范围

- [x] 后端
- [x] 前端

## 后续计划

- 接入 Oracle 数据库替换 mock 数据
- 详情页独立路由
- 前端增加错误状态和空数据 UI