### PR TITLE
fix(docker): 同步后端 Docker 镜像到 .NET 10

### DIFF
--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -70,10 +70,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g @openapitools/openapi-generator-cli
+          npm install -g @openapitools/openapi-generator-cli@2.39.1
           mkdir -p frontend/src/api
 
-          npx @openapitools/openapi-generator-cli generate \
+          npx @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
             -g typescript-axios \
             -o frontend/src/api \
@@ -89,14 +89,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g @openapitools/openapi-generator-cli
+          npm install -g @openapitools/openapi-generator-cli@2.39.1
           mkdir -p backend/Models
 
-          npx @openapitools/openapi-generator-cli generate \
+          npx @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
             -g aspnetcore \
             -o backend/Generated \
-            --additional-properties=aspnetCoreVersion=net10.0,classModifier=public,operationModifier=virtual
+            --additional-properties=aspnetCoreVersion=8.0,classModifier=public,operationModifier=virtual
 
           # 只保留 Models 目录（Controller 由开发者手写）
           if [[ -d backend/Generated/src/*/Models ]]; then

--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -96,7 +96,7 @@ jobs:
             -i api/openapi.yaml \
             -g aspnetcore \
             -o backend/Generated \
-            --additional-properties=aspnetCoreVersion=net9.0,classModifier=public,operationModifier=virtual
+            --additional-properties=aspnetCoreVersion=net10.0,classModifier=public,operationModifier=virtual
 
           # 只保留 Models 目录（Controller 由开发者手写）
           if [[ -d backend/Generated/src/*/Models ]]; then

--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -70,10 +70,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g @openapitools/openapi-generator-cli@2.39.1
           mkdir -p frontend/src/api
 
-          npx @openapitools/openapi-generator-cli@2.39.1 generate \
+          npx --yes @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
             -g typescript-axios \
             -o frontend/src/api \
@@ -89,10 +88,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g @openapitools/openapi-generator-cli@2.39.1
           mkdir -p backend/Models
 
-          npx @openapitools/openapi-generator-cli@2.39.1 generate \
+          npx --yes @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
             -g aspnetcore \
             -o backend/Generated \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 - `main` 保存阶段性稳定版本，`dev` 用作日常集成，个人任务从 `dev` 拉功能分支。
 - 功能分支可以 `fetch + rebase`，但最好不要。
 - 密码、私钥、服务器 IP、Oracle 连接串不进仓库，只放本机环境变量或 GitHub Secrets。
-- 前后端分离：后端 C# / ASP.NET Core Web API，前端 Vue 3 / Vite + Element Plus，数据库 Oracle。
+- 前后端分离：后端 C# / ASP.NET Core 10 Web API，前端 Vue 3 / Vite + Element Plus，数据库 Oracle。
 
 ## 仓库目录
 
@@ -28,7 +28,7 @@
 
 - Visual Studio 2022 或更高版本。
 - `ASP.NET and web development` 工作负载。
-- .NET SDK。
+- .NET SDK 10.0（后端项目目标框架为 `net10.0`）。
 - 远程 Oracle 数据库（团队共用，不需本地安装）。后端通过 EF Core 托管驱动直连。
   - 首次配置：复制 `backend/appsettings.Development.example.json` 为 `appsettings.Development.json`（已 gitignore），填入连接信息。详见 `database/README.md`。
 - SQL Developer（可选，方便手动浏览数据库）。

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ClubHub 是《数据库课程设计》项目，面向高校社团日常运营场
 ## 技术栈
 
 - IDE：Visual Studio Community 2022 或更高版本
-- 后端：C# / ASP.NET Core Web API
+- 后端：C# / ASP.NET Core 10 Web API（目标框架 `net10.0`）
 - 前端：Vue 3 / Vite
 - 数据库：Oracle Database 18c 或更高版本
 - 数据访问：Oracle Managed Data Access / ODP.NET，必要时使用 Oracle EF Core Provider
@@ -41,6 +41,6 @@ ClubHub 是《数据库课程设计》项目，面向高校社团日常运营场
 ## 协作与环境
 
 1. 阅读 `CONTRIBUTING.md`，确认环境、分支、提交、Issue、PR、CI/CD 和安全规范。
-2. 配好 Visual Studio、.NET SDK、Oracle XE、SQL Developer。
+2. 配好 Visual Studio、.NET SDK 10.0、Oracle XE、SQL Developer。
 3. 用 `database/schema.sql` 创建本地数据库结构，用 `database/verify.sql` 验证。
 4. 日常开发先从 `dev` 分支开功能分支，用 Issue、PR 和 commit 留痕。

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: restore + publish
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY backend/*.csproj backend/
 RUN dotnet restore backend/ClubHub.Api.csproj
@@ -7,7 +7,7 @@ COPY backend/ backend/
 RUN dotnet publish backend/ClubHub.Api.csproj -c Release -o /app --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 COPY --from=build /app .
 EXPOSE 5000

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@
 
 services:
   backend:
-    image: mcr.microsoft.com/dotnet/sdk:9.0
+    image: mcr.microsoft.com/dotnet/sdk:10.0
     working_dir: /src
     ports:
       - "5000:5000"


### PR DESCRIPTION
## 修改摘要

- 将 `backend/Dockerfile` 的 build 镜像从 `mcr.microsoft.com/dotnet/sdk:9.0` 升级到 `mcr.microsoft.com/dotnet/sdk:10.0`。
- 将 `backend/Dockerfile` 的 runtime 镜像从 `mcr.microsoft.com/dotnet/aspnet:9.0` 升级到 `mcr.microsoft.com/dotnet/aspnet:10.0`。
- 将 `docker-compose.dev.yml` 的后端开发镜像同步到 `.NET SDK 10.0`。
- 锁定 `@openapitools/openapi-generator-cli` 为 `2.39.1`，避免生成结果漂移。
- 将 OpenAPI 后端生成参数设为官方支持的 `aspnetCoreVersion=8.0`。该 workflow 只保留生成出的 Models，生成模型可用于当前 `net10.0` 后端项目。
- 在 `README.md` 和 `CONTRIBUTING.md` 中明确后端使用 `.NET SDK 10.0 / net10.0`。

## 课程功能点

- 不对应具体业务功能点。
- 本 PR 是基础设施修复，用于恢复 main 分支自动构建镜像和部署流程。

## 原因

当前后端项目 `backend/ClubHub.Api.csproj` 目标框架是 `net10.0`，但部署 workflow 构建镜像时使用的是 `.NET 9 SDK`，因此在 `dotnet restore` 阶段报错：

```text
error NETSDK1045: The current .NET SDK does not support targeting .NET 10.0.
```

课程要求是较新版本 Visual Studio / VS.NET、C#、Oracle 18c 或更高版本，没有限定 .NET 9；使用 .NET 10 不违反课程要求。

## 影响范围

- 影响后端 Docker 镜像构建。
- 影响本地 Docker 开发环境中的后端 SDK 镜像。
- 影响 `api/openapi.yaml` 变更时触发的 API 代码生成 workflow。
- 不修改业务代码，不修改数据库结构。

## 验证

- [x] `git diff --check`
- [x] `npm view @openapitools/openapi-generator-cli@2.39.1 version`
- [x] 已确认主仓库不再存在 `sdk:9.0`、`aspnet:9.0`、`net9.0`、`9.0.x` 等真实 .NET 9 残留
- [ ] GitHub Actions 构建后端镜像通过

## 数据库影响

无数据库结构、数据或迁移脚本变更。

## 部署影响

合并到 `main` 后会重新触发部署 workflow。后端镜像将使用 .NET 10 SDK 构建，并使用 .NET 10 ASP.NET Runtime 运行。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 更新了 README 和贡献指南中的技术栈说明与本地环境要求，明确 .NET 10 及相关目标框架版本。
* **Chores**
  * 统一了后端与开发环境的容器镜像版本到 10.0。
  * 调整了自动生成接口代码的流程，改为固定使用指定版本工具，提升一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->