### PR TITLE
chore(sync): 将 main 热修复同步回 dev

### DIFF
--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -70,10 +70,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g @openapitools/openapi-generator-cli
+          npm install -g @openapitools/openapi-generator-cli@2.39.1
           mkdir -p frontend/src/api
 
-          npx @openapitools/openapi-generator-cli generate \
+          npx @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
             -g typescript-axios \
             -o frontend/src/api \
@@ -89,14 +89,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g @openapitools/openapi-generator-cli
+          npm install -g @openapitools/openapi-generator-cli@2.39.1
           mkdir -p backend/Models
 
-          npx @openapitools/openapi-generator-cli generate \
+          npx @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
             -g aspnetcore \
             -o backend/Generated \
-            --additional-properties=aspnetCoreVersion=net10.0,classModifier=public,operationModifier=virtual
+            --additional-properties=aspnetCoreVersion=8.0,classModifier=public,operationModifier=virtual
 
           # 只保留 Models 目录（Controller 由开发者手写）
           if [[ -d backend/Generated/src/*/Models ]]; then

--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -96,7 +96,7 @@ jobs:
             -i api/openapi.yaml \
             -g aspnetcore \
             -o backend/Generated \
-            --additional-properties=aspnetCoreVersion=net9.0,classModifier=public,operationModifier=virtual
+            --additional-properties=aspnetCoreVersion=net10.0,classModifier=public,operationModifier=virtual
 
           # 只保留 Models 目录（Controller 由开发者手写）
           if [[ -d backend/Generated/src/*/Models ]]; then

--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -70,10 +70,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g @openapitools/openapi-generator-cli@2.39.1
           mkdir -p frontend/src/api
 
-          npx @openapitools/openapi-generator-cli@2.39.1 generate \
+          npx --yes @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
             -g typescript-axios \
             -o frontend/src/api \
@@ -89,10 +88,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g @openapitools/openapi-generator-cli@2.39.1
           mkdir -p backend/Models
 
-          npx @openapitools/openapi-generator-cli@2.39.1 generate \
+          npx --yes @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
             -g aspnetcore \
             -o backend/Generated \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 - `main` 保存阶段性稳定版本，`dev` 用作日常集成，个人任务从 `dev` 拉功能分支。
 - 功能分支可以 `fetch + rebase`，但最好不要。
 - 密码、私钥、服务器 IP、Oracle 连接串不进仓库，只放本机环境变量或 GitHub Secrets。
-- 前后端分离：后端 C# / ASP.NET Core Web API，前端 Vue 3 / Vite + Element Plus，数据库 Oracle。
+- 前后端分离：后端 C# / ASP.NET Core 10 Web API，前端 Vue 3 / Vite + Element Plus，数据库 Oracle。
 
 ## 仓库目录
 
@@ -28,7 +28,7 @@
 
 - Visual Studio 2022 或更高版本。
 - `ASP.NET and web development` 工作负载。
-- .NET SDK。
+- .NET SDK 10.0（后端项目目标框架为 `net10.0`）。
 - 远程 Oracle 数据库（团队共用，不需本地安装）。后端通过 EF Core 托管驱动直连。
   - 首次配置：复制 `backend/appsettings.Development.example.json` 为 `appsettings.Development.json`（已 gitignore），填入连接信息。详见 `database/README.md`。
 - SQL Developer（可选，方便手动浏览数据库）。

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ClubHub 是《数据库课程设计》项目，面向高校社团日常运营场
 ## 技术栈
 
 - IDE：Visual Studio Community 2022 或更高版本
-- 后端：C# / ASP.NET Core Web API
+- 后端：C# / ASP.NET Core 10 Web API（目标框架 `net10.0`）
 - 前端：Vue 3 / Vite
 - 数据库：Oracle Database 18c 或更高版本
 - 数据访问：Oracle Managed Data Access / ODP.NET，必要时使用 Oracle EF Core Provider
@@ -41,6 +41,6 @@ ClubHub 是《数据库课程设计》项目，面向高校社团日常运营场
 ## 协作与环境
 
 1. 阅读 `CONTRIBUTING.md`，确认环境、分支、提交、Issue、PR、CI/CD 和安全规范。
-2. 配好 Visual Studio、.NET SDK、Oracle XE、SQL Developer。
+2. 配好 Visual Studio、.NET SDK 10.0、Oracle XE、SQL Developer。
 3. 用 `database/schema.sql` 创建本地数据库结构，用 `database/verify.sql` 验证。
 4. 日常开发先从 `dev` 分支开功能分支，用 Issue、PR 和 commit 留痕。

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: restore + publish
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY backend/*.csproj backend/
 RUN dotnet restore backend/ClubHub.Api.csproj
@@ -7,7 +7,7 @@ COPY backend/ backend/
 RUN dotnet publish backend/ClubHub.Api.csproj -c Release -o /app --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 COPY --from=build /app .
 EXPOSE 5000

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@
 
 services:
   backend:
-    image: mcr.microsoft.com/dotnet/sdk:9.0
+    image: mcr.microsoft.com/dotnet/sdk:10.0
     working_dir: /src
     ports:
       - "5000:5000"


### PR DESCRIPTION
## 修改摘要

将已经合入 main 的 #41 热修复同步回 dev，避免日常开发分支落后于线上稳定分支。

同步内容包括：

- 后端 Dockerfile 使用 .NET 10 SDK / ASP.NET Runtime。
- 本地 docker-compose.dev.yml 使用 .NET SDK 10。
- OpenAPI Generator 固定版本并使用支持的 spnetCoreVersion=8.0 生成后端 Models。
- README / CONTRIBUTING 同步 .NET 10 环境说明。

## 原因

#41 是为了修复 main 部署失败而直接合入 main 的 hotfix。合并后 dev 落后于 main，需要回灌，保证后续功能分支从 dev 开发时也包含同样的构建和部署修复。

## 验证

- #41 PR 已通过 CI / CodeRabbit。
- #41 合入 main 后 Deploy 重跑成功。

## 数据库影响

无。

## 部署影响

无新的部署影响；本 PR 只是将已在 main 生效的配置同步回 dev。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 后端与生成流程已升级到 .NET 10 / ASP.NET Core 10，保持与最新运行环境一致。
  * API 代码生成改为固定版本执行，提升生成结果的一致性。

* **文档**
  * 更新了 README 与协作说明，明确本地开发所需的 .NET SDK 版本为 10.0。

* **其他**
  * 容器与开发环境配置同步更新为 .NET 10。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->