### PR TITLE
fix: 升级 Microsoft.AspNetCore.OpenApi 到 10.0.0

### DIFF
--- a/backend/ClubHub.Api.csproj
+++ b/backend/ClubHub.Api.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.26200" />
   </ItemGroup>
 


### PR DESCRIPTION
## 修改摘要

`Microsoft.AspNetCore.OpenApi` 从 9.0.0 升级到 10.0.0，匹配 net10.0 目标框架。

## 来源

- Issue #32
- CodeRabbit review on PR #30

## 影响范围

- [x] 后端

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了应用的依赖版本，包含一项 OpenAPI 相关组件升级。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->