### PR TITLE
fix(ci): 修复 OpenAPI 后端模型生成参数

### DIFF
--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -94,11 +94,15 @@ jobs:
             -i api/openapi.yaml \
             -g aspnetcore \
             -o backend/Generated \
-            --additional-properties=aspnetCoreVersion=8.0,classModifier=public,operationModifier=virtual
+            --additional-properties=aspnetCoreVersion=8.0
 
           # 只保留 Models 目录（Controller 由开发者手写）
-          if [[ -d backend/Generated/src/*/Models ]]; then
-            cp -R backend/Generated/src/*/Models/* backend/Models/ 2>/dev/null || true
+          models_dir="$(find backend/Generated/src -type d -path '*/Models' -print -quit)"
+          if [[ -n "$models_dir" ]]; then
+            cp -R "$models_dir"/. backend/Models/
+          else
+            echo "::error::未找到 OpenAPI Generator 输出的 Models 目录。"
+            exit 1
           fi
           rm -rf backend/Generated
           echo "后端 ASP.NET Core 模型已生成。"

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ Wallet_*/
 tnsnames.ora.local
 
 # Course scratch exports
+.claude/
 .codex-extracted/
 .scratch/
 tmp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,6 +370,7 @@ ClubHub 采用 API-first 开发模式：**先定义 API 契约，再自动生成
 > **注意**：生成的文件（`frontend/src/api/*`、`backend/Models/*`）禁止手动修改。
 > 如果改了它们，下次 `gen-api-code.yml` 运行会覆盖你的改动。
 > 需要修改 API 行为时，请改 `api/openapi.yaml`，然后让流水线重新生成。
+> 维护生成 workflow 时，后端 `aspnetcore` generator 目前只保留 `aspnetCoreVersion=8.0` 参数。不要加入 `classModifier=public`；当前生成器会直接报错。`operationModifier` 只影响生成 Controller，而我们只复制 Models，因此也不需要保留。
 
 ## 本地运行
 


### PR DESCRIPTION
修复 OpenAPI Generator 后端 aspnetcore 生成参数：删除会导致生成器报错的 classModifier=public，保留 aspnetCoreVersion=8.0，并用 find 稳定定位生成出的 Models 目录再复制。\n\n验证：\n- 使用 PR #42 的 api/openapi.yaml 运行 aspnetcore 后端生成器，通过。\n- 使用 PR #42 的 api/openapi.yaml 运行 typescript-axios 前端生成器，通过。\n- 复查 GitHub Actions 旧失败日志，失败根因为 classModifier: Invalid value 'public'。\n- python 解析 gen-api-code.yml，通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进后端 API 代码生成流程：当模型未生成时会明确报错并停止，避免不完整产物。
  * 优化生成产物的 Models 拷贝逻辑，提升匹配准确性与稳定性，减少异常导致的失败。

* **Documentation**
  * 补充 API-first 开发流程的维护说明，明确生成器参数的约束与当前流程所需项。  

* **Chores**
  * 新增对 `.claude/` 目录的忽略规则，防止其被纳入版本管理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->