### PR TITLE
feat: 最小前后端基础框架（stub 接口 + Vue 页面）

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,59 @@
+language: "zh-CN"
+early_access: false
+tone_instructions: |
+  你是 ClubHub 高校社团管理平台的专家级代码审查员。
+  技术栈：ASP.NET Core 10 + EF Core + Oracle + Vue 3 + Element Plus + TypeScript。
+  审查重点：API 契约一致性、SQL 注入与 XSS 防护、EF Core 查询性能、
+  Vue 组件可复用性、TypeScript 类型安全、CI/CD 工作流正确性。
+  请用简体中文给出简洁、可执行的反馈，每条建议附带代码示例。
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches: ["main", "dev"]
+  path_instructions:
+    - path: "backend/**/*.cs"
+      instructions: |
+        审查 ASP.NET Core + EF Core 代码。检查要点：
+        - Controller 是否严格匹配 api/openapi.yaml 的路径和 Schema。
+        - EF Core 查询是否有 N+1 问题，是否正确使用 Include/ThenInclude。
+        - Oracle 列名大小写是否与 [Column] 属性一致。
+        - 输入校验（[Required]、StringLength 等）。
+        - 异常处理与 HTTP 状态码选择。
+    - path: "frontend/**/*.{ts,vue}"
+      instructions: |
+        审查 Vue 3 + Element Plus + TypeScript 代码。检查要点：
+        - 组件是否使用 script setup + Composition API。
+        - TypeScript 类型定义是否完整（无 any）。
+        - API 调用是否使用 fetch 并正确处理 loading/error/empty 三态。
+        - Element Plus 组件用法是否正确。
+        - 响应式布局与无障碍访问。
+    - path: "api/**/*.yaml"
+      instructions: |
+        审查 OpenAPI 3.0 规范文件。检查要点：
+        - 路径命名是否符合 RESTful 约定。
+        - Schema 字段是否完整（description、example、required）。
+        - operationId 是否唯一且有语义。
+        - 请求/响应示例是否合理。
+    - path: "database/**/*.sql"
+      instructions: |
+        审查 Oracle SQL 脚本。检查要点：
+        - 是否使用 Oracle 语法（不混用 MySQL/SQL Server 写法）。
+        - 所有 varchar2 是否带长度。
+        - 外键约束是否正确。
+        - 迁移脚本是否注明影响范围和回滚方案。
+    - path: ".github/workflows/*.yml"
+      instructions: |
+        审查 GitHub Actions 工作流。检查要点：
+        - Secrets 是否在 GitHub Secrets 而非硬编码。
+        - 条件触发是否合理（paths、branches）。
+        - Action 版本是否明确。
+        - Docker 镜像标签策略。
+chat:
+  auto_reply: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         if: steps.detect.outputs.exists == 'true'
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore 和 Build
         if: steps.detect.outputs.exists == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 前后端分离，实现轻量：
 
 - `backend/`：ASP.NET Core Web API，负责 C# 业务逻辑、权限、Oracle 数据访问。
-- `frontend/`：Vue 3 + Vite 或同等轻量前端，负责页面和交互。
+- `frontend/`：Vue 3 + Vite + Element Plus，负责页面和交互。
 - `database/`：Oracle 建表脚本、验证脚本、种子数据、视图和迁移脚本。
 - `docs/`：各类文档。
 - `docker-compose.yml`：生产环境 Docker 编排。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 - `main` 保存阶段性稳定版本，`dev` 用作日常集成，个人任务从 `dev` 拉功能分支。
 - 功能分支可以 `fetch + rebase`，但最好不要。
 - 密码、私钥、服务器 IP、Oracle 连接串不进仓库，只放本机环境变量或 GitHub Secrets。
-- 前后端分离：后端 C# / ASP.NET Core Web API，前端 Vue 3 / Vite，数据库 Oracle。
+- 前后端分离：后端 C# / ASP.NET Core Web API，前端 Vue 3 / Vite + Element Plus，数据库 Oracle。
 
 ## 仓库目录
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,9 @@
 - Visual Studio 2022 或更高版本。
 - `ASP.NET and web development` 工作负载。
 - .NET SDK。
-- Oracle Database 18c 或更高版本。建议 Oracle 21c XE。
-- SQL Developer 或其他 Oracle 客户端。
+- 远程 Oracle 数据库（团队共用，不需本地安装）。后端通过 EF Core 托管驱动直连。
+  - 首次配置：复制 `backend/appsettings.Development.example.json` 为 `appsettings.Development.json`（已 gitignore），填入连接信息。详见 `database/README.md`。
+- SQL Developer（可选，方便手动浏览数据库）。
 - 如果开发前端，再安装 Node.js LTS，并启用 Corepack / pnpm。
 - `gh` CLI（GitHub 官方命令行工具）：用于创建 PR、查看 CI 状态。未安装时请提醒用户根据用户的系统 / 环境进行安装。
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16,7 +16,6 @@ paths:
   /api/health:
     get:
       summary: 健康检查
-      description: 返回 API 服务运行状态。
       operationId: healthCheck
       responses:
         "200":
@@ -26,6 +25,70 @@ paths:
               schema:
                 $ref: "#/components/schemas/HealthStatus"
 
+  /api/clubs:
+    get:
+      summary: 获取社团列表
+      operationId: getClubs
+      responses:
+        "200":
+          description: 社团列表
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Club"
+
+  /api/clubs/{clubId}:
+    get:
+      summary: 获取社团详情
+      operationId: getClubById
+      parameters:
+        - name: clubId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: 社团详情
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Club"
+
+  /api/activities:
+    get:
+      summary: 获取活动列表
+      operationId: getActivities
+      responses:
+        "200":
+          description: 活动列表
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Activity"
+
+  /api/activities/{activityId}:
+    get:
+      summary: 获取活动详情
+      operationId: getActivityById
+      parameters:
+        - name: activityId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: 活动详情
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Activity"
+
 components:
   schemas:
     HealthStatus:
@@ -33,12 +96,71 @@ components:
       properties:
         status:
           type: string
-          description: 服务状态
           example: healthy
         timestamp:
           type: string
           format: date-time
-          description: 当前时间
       required:
         - status
         - timestamp
+
+    Club:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        category:
+          type: string
+        memberCount:
+          type: integer
+        presidentName:
+          type: string
+        establishedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - category
+        - memberCount
+        - presidentName
+
+    Activity:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        clubName:
+          type: string
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+        location:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [draft, published, ongoing, finished, cancelled]
+        maxParticipants:
+          type: integer
+          nullable: true
+        currentParticipants:
+          type: integer
+      required:
+        - id
+        - title
+        - clubName
+        - startTime
+        - endTime
+        - status
+        - currentParticipants

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -38,6 +38,22 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Club"
+    post:
+      summary: 创建社团
+      operationId: createClub
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateClubRequest"
+      responses:
+        "201":
+          description: 社团已创建
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Club"
 
   /api/clubs/{clubId}:
     get:
@@ -56,6 +72,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Club"
+    put:
+      summary: 更新社团
+      operationId: updateClub
+      parameters:
+        - name: clubId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateClubRequest"
+      responses:
+        "200":
+          description: 社团已更新
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Club"
+    delete:
+      summary: 删除社团
+      operationId: deleteClub
+      parameters:
+        - name: clubId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: 社团已删除
 
   /api/activities:
     get:
@@ -129,6 +179,33 @@ components:
         - category
         - memberCount
         - presidentName
+
+    CreateClubRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+        category:
+          type: string
+        description:
+          type: string
+          nullable: true
+      required:
+        - name
+        - category
+
+    UpdateClubRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+        category:
+          type: string
+        description:
+          type: string
+          nullable: true
 
     Activity:
       type: object

--- a/backend/ClubHub.Api.csproj
+++ b/backend/ClubHub.Api.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.26200" />
   </ItemGroup>
 
 </Project>

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -1,4 +1,6 @@
+using ClubHub.Api.Data;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace ClubHub.Api.Controllers;
 
@@ -6,20 +8,49 @@ namespace ClubHub.Api.Controllers;
 [Route("api/[controller]")]
 public class ActivitiesController : ControllerBase
 {
-    private static readonly List<ActivityDto> Activities =
-    [
-        new(1, "2025 秋季 Hackathon", "计算机协会", new DateTime(2025, 10, 15, 9, 0, 0), new DateTime(2025, 10, 15, 18, 0, 0), "大学生活动中心 301", "published", 60, 38),
-        new(2, "校园摄影大赛作品展", "摄影社", new DateTime(2025, 11, 1, 10, 0, 0), new DateTime(2025, 11, 3, 17, 0, 0), "图书馆一楼展厅", "published", null, 12),
-        new(3, "羽毛球新生杯", "羽毛球协会", new DateTime(2025, 10, 20, 14, 0, 0), new DateTime(2025, 10, 20, 17, 0, 0), "体育馆羽毛球场", "draft", 32, 0),
-    ];
+    private readonly ClubHubDbContext _db;
+
+    public ActivitiesController(ClubHubDbContext db) => _db = db;
 
     [HttpGet]
-    public IActionResult GetAll() => Ok(Activities);
+    public async Task<IActionResult> GetAll()
+    {
+        var activities = await _db.Activities
+            .OrderBy(a => a.ActivityId)
+            .Select(a => new ActivityDto(
+                a.ActivityId,
+                a.Title,
+                a.Club != null ? a.Club.ClubName : "",
+                a.StartAt,
+                a.EndAt,
+                a.Location,
+                a.ActivityStatus,
+                a.Capacity,
+                a.CreatedAt
+            ))
+            .ToListAsync();
+
+        return Ok(activities);
+    }
 
     [HttpGet("{activityId:int}")]
-    public IActionResult GetById(int activityId)
+    public async Task<IActionResult> GetById(int activityId)
     {
-        var activity = Activities.FirstOrDefault(a => a.Id == activityId);
+        var activity = await _db.Activities
+            .Where(a => a.ActivityId == activityId)
+            .Select(a => new ActivityDto(
+                a.ActivityId,
+                a.Title,
+                a.Club != null ? a.Club.ClubName : "",
+                a.StartAt,
+                a.EndAt,
+                a.Location,
+                a.ActivityStatus,
+                a.Capacity,
+                a.CreatedAt
+            ))
+            .FirstOrDefaultAsync();
+
         return activity is null ? NotFound() : Ok(activity);
     }
 }
@@ -28,10 +59,10 @@ public record ActivityDto(
     int Id,
     string Title,
     string ClubName,
-    DateTime StartTime,
-    DateTime EndTime,
+    DateTime? StartTime,
+    DateTime? EndTime,
     string? Location,
-    string Status,
+    string? Status,
     int? MaxParticipants,
-    int CurrentParticipants
+    DateTime CreatedAt
 );

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClubHub.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ActivitiesController : ControllerBase
+{
+    private static readonly List<ActivityDto> Activities =
+    [
+        new(1, "2025 秋季 Hackathon", "计算机协会", new DateTime(2025, 10, 15, 9, 0, 0), new DateTime(2025, 10, 15, 18, 0, 0), "大学生活动中心 301", "published", 60, 38),
+        new(2, "校园摄影大赛作品展", "摄影社", new DateTime(2025, 11, 1, 10, 0, 0), new DateTime(2025, 11, 3, 17, 0, 0), "图书馆一楼展厅", "published", null, 12),
+        new(3, "羽毛球新生杯", "羽毛球协会", new DateTime(2025, 10, 20, 14, 0, 0), new DateTime(2025, 10, 20, 17, 0, 0), "体育馆羽毛球场", "draft", 32, 0),
+    ];
+
+    [HttpGet]
+    public IActionResult GetAll() => Ok(Activities);
+
+    [HttpGet("{activityId:int}")]
+    public IActionResult GetById(int activityId)
+    {
+        var activity = Activities.FirstOrDefault(a => a.Id == activityId);
+        return activity is null ? NotFound() : Ok(activity);
+    }
+}
+
+public record ActivityDto(
+    int Id,
+    string Title,
+    string ClubName,
+    DateTime StartTime,
+    DateTime EndTime,
+    string? Location,
+    string Status,
+    int? MaxParticipants,
+    int CurrentParticipants
+);

--- a/backend/Controllers/ClubsController.cs
+++ b/backend/Controllers/ClubsController.cs
@@ -1,4 +1,6 @@
+using ClubHub.Api.Data;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace ClubHub.Api.Controllers;
 
@@ -6,20 +8,45 @@ namespace ClubHub.Api.Controllers;
 [Route("api/[controller]")]
 public class ClubsController : ControllerBase
 {
-    private static readonly List<ClubDto> Clubs =
-    [
-        new(1, "计算机协会", "编程竞赛、技术分享、黑客松组织", "学术科技", 42, "张三", new DateTime(2024, 9, 1)),
-        new(2, "摄影社", "校园摄影采风、人像摄影教学、作品展览", "文化艺术", 28, "李四", new DateTime(2024, 9, 15)),
-        new(3, "羽毛球协会", "每周训练、校内联赛、校际交流赛", "体育竞技", 35, "王五", new DateTime(2024, 3, 10)),
-    ];
+    private readonly ClubHubDbContext _db;
+
+    public ClubsController(ClubHubDbContext db) => _db = db;
 
     [HttpGet]
-    public IActionResult GetAll() => Ok(Clubs);
+    public async Task<IActionResult> GetAll()
+    {
+        var clubs = await _db.Clubs
+            .OrderBy(c => c.ClubId)
+            .Select(c => new ClubDto(
+                c.ClubId,
+                c.ClubName,
+                c.Description,
+                c.Category,
+                c.ClubStatus,
+                c.FoundedAt,
+                c.CreatedAt
+            ))
+            .ToListAsync();
+
+        return Ok(clubs);
+    }
 
     [HttpGet("{clubId:int}")]
-    public IActionResult GetById(int clubId)
+    public async Task<IActionResult> GetById(int clubId)
     {
-        var club = Clubs.FirstOrDefault(c => c.Id == clubId);
+        var club = await _db.Clubs
+            .Where(c => c.ClubId == clubId)
+            .Select(c => new ClubDto(
+                c.ClubId,
+                c.ClubName,
+                c.Description,
+                c.Category,
+                c.ClubStatus,
+                c.FoundedAt,
+                c.CreatedAt
+            ))
+            .FirstOrDefaultAsync();
+
         return club is null ? NotFound() : Ok(club);
     }
 }
@@ -28,8 +55,8 @@ public record ClubDto(
     int Id,
     string Name,
     string? Description,
-    string Category,
-    int MemberCount,
-    string PresidentName,
-    DateTime? EstablishedAt
+    string? Category,
+    string? Status,
+    DateTime? FoundedAt,
+    DateTime CreatedAt
 );

--- a/backend/Controllers/ClubsController.cs
+++ b/backend/Controllers/ClubsController.cs
@@ -1,4 +1,5 @@
 using ClubHub.Api.Data;
+using ClubHub.Api.Data.Entities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,16 +19,8 @@ public class ClubsController : ControllerBase
         var clubs = await _db.Clubs
             .OrderBy(c => c.ClubId)
             .Select(c => new ClubDto(
-                c.ClubId,
-                c.ClubName,
-                c.Description,
-                c.Category,
-                c.ClubStatus,
-                c.FoundedAt,
-                c.CreatedAt
-            ))
+                c.ClubId, c.ClubName, c.Description, c.Category, c.ClubStatus, c.FoundedAt, c.CreatedAt))
             .ToListAsync();
-
         return Ok(clubs);
     }
 
@@ -37,26 +30,72 @@ public class ClubsController : ControllerBase
         var club = await _db.Clubs
             .Where(c => c.ClubId == clubId)
             .Select(c => new ClubDto(
-                c.ClubId,
-                c.ClubName,
-                c.Description,
-                c.Category,
-                c.ClubStatus,
-                c.FoundedAt,
-                c.CreatedAt
-            ))
+                c.ClubId, c.ClubName, c.Description, c.Category, c.ClubStatus, c.FoundedAt, c.CreatedAt))
             .FirstOrDefaultAsync();
-
         return club is null ? NotFound() : Ok(club);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateClubRequest req)
+    {
+        // 获取下一个 ID
+        var maxId = await _db.Clubs.MaxAsync(c => (int?)c.ClubId) ?? 0;
+        var club = new Club
+        {
+            ClubId = maxId + 1,
+            ClubName = req.Name,
+            Category = req.Category,
+            Description = req.Description,
+            ClubStatus = "active",
+            FoundedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow
+        };
+        _db.Clubs.Add(club);
+        await _db.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetById), new { clubId = club.ClubId }, new ClubDto(
+            club.ClubId, club.ClubName, club.Description, club.Category, club.ClubStatus, club.FoundedAt, club.CreatedAt));
+    }
+
+    [HttpPut("{clubId:int}")]
+    public async Task<IActionResult> Update(int clubId, [FromBody] UpdateClubRequest req)
+    {
+        var club = await _db.Clubs.FindAsync(clubId);
+        if (club is null) return NotFound();
+
+        if (req.Name is not null) club.ClubName = req.Name;
+        if (req.Category is not null) club.Category = req.Category;
+        if (req.Description is not null) club.Description = req.Description;
+
+        await _db.SaveChangesAsync();
+        return Ok(new ClubDto(
+            club.ClubId, club.ClubName, club.Description, club.Category, club.ClubStatus, club.FoundedAt, club.CreatedAt));
+    }
+
+    [HttpDelete("{clubId:int}")]
+    public async Task<IActionResult> Delete(int clubId)
+    {
+        var club = await _db.Clubs.FindAsync(clubId);
+        if (club is null) return NotFound();
+
+        _db.Clubs.Remove(club);
+        await _db.SaveChangesAsync();
+        return NoContent();
     }
 }
 
-public record ClubDto(
-    int Id,
-    string Name,
-    string? Description,
-    string? Category,
-    string? Status,
-    DateTime? FoundedAt,
-    DateTime CreatedAt
-);
+public record ClubDto(int Id, string Name, string? Description, string? Category, string? Status, DateTime? FoundedAt, DateTime CreatedAt);
+
+public class CreateClubRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Category { get; set; }
+    public string? Description { get; set; }
+}
+
+public class UpdateClubRequest
+{
+    public string? Name { get; set; }
+    public string? Category { get; set; }
+    public string? Description { get; set; }
+}

--- a/backend/Controllers/ClubsController.cs
+++ b/backend/Controllers/ClubsController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClubHub.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ClubsController : ControllerBase
+{
+    private static readonly List<ClubDto> Clubs =
+    [
+        new(1, "计算机协会", "编程竞赛、技术分享、黑客松组织", "学术科技", 42, "张三", new DateTime(2024, 9, 1)),
+        new(2, "摄影社", "校园摄影采风、人像摄影教学、作品展览", "文化艺术", 28, "李四", new DateTime(2024, 9, 15)),
+        new(3, "羽毛球协会", "每周训练、校内联赛、校际交流赛", "体育竞技", 35, "王五", new DateTime(2024, 3, 10)),
+    ];
+
+    [HttpGet]
+    public IActionResult GetAll() => Ok(Clubs);
+
+    [HttpGet("{clubId:int}")]
+    public IActionResult GetById(int clubId)
+    {
+        var club = Clubs.FirstOrDefault(c => c.Id == clubId);
+        return club is null ? NotFound() : Ok(club);
+    }
+}
+
+public record ClubDto(
+    int Id,
+    string Name,
+    string? Description,
+    string Category,
+    int MemberCount,
+    string PresidentName,
+    DateTime? EstablishedAt
+);

--- a/backend/Data/ClubHubDbContext.cs
+++ b/backend/Data/ClubHubDbContext.cs
@@ -1,0 +1,28 @@
+using ClubHub.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClubHub.Api.Data;
+
+public class ClubHubDbContext : DbContext
+{
+    public ClubHubDbContext(DbContextOptions<ClubHubDbContext> options) : base(options) { }
+
+    public DbSet<Club> Clubs => Set<Club>();
+    public DbSet<Activity> Activities => Set<Activity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Club>(e =>
+        {
+            e.HasKey(c => c.ClubId);
+            e.HasMany(c => c.Activities)
+             .WithOne(a => a.Club)
+             .HasForeignKey(a => a.ClubId);
+        });
+
+        modelBuilder.Entity<Activity>(e =>
+        {
+            e.HasKey(a => a.ActivityId);
+        });
+    }
+}

--- a/backend/Data/Entities/Activity.cs
+++ b/backend/Data/Entities/Activity.cs
@@ -5,46 +5,45 @@ namespace ClubHub.Api.Data.Entities;
 [Table("ACTIVITIES")]
 public class Activity
 {
-    [Column("activity_id")]
+    [Column("ACTIVITY_ID")]
     public int ActivityId { get; set; }
 
-    [Column("club_id")]
+    [Column("CLUB_ID")]
     public int ClubId { get; set; }
 
-    [Column("title")]
+    [Column("TITLE")]
     public string Title { get; set; } = string.Empty;
 
-    [Column("activity_type")]
+    [Column("ACTIVITY_TYPE")]
     public string? ActivityType { get; set; }
 
-    [Column("description")]
+    [Column("DESCRIPTION")]
     public string? Description { get; set; }
 
-    [Column("location")]
+    [Column("LOCATION")]
     public string? Location { get; set; }
 
-    [Column("start_at")]
+    [Column("START_AT")]
     public DateTime? StartAt { get; set; }
 
-    [Column("end_at")]
+    [Column("END_AT")]
     public DateTime? EndAt { get; set; }
 
-    [Column("capacity")]
+    [Column("CAPACITY")]
     public int? Capacity { get; set; }
 
-    [Column("registration_deadline")]
+    [Column("REGISTRATION_DEADLINE")]
     public DateTime? RegistrationDeadline { get; set; }
 
-    [Column("activity_status")]
+    [Column("ACTIVITY_STATUS")]
     public string? ActivityStatus { get; set; }
 
-    [Column("published_at")]
+    [Column("PUBLISHED_AT")]
     public DateTime? PublishedAt { get; set; }
 
-    [Column("created_at")]
+    [Column("CREATED_AT")]
     public DateTime CreatedAt { get; set; }
 
-    // 导航属性：所属社团
     [ForeignKey("ClubId")]
     public Club? Club { get; set; }
 }

--- a/backend/Data/Entities/Activity.cs
+++ b/backend/Data/Entities/Activity.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ClubHub.Api.Data.Entities;
+
+[Table("ACTIVITIES")]
+public class Activity
+{
+    [Column("activity_id")]
+    public int ActivityId { get; set; }
+
+    [Column("club_id")]
+    public int ClubId { get; set; }
+
+    [Column("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [Column("activity_type")]
+    public string? ActivityType { get; set; }
+
+    [Column("description")]
+    public string? Description { get; set; }
+
+    [Column("location")]
+    public string? Location { get; set; }
+
+    [Column("start_at")]
+    public DateTime? StartAt { get; set; }
+
+    [Column("end_at")]
+    public DateTime? EndAt { get; set; }
+
+    [Column("capacity")]
+    public int? Capacity { get; set; }
+
+    [Column("registration_deadline")]
+    public DateTime? RegistrationDeadline { get; set; }
+
+    [Column("activity_status")]
+    public string? ActivityStatus { get; set; }
+
+    [Column("published_at")]
+    public DateTime? PublishedAt { get; set; }
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    // 导航属性：所属社团
+    [ForeignKey("ClubId")]
+    public Club? Club { get; set; }
+}

--- a/backend/Data/Entities/Club.cs
+++ b/backend/Data/Entities/Club.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ClubHub.Api.Data.Entities;
+
+[Table("CLUBS")]
+public class Club
+{
+    [Column("club_id")]
+    public int ClubId { get; set; }
+
+    [Column("club_name")]
+    public string ClubName { get; set; } = string.Empty;
+
+    [Column("category")]
+    public string? Category { get; set; }
+
+    [Column("description")]
+    public string? Description { get; set; }
+
+    [Column("logo_url")]
+    public string? LogoUrl { get; set; }
+
+    [Column("president_user_id")]
+    public int? PresidentUserId { get; set; }
+
+    [Column("club_status")]
+    public string? ClubStatus { get; set; }
+
+    [Column("founded_at")]
+    public DateTime? FoundedAt { get; set; }
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [Column("updated_at")]
+    public DateTime? UpdatedAt { get; set; }
+
+    // 导航属性：关联的活动
+    public ICollection<Activity> Activities { get; set; } = new List<Activity>();
+}

--- a/backend/Data/Entities/Club.cs
+++ b/backend/Data/Entities/Club.cs
@@ -5,36 +5,35 @@ namespace ClubHub.Api.Data.Entities;
 [Table("CLUBS")]
 public class Club
 {
-    [Column("club_id")]
+    [Column("CLUB_ID")]
     public int ClubId { get; set; }
 
-    [Column("club_name")]
+    [Column("CLUB_NAME")]
     public string ClubName { get; set; } = string.Empty;
 
-    [Column("category")]
+    [Column("CATEGORY")]
     public string? Category { get; set; }
 
-    [Column("description")]
+    [Column("DESCRIPTION")]
     public string? Description { get; set; }
 
-    [Column("logo_url")]
+    [Column("LOGO_URL")]
     public string? LogoUrl { get; set; }
 
-    [Column("president_user_id")]
+    [Column("PRESIDENT_USER_ID")]
     public int? PresidentUserId { get; set; }
 
-    [Column("club_status")]
+    [Column("CLUB_STATUS")]
     public string? ClubStatus { get; set; }
 
-    [Column("founded_at")]
+    [Column("FOUNDED_AT")]
     public DateTime? FoundedAt { get; set; }
 
-    [Column("created_at")]
+    [Column("CREATED_AT")]
     public DateTime CreatedAt { get; set; }
 
-    [Column("updated_at")]
+    [Column("UPDATED_AT")]
     public DateTime? UpdatedAt { get; set; }
 
-    // 导航属性：关联的活动
     public ICollection<Activity> Activities { get; set; } = new List<Activity>();
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,6 +1,13 @@
+using ClubHub.Api.Data;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+
+builder.Services.AddDbContext<ClubHubDbContext>(options =>
+    options.UseOracle(builder.Configuration.GetConnectionString("Default"))
+);
 
 var app = builder.Build();
 

--- a/backend/appsettings.Development.example.json
+++ b/backend/appsettings.Development.example.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "Default": "User Id=CLUBHUB;Password=your_password;Data Source=//your_host:1521/your_service_name"
+  }
+}

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Default": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/database/README.md
+++ b/database/README.md
@@ -8,17 +8,29 @@
 - `views/`：后续放统计视图。
 - `migrations/`：后续放表结构演进说明或迁移脚本。
 
-## 本地初始化
+## 后端连接数据库
 
-在 SQL Developer 中打开 `schema.sql`，确认连接下拉框选择 `CLUBHUB-XEPDB1`，然后用 F5 运行脚本。
+ASP.NET Core 后端通过 EF Core + Oracle 驱动连接远程 Oracle，**不需要在本地安装 Oracle 客户端**。
 
-不要用管理员连接执行建表脚本；建表脚本应该运行在 `CLUBHUB` 用户下。
+### 配置方法
 
-## 验证
+1. 复制 `backend/appsettings.Development.example.json` 为 `backend/appsettings.Development.json`（该文件已加入 `.gitignore`，不会提交到仓库）。
+2. 填入远程 Oracle 的连接信息：
 
-在 SQL Developer 中打开并执行 `verify.sql`。
+```json
+{
+  "ConnectionStrings": {
+    "Default": "User Id=CLUBHUB;Password=你的密码;Data Source=//服务器IP:1521/服务名"
+  }
+}
+```
 
-当前已验证 `CLUBHUB` 用户下共有 22 张表。
+3. `dotnet run --project backend` 启动后端，自动连接数据库。
+
+### 原理
+
+- NuGet 包 `Oracle.EntityFrameworkCore`（已安装）内含 `Oracle.ManagedDataAccess.Core`，是 Oracle 官方提供的全托管驱动，直接通过网络连接远程 Oracle，不依赖本地 Oracle 客户端。
+- 连接字符串中 `Data Source` 的格式为 `//主机:端口/服务名`，例如 `//10.0.0.5:1521/CLUBHUB`。
 
 ## 修改规则
 

--- a/database/seeds/001_sample_clubs.sql
+++ b/database/seeds/001_sample_clubs.sql
@@ -1,0 +1,17 @@
+-- 社团样例数据
+INSERT INTO CLUBS (club_id, club_name, category, description, president_user_id, club_status, founded_at, created_at)
+VALUES (1, '计算机协会', '学术科技', '编程竞赛、技术分享、黑客松组织', NULL, 'active', DATE '2024-09-01', SYSDATE);
+
+INSERT INTO CLUBS (club_id, club_name, category, description, president_user_id, club_status, founded_at, created_at)
+VALUES (2, '摄影社', '文化艺术', '校园摄影采风、人像摄影教学、作品展览', NULL, 'active', DATE '2024-09-15', SYSDATE);
+
+INSERT INTO CLUBS (club_id, club_name, category, description, president_user_id, club_status, founded_at, created_at)
+VALUES (3, '羽毛球协会', '体育竞技', '每周训练、校内联赛、校际交流赛', NULL, 'active', DATE '2024-03-10', SYSDATE);
+
+INSERT INTO CLUBS (club_id, club_name, category, description, president_user_id, club_status, founded_at, created_at)
+VALUES (4, '辩论队', '学术科技', '辩论技巧训练、校内辩论赛、校际交流', NULL, 'active', DATE '2023-11-01', SYSDATE);
+
+INSERT INTO CLUBS (club_id, club_name, category, description, president_user_id, club_status, founded_at, created_at)
+VALUES (5, '志愿者协会', '公益实践', '社区服务、支教活动、公益项目', NULL, 'active', DATE '2024-01-15', SYSDATE);
+
+COMMIT;

--- a/database/seeds/002_sample_activities.sql
+++ b/database/seeds/002_sample_activities.sql
@@ -1,0 +1,20 @@
+-- 活动样例数据
+INSERT INTO ACTIVITIES (activity_id, club_id, title, activity_type, description, location, start_at, end_at, capacity, activity_status, created_at)
+VALUES (1, 1, '2025 秋季 Hackathon', 'competition', '48 小时编程马拉松，自由组队，主题现场公布。', '大学生活动中心 301', TIMESTAMP '2025-10-15 09:00:00', TIMESTAMP '2025-10-15 18:00:00', 60, 'published', SYSDATE);
+
+INSERT INTO ACTIVITIES (activity_id, club_id, title, activity_type, description, location, start_at, end_at, capacity, activity_status, created_at)
+VALUES (2, 1, 'Python 入门工作坊', 'workshop', '面向零基础同学，从环境配置到完成一个小项目。', '教学楼 B101', TIMESTAMP '2025-11-01 14:00:00', TIMESTAMP '2025-11-01 17:00:00', 30, 'published', SYSDATE);
+
+INSERT INTO ACTIVITIES (activity_id, club_id, title, activity_type, description, location, start_at, end_at, capacity, activity_status, created_at)
+VALUES (3, 2, '校园摄影大赛作品展', 'exhibition', '展出本届摄影大赛获奖及入围作品。', '图书馆一楼展厅', TIMESTAMP '2025-11-01 10:00:00', TIMESTAMP '2025-11-03 17:00:00', NULL, 'published', SYSDATE);
+
+INSERT INTO ACTIVITIES (activity_id, club_id, title, activity_type, description, location, start_at, end_at, capacity, activity_status, created_at)
+VALUES (4, 2, '人像摄影外拍活动', 'outing', '前往校园后山拍摄秋日人像，自带相机。', '校园后山', TIMESTAMP '2025-10-25 14:00:00', TIMESTAMP '2025-10-25 17:00:00', 15, 'draft', SYSDATE);
+
+INSERT INTO ACTIVITIES (activity_id, club_id, title, activity_type, description, location, start_at, end_at, capacity, activity_status, created_at)
+VALUES (5, 3, '羽毛球新生杯', 'competition', '面向全校新生的羽毛球比赛，分男女组。', '体育馆羽毛球场', TIMESTAMP '2025-10-20 14:00:00', TIMESTAMP '2025-10-20 17:00:00', 32, 'published', SYSDATE);
+
+INSERT INTO ACTIVITIES (activity_id, club_id, title, activity_type, description, location, start_at, end_at, capacity, activity_status, created_at)
+VALUES (6, 3, '每周常规训练', 'training', '每周二周四例训，新老队员均可参加。', '体育馆羽毛球场', TIMESTAMP '2025-09-01 19:00:00', TIMESTAMP '2025-09-01 21:00:00', NULL, 'ongoing', SYSDATE);
+
+COMMIT;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.39"
+    "vue": "^3.5.39",
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "element-plus": "^2.14.2",
     "vue": "^3.5.39",
     "vue-router": "^4.6.4"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@6.0.3)
+      vue-router:
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.39(typescript@6.0.3))
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -202,6 +205,9 @@ packages:
 
   '@vue/compiler-ssr@3.5.39':
     resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/language-core@3.3.6':
     resolution: {integrity: sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==}
@@ -434,6 +440,11 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
   vue-tsc@3.3.6:
     resolution: {integrity: sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==}
     hasBin: true
@@ -597,6 +608,8 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.39
       '@vue/shared': 3.5.39
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/language-core@3.3.6':
     dependencies:
@@ -770,6 +783,11 @@ snapshots:
       fsevents: 2.3.3
 
   vscode-uri@3.1.0: {}
+
+  vue-router@4.6.4(vue@3.5.39(typescript@6.0.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.39(typescript@6.0.3)
 
   vue-tsc@3.3.6(typescript@6.0.3):
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      element-plus:
+        specifier: ^2.14.2
+        version: 2.14.2(vue@3.5.39(typescript@6.0.3))
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@6.0.3)
@@ -53,6 +56,15 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@ctrl/tinycolor@4.2.0':
+    resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
+    engines: {node: '>=14'}
+
+  '@element-plus/icons-vue@2.3.2':
+    resolution: {integrity: sha512-OzIuTaIfC8QXEPmJvB4Y4kw34rSXdCJzxcD1kFStBvr8bK6X1zQAYDo0CNMjojnfTqRQCJ0I7prlErcoRiET2A==}
+    peerDependencies:
+      vue: ^3.2.0
+
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
@@ -61,6 +73,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -172,11 +193,23 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sxzz/popperjs-es@2.11.8':
+    resolution: {integrity: sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
   '@vitejs/plugin-vue@6.0.7':
     resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
@@ -240,15 +273,39 @@ packages:
       vue:
         optional: true
 
+  '@vueuse/core@14.3.0':
+    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/metadata@14.3.0':
+    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
+
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+    peerDependencies:
+      vue: ^3.5.0
+
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
+
+  async-validator@4.2.5:
+    resolution: {integrity: sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  element-plus@2.14.2:
+    resolution: {integrity: sha512-eNH9uP3wQoNqieEIHXiNvIVv+zO5sZDU0CAZq5b0zqSN06DD0/V9xIq1R/qm3rw5k3nBTM1JvpxhCfRbaFLzDQ==}
+    peerDependencies:
+      vue: ^3.3.7
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -345,8 +402,24 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash-unified@1.0.3:
+    resolution: {integrity: sha512-WK9qSozxXOD7ZJQlpSqOT+om2ZfcT4yO+03FuzAHD0wF6S0l0090LRPDx3vhTTLZ8cFKpBn+IOcVXK6qOcIlfQ==}
+    peerDependencies:
+      '@types/lodash-es': '*'
+      lodash: '*'
+      lodash-es: '*'
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
@@ -355,6 +428,9 @@ packages:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  normalize-wheel-es@1.2.0:
+    resolution: {integrity: sha512-Wj7+EJQ8mSuXr2iWfnujrimU35R2W4FAErEyTmJoJ7ucwTn2hOUSsRehMb5RSYkxXGTM7Y9QpvPmp++w5ftoJw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -440,6 +516,9 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-component-type-helpers@3.3.6:
+    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
+
   vue-router@4.6.4:
     resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
     peerDependencies:
@@ -474,6 +553,12 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@ctrl/tinycolor@4.2.0': {}
+
+  '@element-plus/icons-vue@2.3.2(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.39(typescript@6.0.3)
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -489,6 +574,17 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -552,14 +648,24 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@sxzz/popperjs-es@2.11.8': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.24
+
+  '@types/lodash@4.17.24': {}
+
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/web-bluetooth@0.0.21': {}
 
   '@vitejs/plugin-vue@6.0.7(vite@8.1.3(@types/node@24.13.2))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
@@ -650,11 +756,47 @@ snapshots:
       typescript: 6.0.3
       vue: 3.5.39(typescript@6.0.3)
 
+  '@vueuse/core@14.3.0(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.3.0
+      '@vueuse/shared': 14.3.0(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
+
+  '@vueuse/metadata@14.3.0': {}
+
+  '@vueuse/shared@14.3.0(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.39(typescript@6.0.3)
+
   alien-signals@3.2.1: {}
+
+  async-validator@4.2.5: {}
 
   csstype@3.2.3: {}
 
+  dayjs@1.11.21: {}
+
   detect-libc@2.1.2: {}
+
+  element-plus@2.14.2(vue@3.5.39(typescript@6.0.3)):
+    dependencies:
+      '@ctrl/tinycolor': 4.2.0
+      '@element-plus/icons-vue': 2.3.2(vue@3.5.39(typescript@6.0.3))
+      '@floating-ui/dom': 1.7.6
+      '@popperjs/core': '@sxzz/popperjs-es@2.11.8'
+      '@types/lodash': 4.17.24
+      '@types/lodash-es': 4.17.12
+      '@vueuse/core': 14.3.0(vue@3.5.39(typescript@6.0.3))
+      async-validator: 4.2.5
+      dayjs: 1.11.21
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      lodash-unified: 1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.18.1)(lodash@4.18.1)
+      memoize-one: 6.0.0
+      normalize-wheel-es: 1.2.0
+      vue: 3.5.39(typescript@6.0.3)
+      vue-component-type-helpers: 3.3.6
 
   entities@7.0.1: {}
 
@@ -716,13 +858,27 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lodash-es@4.18.1: {}
+
+  lodash-unified@1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.18.1)(lodash@4.18.1):
+    dependencies:
+      '@types/lodash-es': 4.17.12
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+
+  lodash@4.18.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  memoize-one@6.0.0: {}
+
   muggle-string@0.4.1: {}
 
   nanoid@3.3.15: {}
+
+  normalize-wheel-es@1.2.0: {}
 
   path-browserify@1.0.1: {}
 
@@ -783,6 +939,8 @@ snapshots:
       fsevents: 2.3.3
 
   vscode-uri@3.1.0: {}
+
+  vue-component-type-helpers@3.3.6: {}
 
   vue-router@4.6.4(vue@3.5.39(typescript@6.0.3)):
     dependencies:

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,7 +13,6 @@ const error = ref("");
 async function checkHealth() {
   loading.value = true;
   error.value = "";
-  health.value = null;
   try {
     const res = await fetch("/api/health");
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -27,47 +26,41 @@ async function checkHealth() {
 </script>
 
 <template>
-  <div class="container">
+  <header>
     <h1>ClubHub</h1>
-    <p>高校社团运营与协同管理平台</p>
+    <nav>
+      <router-link to="/clubs">社团</router-link>
+      <router-link to="/activities">活动</router-link>
+      <button class="health-btn" @click="checkHealth" :disabled="loading">
+        {{ loading ? "…" : "health" }}
+      </button>
+    </nav>
+  </header>
 
-    <button @click="checkHealth" :disabled="loading">
-      {{ loading ? "检查中…" : "检查后端连接" }}
-    </button>
+  <div v-if="health" class="banner ok">后端连接正常</div>
+  <div v-if="error" class="banner error">{{ error }}</div>
 
-    <div v-if="health" class="result ok">
-      <p>状态：{{ health.status }}</p>
-      <p>时间：{{ new Date(health.timestamp).toLocaleString() }}</p>
-    </div>
-    <div v-if="error" class="result error">
-      <p>连接失败：{{ error }}</p>
-    </div>
-  </div>
+  <main>
+    <router-view />
+  </main>
 </template>
 
 <style scoped>
-.container {
-  max-width: 480px;
-  margin: 80px auto;
-  text-align: center;
-  font-family: system-ui, sans-serif;
+header {
+  background: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  padding: 12px 24px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
 }
-button {
-  padding: 10px 24px;
-  font-size: 16px;
-  cursor: pointer;
-}
-.result {
-  margin-top: 24px;
-  padding: 16px;
-  border-radius: 8px;
-}
-.ok {
-  background: #e8f5e9;
-  color: #2e7d32;
-}
-.error {
-  background: #fce4ec;
-  color: #c62828;
-}
+header h1 { font-size: 20px; margin: 0; }
+nav { display: flex; gap: 16px; align-items: center; }
+nav a { color: #333; text-decoration: none; font-size: 15px; }
+nav a:hover { color: #1976d2; }
+.health-btn { font-size: 12px; padding: 2px 8px; cursor: pointer; }
+.banner { text-align: center; padding: 8px; font-size: 14px; }
+.ok { background: #e8f5e9; color: #2e7d32; }
+.error { background: #fce4ec; color: #c62828; }
+main { padding: 24px; }
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,66 +1,59 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
-interface HealthStatus {
-  status: string;
-  timestamp: string;
-}
-
-const health = ref<HealthStatus | null>(null);
-const loading = ref(false);
-const error = ref("");
+const healthOk = ref(false);
 
 async function checkHealth() {
-  loading.value = true;
-  error.value = "";
   try {
     const res = await fetch("/api/health");
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    health.value = await res.json();
-  } catch (e) {
-    error.value = e instanceof Error ? e.message : "请求失败";
-  } finally {
-    loading.value = false;
+    healthOk.value = res.ok;
+  } catch {
+    healthOk.value = false;
   }
 }
 </script>
 
 <template>
-  <header>
-    <h1>ClubHub</h1>
-    <nav>
-      <router-link to="/clubs">社团</router-link>
-      <router-link to="/activities">活动</router-link>
-      <button class="health-btn" @click="checkHealth" :disabled="loading">
-        {{ loading ? "…" : "health" }}
-      </button>
-    </nav>
-  </header>
-
-  <div v-if="health" class="banner ok">后端连接正常</div>
-  <div v-if="error" class="banner error">{{ error }}</div>
-
-  <main>
-    <router-view />
-  </main>
+  <el-container>
+    <el-header>
+      <div class="brand">ClubHub</div>
+      <el-menu mode="horizontal" router :default-active="$route.path" class="nav">
+        <el-menu-item index="/clubs">社团</el-menu-item>
+        <el-menu-item index="/activities">活动</el-menu-item>
+        <div class="health">
+          <el-tag :type="healthOk ? 'success' : 'danger'" size="small" @click="checkHealth">
+            {{ healthOk ? "后端已连接" : "点击检测" }}
+          </el-tag>
+        </div>
+      </el-menu>
+    </el-header>
+    <el-main>
+      <router-view />
+    </el-main>
+  </el-container>
 </template>
 
 <style scoped>
-header {
-  background: #fff;
-  border-bottom: 1px solid #e0e0e0;
-  padding: 12px 24px;
+.el-header {
   display: flex;
   align-items: center;
-  gap: 24px;
+  border-bottom: 1px solid var(--el-border-color-light);
+  padding: 0 16px;
 }
-header h1 { font-size: 20px; margin: 0; }
-nav { display: flex; gap: 16px; align-items: center; }
-nav a { color: #333; text-decoration: none; font-size: 15px; }
-nav a:hover { color: #1976d2; }
-.health-btn { font-size: 12px; padding: 2px 8px; cursor: pointer; }
-.banner { text-align: center; padding: 8px; font-size: 14px; }
-.ok { background: #e8f5e9; color: #2e7d32; }
-.error { background: #fce4ec; color: #c62828; }
-main { padding: 24px; }
+.brand {
+  font-size: 18px;
+  font-weight: 600;
+  margin-right: 16px;
+  white-space: nowrap;
+}
+.nav {
+  flex: 1;
+  border-bottom: none !important;
+}
+.health {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  cursor: pointer;
+}
 </style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,8 @@
-import { createApp } from 'vue'
-import './style.css'
-import App from './App.vue'
+import { createApp } from "vue";
+import "./style.css";
+import App from "./App.vue";
+import router from "./router";
 
-createApp(App).mount('#app')
+const app = createApp(App);
+app.use(router);
+app.mount("#app");

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,8 +1,11 @@
 import { createApp } from "vue";
+import ElementPlus from "element-plus";
+import "element-plus/dist/index.css";
 import "./style.css";
 import App from "./App.vue";
 import router from "./router";
 
 const app = createApp(App);
+app.use(ElementPlus);
 app.use(router);
 app.mount("#app");

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,0 +1,14 @@
+import { createRouter, createWebHistory } from "vue-router";
+import ClubList from "../views/ClubList.vue";
+import ActivityList from "../views/ActivityList.vue";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: "/", redirect: "/clubs" },
+    { path: "/clubs", component: ClubList },
+    { path: "/activities", component: ActivityList },
+  ],
+});
+
+export default router;

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+
+interface Activity {
+  id: number;
+  title: string;
+  clubName: string;
+  startTime: string;
+  endTime: string;
+  location: string | null;
+  status: string;
+  maxParticipants: number | null;
+  currentParticipants: number;
+}
+
+const activities = ref<Activity[]>([]);
+const loading = ref(true);
+
+const statusLabel: Record<string, string> = {
+  draft: "草稿",
+  published: "报名中",
+  ongoing: "进行中",
+  finished: "已结束",
+  cancelled: "已取消",
+};
+
+onMounted(async () => {
+  try {
+    const res = await fetch("/api/activities");
+    activities.value = await res.json();
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="page">
+    <h2>活动列表</h2>
+    <div v-if="loading">加载中…</div>
+    <div v-else class="grid">
+      <div v-for="act in activities" :key="act.id" class="card">
+        <h3>{{ act.title }}</h3>
+        <div class="meta">{{ act.clubName }}</div>
+        <div class="meta">{{ new Date(act.startTime).toLocaleString() }} — {{ new Date(act.endTime).toLocaleString() }}</div>
+        <div v-if="act.location" class="meta">地点：{{ act.location }}</div>
+        <div class="meta">
+          <span class="tag">{{ statusLabel[act.status] || act.status }}</span>
+          参与人数：{{ act.currentParticipants }}{{ act.maxParticipants ? ' / ' + act.maxParticipants : '' }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.page { max-width: 720px; margin: 0 auto; }
+.grid { display: flex; flex-direction: column; gap: 16px; margin-top: 16px; }
+.card { background: #fff; border-radius: 8px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+.card h3 { margin: 0 0 8px; }
+.meta { font-size: 14px; color: #666; margin-bottom: 4px; }
+.tag { background: #e3f2fd; color: #1976d2; padding: 1px 8px; border-radius: 4px; font-size: 12px; margin-right: 8px; }
+</style>

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -5,16 +5,17 @@ interface Activity {
   id: number;
   title: string;
   clubName: string;
-  startTime: string;
-  endTime: string;
+  startTime: string | null;
+  endTime: string | null;
   location: string | null;
-  status: string;
+  status: string | null;
   maxParticipants: number | null;
-  currentParticipants: number;
+  createdAt: string;
 }
 
 const activities = ref<Activity[]>([]);
 const loading = ref(true);
+const error = ref("");
 
 const statusLabel: Record<string, string> = {
   draft: "草稿",
@@ -27,7 +28,10 @@ const statusLabel: Record<string, string> = {
 onMounted(async () => {
   try {
     const res = await fetch("/api/activities");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
     activities.value = await res.json();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "加载失败";
   } finally {
     loading.value = false;
   }
@@ -37,16 +41,21 @@ onMounted(async () => {
 <template>
   <div class="page">
     <h2>活动列表</h2>
+    <div v-if="error" class="err">{{ error }}</div>
     <div v-if="loading">加载中…</div>
+    <div v-else-if="activities.length === 0" class="empty">暂无活动数据</div>
     <div v-else class="grid">
       <div v-for="act in activities" :key="act.id" class="card">
         <h3>{{ act.title }}</h3>
         <div class="meta">{{ act.clubName }}</div>
-        <div class="meta">{{ new Date(act.startTime).toLocaleString() }} — {{ new Date(act.endTime).toLocaleString() }}</div>
+        <div v-if="act.startTime" class="meta">
+          {{ new Date(act.startTime).toLocaleString() }}
+          <template v-if="act.endTime"> — {{ new Date(act.endTime).toLocaleString() }}</template>
+        </div>
         <div v-if="act.location" class="meta">地点：{{ act.location }}</div>
         <div class="meta">
-          <span class="tag">{{ statusLabel[act.status] || act.status }}</span>
-          参与人数：{{ act.currentParticipants }}{{ act.maxParticipants ? ' / ' + act.maxParticipants : '' }}
+          <span v-if="act.status" class="tag">{{ statusLabel[act.status] || act.status }}</span>
+          <span v-if="act.maxParticipants">上限 {{ act.maxParticipants }} 人</span>
         </div>
       </div>
     </div>
@@ -60,4 +69,6 @@ onMounted(async () => {
 .card h3 { margin: 0 0 8px; }
 .meta { font-size: 14px; color: #666; margin-bottom: 4px; }
 .tag { background: #e3f2fd; color: #1976d2; padding: 1px 8px; border-radius: 4px; font-size: 12px; margin-right: 8px; }
+.err { color: #c62828; margin: 16px 0; }
+.empty { color: #999; margin-top: 24px; text-align: center; }
 </style>

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
-
 interface Activity {
   id: number;
   title: string;
@@ -10,7 +9,6 @@ interface Activity {
   location: string | null;
   status: string | null;
   maxParticipants: number | null;
-  createdAt: string;
 }
 
 const activities = ref<Activity[]>([]);
@@ -25,7 +23,16 @@ const statusLabel: Record<string, string> = {
   cancelled: "已取消",
 };
 
+const statusType: Record<string, string> = {
+  draft: "info",
+  published: "success",
+  ongoing: "",
+  finished: "info",
+  cancelled: "danger",
+};
+
 onMounted(async () => {
+  loading.value = true;
   try {
     const res = await fetch("/api/activities");
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -41,34 +48,36 @@ onMounted(async () => {
 <template>
   <div class="page">
     <h2>活动列表</h2>
-    <div v-if="error" class="err">{{ error }}</div>
-    <div v-if="loading">加载中…</div>
-    <div v-else-if="activities.length === 0" class="empty">暂无活动数据</div>
-    <div v-else class="grid">
-      <div v-for="act in activities" :key="act.id" class="card">
-        <h3>{{ act.title }}</h3>
-        <div class="meta">{{ act.clubName }}</div>
-        <div v-if="act.startTime" class="meta">
-          {{ new Date(act.startTime).toLocaleString() }}
-          <template v-if="act.endTime"> — {{ new Date(act.endTime).toLocaleString() }}</template>
-        </div>
-        <div v-if="act.location" class="meta">地点：{{ act.location }}</div>
-        <div class="meta">
-          <span v-if="act.status" class="tag">{{ statusLabel[act.status] || act.status }}</span>
-          <span v-if="act.maxParticipants">上限 {{ act.maxParticipants }} 人</span>
-        </div>
-      </div>
-    </div>
+
+    <el-alert v-if="error" :title="error" type="error" show-icon closable @close="error=''" />
+
+    <el-table v-loading="loading" :data="activities" stripe empty-text="暂无活动数据">
+      <el-table-column prop="id" label="ID" width="60" />
+      <el-table-column prop="title" label="标题" />
+      <el-table-column prop="clubName" label="主办社团" width="120" />
+      <el-table-column label="时间" width="180">
+        <template #default="{ row }">
+          <span v-if="row.startTime">{{ new Date(row.startTime).toLocaleString() }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column prop="location" label="地点" />
+      <el-table-column label="状态" width="100">
+        <template #default="{ row }">
+          <el-tag v-if="row.status" :type="statusType[row.status] || 'info'" size="small">
+            {{ statusLabel[row.status] || row.status }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="名额" width="80">
+        <template #default="{ row }">
+          {{ row.maxParticipants ?? "不限" }}
+        </template>
+      </el-table-column>
+    </el-table>
   </div>
 </template>
 
 <style scoped>
-.page { max-width: 720px; margin: 0 auto; }
-.grid { display: flex; flex-direction: column; gap: 16px; margin-top: 16px; }
-.card { background: #fff; border-radius: 8px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
-.card h3 { margin: 0 0 8px; }
-.meta { font-size: 14px; color: #666; margin-bottom: 4px; }
-.tag { background: #e3f2fd; color: #1976d2; padding: 1px 8px; border-radius: 4px; font-size: 12px; margin-right: 8px; }
-.err { color: #c62828; margin: 16px 0; }
-.empty { color: #999; margin-top: 24px; text-align: center; }
+.page { max-width: 960px; margin: 0 auto; }
+h2 { margin-bottom: 12px; }
 </style>

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -20,6 +20,7 @@ const newDesc = ref("");
 const creating = ref(false);
 
 async function loadClubs() {
+  loading.value = true;
   error.value = "";
   try {
     const res = await fetch("/api/clubs");
@@ -27,6 +28,8 @@ async function loadClubs() {
     clubs.value = await res.json();
   } catch (e) {
     error.value = e instanceof Error ? e.message : "加载失败";
+  } finally {
+    loading.value = false;
   }
 }
 

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+
+interface Club {
+  id: number;
+  name: string;
+  description: string | null;
+  category: string;
+  memberCount: number;
+  presidentName: string;
+}
+
+const clubs = ref<Club[]>([]);
+const loading = ref(true);
+
+onMounted(async () => {
+  try {
+    const res = await fetch("/api/clubs");
+    clubs.value = await res.json();
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="page">
+    <h2>社团列表</h2>
+    <div v-if="loading">加载中…</div>
+    <div v-else class="grid">
+      <div v-for="club in clubs" :key="club.id" class="card">
+        <h3>{{ club.name }}</h3>
+        <div class="meta">{{ club.category }} · {{ club.memberCount }} 人</div>
+        <div class="meta">社长：{{ club.presidentName }}</div>
+        <p v-if="club.description">{{ club.description }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.page { max-width: 720px; margin: 0 auto; }
+.grid { display: flex; flex-direction: column; gap: 16px; margin-top: 16px; }
+.card { background: #fff; border-radius: 8px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+.card h3 { margin: 0 0 8px; }
+.meta { font-size: 14px; color: #666; margin-bottom: 4px; }
+</style>

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -1,23 +1,23 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
+import { ElMessageBox } from "element-plus";
 
 interface Club {
   id: number;
   name: string;
   description: string | null;
   category: string | null;
-  status: string | null;
 }
 
 const clubs = ref<Club[]>([]);
 const loading = ref(true);
 const error = ref("");
 
-// 新增表单
-const newName = ref("");
-const newCategory = ref("");
-const newDesc = ref("");
-const creating = ref(false);
+const dialogVisible = ref(false);
+const formName = ref("");
+const formCategory = ref("");
+const formDesc = ref("");
+const saving = ref(false);
 
 async function loadClubs() {
   loading.value = true;
@@ -33,34 +33,37 @@ async function loadClubs() {
   }
 }
 
+function openCreate() {
+  formName.value = "";
+  formCategory.value = "";
+  formDesc.value = "";
+  dialogVisible.value = true;
+}
+
 async function createClub() {
-  if (!newName.value || !newCategory.value) return;
-  creating.value = true;
+  if (!formName.value || !formCategory.value) return;
+  saving.value = true;
   try {
     await fetch("/api/clubs", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: newName.value, category: newCategory.value, description: newDesc.value || null }),
+      body: JSON.stringify({ name: formName.value, category: formCategory.value, description: formDesc.value || null }),
     });
-    newName.value = "";
-    newCategory.value = "";
-    newDesc.value = "";
+    dialogVisible.value = false;
     await loadClubs();
   } catch (e) {
     error.value = e instanceof Error ? e.message : "创建失败";
   } finally {
-    creating.value = false;
+    saving.value = false;
   }
 }
 
 async function deleteClub(id: number, name: string) {
-  if (!confirm(`确认删除「${name}」？`)) return;
   try {
+    await ElMessageBox.confirm(`确认删除「${name}」？`, "删除社团", { type: "warning" });
     await fetch(`/api/clubs/${id}`, { method: "DELETE" });
     await loadClubs();
-  } catch (e) {
-    error.value = e instanceof Error ? e.message : "删除失败";
-  }
+  } catch { /* 用户取消 */ }
 }
 
 onMounted(loadClubs);
@@ -68,46 +71,48 @@ onMounted(loadClubs);
 
 <template>
   <div class="page">
-    <h2>社团列表</h2>
-
-    <!-- 新增表单 -->
-    <div class="form">
-      <input v-model="newName" placeholder="社团名称" />
-      <input v-model="newCategory" placeholder="分类（如：学术科技）" />
-      <input v-model="newDesc" placeholder="简介（可选）" />
-      <button @click="createClub" :disabled="creating || !newName || !newCategory">
-        {{ creating ? "创建中…" : "新增社团" }}
-      </button>
+    <div class="toolbar">
+      <h2>社团列表</h2>
+      <el-button type="primary" @click="openCreate">新增社团</el-button>
     </div>
 
-    <div v-if="error" class="err">{{ error }}</div>
-    <div v-if="loading">加载中…</div>
-    <div v-else-if="clubs.length === 0" class="empty">暂无社团数据</div>
-    <div v-else class="grid">
-      <div v-for="club in clubs" :key="club.id" class="card">
-        <div class="row">
-          <h3>{{ club.name }}</h3>
-          <button class="del" @click="deleteClub(club.id, club.name)">删除</button>
-        </div>
-        <div class="meta">{{ club.category ?? "未分类" }}</div>
-        <p v-if="club.description">{{ club.description }}</p>
-      </div>
-    </div>
+    <el-alert v-if="error" :title="error" type="error" show-icon closable @close="error=''" />
+
+    <el-table v-loading="loading" :data="clubs" stripe empty-text="暂无社团数据">
+      <el-table-column prop="id" label="ID" width="60" />
+      <el-table-column prop="name" label="名称" />
+      <el-table-column prop="category" label="分类" />
+      <el-table-column prop="description" label="简介" show-overflow-tooltip />
+      <el-table-column label="操作" width="80">
+        <template #default="{ row }">
+          <el-button type="danger" size="small" text @click="deleteClub(row.id, row.name)">删除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <!-- 新增对话框 -->
+    <el-dialog v-model="dialogVisible" title="新增社团" width="420px">
+      <el-form label-position="top">
+        <el-form-item label="名称" required>
+          <el-input v-model="formName" placeholder="社团名称" />
+        </el-form-item>
+        <el-form-item label="分类" required>
+          <el-input v-model="formCategory" placeholder="如：学术科技" />
+        </el-form-item>
+        <el-form-item label="简介">
+          <el-input v-model="formDesc" type="textarea" placeholder="可选" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="createClub">确定</el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <style scoped>
-.page { max-width: 720px; margin: 0 auto; }
-.form { display: flex; gap: 8px; margin-bottom: 16px; flex-wrap: wrap; }
-.form input { flex: 1; min-width: 120px; padding: 6px 10px; border: 1px solid #ccc; border-radius: 6px; }
-.form button { padding: 6px 16px; border: none; background: #1976d2; color: #fff; border-radius: 6px; cursor: pointer; }
-.form button:disabled { opacity: .5; cursor: default; }
-.grid { display: flex; flex-direction: column; gap: 16px; margin-top: 16px; }
-.card { background: #fff; border-radius: 8px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
-.row { display: flex; justify-content: space-between; align-items: center; }
-.row h3 { margin: 0; }
-.del { border: none; background: none; color: #c62828; cursor: pointer; font-size: 13px; }
-.meta { font-size: 14px; color: #666; margin-bottom: 4px; }
-.err { color: #c62828; margin: 16px 0; }
-.empty { color: #999; margin-top: 24px; text-align: center; }
+.page { max-width: 860px; margin: 0 auto; }
+.toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+.toolbar h2 { margin: 0; }
 </style>

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -7,40 +7,86 @@ interface Club {
   description: string | null;
   category: string | null;
   status: string | null;
-  foundedAt: string | null;
-  createdAt: string;
 }
 
 const clubs = ref<Club[]>([]);
 const loading = ref(true);
 const error = ref("");
 
-onMounted(async () => {
+// 新增表单
+const newName = ref("");
+const newCategory = ref("");
+const newDesc = ref("");
+const creating = ref(false);
+
+async function loadClubs() {
+  error.value = "";
   try {
     const res = await fetch("/api/clubs");
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     clubs.value = await res.json();
   } catch (e) {
     error.value = e instanceof Error ? e.message : "加载失败";
-  } finally {
-    loading.value = false;
   }
-});
+}
+
+async function createClub() {
+  if (!newName.value || !newCategory.value) return;
+  creating.value = true;
+  try {
+    await fetch("/api/clubs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newName.value, category: newCategory.value, description: newDesc.value || null }),
+    });
+    newName.value = "";
+    newCategory.value = "";
+    newDesc.value = "";
+    await loadClubs();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "创建失败";
+  } finally {
+    creating.value = false;
+  }
+}
+
+async function deleteClub(id: number, name: string) {
+  if (!confirm(`确认删除「${name}」？`)) return;
+  try {
+    await fetch(`/api/clubs/${id}`, { method: "DELETE" });
+    await loadClubs();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "删除失败";
+  }
+}
+
+onMounted(loadClubs);
 </script>
 
 <template>
   <div class="page">
     <h2>社团列表</h2>
+
+    <!-- 新增表单 -->
+    <div class="form">
+      <input v-model="newName" placeholder="社团名称" />
+      <input v-model="newCategory" placeholder="分类（如：学术科技）" />
+      <input v-model="newDesc" placeholder="简介（可选）" />
+      <button @click="createClub" :disabled="creating || !newName || !newCategory">
+        {{ creating ? "创建中…" : "新增社团" }}
+      </button>
+    </div>
+
     <div v-if="error" class="err">{{ error }}</div>
     <div v-if="loading">加载中…</div>
     <div v-else-if="clubs.length === 0" class="empty">暂无社团数据</div>
     <div v-else class="grid">
       <div v-for="club in clubs" :key="club.id" class="card">
-        <h3>{{ club.name }}</h3>
-        <div class="meta">
-          {{ club.category ?? "未分类" }}
-          <span v-if="club.status"> · {{ club.status }}</span>
+        <div class="row">
+          <h3>{{ club.name }}</h3>
+          <button class="del" @click="deleteClub(club.id, club.name)">删除</button>
         </div>
+        <div class="meta">{{ club.category ?? "未分类" }}</div>
         <p v-if="club.description">{{ club.description }}</p>
       </div>
     </div>
@@ -49,9 +95,15 @@ onMounted(async () => {
 
 <style scoped>
 .page { max-width: 720px; margin: 0 auto; }
+.form { display: flex; gap: 8px; margin-bottom: 16px; flex-wrap: wrap; }
+.form input { flex: 1; min-width: 120px; padding: 6px 10px; border: 1px solid #ccc; border-radius: 6px; }
+.form button { padding: 6px 16px; border: none; background: #1976d2; color: #fff; border-radius: 6px; cursor: pointer; }
+.form button:disabled { opacity: .5; cursor: default; }
 .grid { display: flex; flex-direction: column; gap: 16px; margin-top: 16px; }
 .card { background: #fff; border-radius: 8px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
-.card h3 { margin: 0 0 8px; }
+.row { display: flex; justify-content: space-between; align-items: center; }
+.row h3 { margin: 0; }
+.del { border: none; background: none; color: #c62828; cursor: pointer; font-size: 13px; }
 .meta { font-size: 14px; color: #666; margin-bottom: 4px; }
 .err { color: #c62828; margin: 16px 0; }
 .empty { color: #999; margin-top: 24px; text-align: center; }

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -5,18 +5,23 @@ interface Club {
   id: number;
   name: string;
   description: string | null;
-  category: string;
-  memberCount: number;
-  presidentName: string;
+  category: string | null;
+  status: string | null;
+  foundedAt: string | null;
+  createdAt: string;
 }
 
 const clubs = ref<Club[]>([]);
 const loading = ref(true);
+const error = ref("");
 
 onMounted(async () => {
   try {
     const res = await fetch("/api/clubs");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
     clubs.value = await res.json();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "加载失败";
   } finally {
     loading.value = false;
   }
@@ -26,12 +31,16 @@ onMounted(async () => {
 <template>
   <div class="page">
     <h2>社团列表</h2>
+    <div v-if="error" class="err">{{ error }}</div>
     <div v-if="loading">加载中…</div>
+    <div v-else-if="clubs.length === 0" class="empty">暂无社团数据</div>
     <div v-else class="grid">
       <div v-for="club in clubs" :key="club.id" class="card">
         <h3>{{ club.name }}</h3>
-        <div class="meta">{{ club.category }} · {{ club.memberCount }} 人</div>
-        <div class="meta">社长：{{ club.presidentName }}</div>
+        <div class="meta">
+          {{ club.category ?? "未分类" }}
+          <span v-if="club.status"> · {{ club.status }}</span>
+        </div>
         <p v-if="club.description">{{ club.description }}</p>
       </div>
     </div>
@@ -44,4 +53,6 @@ onMounted(async () => {
 .card { background: #fff; border-radius: 8px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
 .card h3 { margin: 0 0 8px; }
 .meta { font-size: 14px; color: #666; margin-bottom: 4px; }
+.err { color: #c62828; margin: 16px 0; }
+.empty { color: #999; margin-top: 24px; text-align: center; }
 </style>


### PR DESCRIPTION
## 修改摘要

- api/openapi.yaml 新增 4 个端点（GET /api/clubs、/api/clubs/{id}、/api/activities、/api/activities/{id}）
- 新增 ClubsController + ActivitiesController（硬编码 mock 数据，不连数据库）
- 前端安装 vue-router，新增 ClubList.vue + ActivityList.vue 页面
- App.vue 改为导航 + router-view 布局

## 验证

```
curl localhost:5000/api/clubs              → 3 个社团 JSON ✅
curl localhost:5000/api/clubs/1            → 计算机协会 ✅
curl localhost:5000/api/activities         → 3 个活动 JSON ✅
curl localhost:5000/api/activities/1       → 秋季 Hackathon ✅
dotnet build --configuration Release       → 0 errors ✅
pnpm run build                             → 通过 ✅
```

## 影响范围

- [x] 后端
- [x] 前端

## 后续计划

- 接入 Oracle 数据库替换 mock 数据
- 详情页独立路由
- 前端增加错误状态和空数据 UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增社团与活动列表页面，包含路由跳转、表格展示、创建/删除社团及活动浏览。
  * 后端提供社团与活动的完整 REST 接口，并更新健康检查以驱动前端状态展示。
* **Documentation**
  * 更新贡献与数据库连接说明（改为远程共享 Oracle，提供配置与连接示例）。
  * 更新前端/架构栈表述，并扩展 OpenAPI 契约与示例。
* **Chores**
  * CI 构建环境升级为 .NET 10.x。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->