### PR TITLE
fix(docker): Vite 代理使用环境变量适配 Docker Compose 网络

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,5 +30,7 @@ services:
       sh -c "corepack enable &&
              pnpm install --frozen-lockfile &&
              pnpm run dev --host"
+    environment:
+      - API_PROXY_TARGET=http://backend:5000
     depends_on:
       - backend

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [vue()],
   server: {
     proxy: {
-      "/api": "http://localhost:5000",
+      "/api": process.env.API_PROXY_TARGET || "http://localhost:5000",
     },
   },
 });


### PR DESCRIPTION
Docker Compose 中 Vite dev server 运行在 frontend 容器内，`localhost` 指向容器自身而非 backend 容器，导致 `/api` 代理失败。

## 改动

- `frontend/vite.config.ts`：proxy target 改为读取 `API_PROXY_TARGET` 环境变量，默认值保持 `http://localhost:5000`，兼容非 Docker 本地开发。
- `docker-compose.dev.yml`：frontend 服务设置 `API_PROXY_TARGET=http://backend:5000`，利用 Docker 内部 DNS。

## 课程功能点

不对应具体业务功能点。属于基础设施修复，确保 Docker Compose 开发模式下前后端网络连通性。

## 影响范围

- 影响 Docker Compose 开发模式下的前端 API 代理。
- 不影响非 Docker 本地开发（默认值兼容）。
- 不修改业务代码，不修改数据库结构。

## 验证

- [x] 非 Docker 场景：未设置 `API_PROXY_TARGET` 时，proxy target 回退为 `http://localhost:5000`，行为不变。
- [x] Docker 场景：frontend 容器接收 `API_PROXY_TARGET=http://backend:5000` 环境变量，Vite 将 `/api` 请求转发到 backend 容器。

## 数据库影响

无。

## 部署影响

无。生产环境使用 `docker-compose.yml`（Nginx 反向代理），不走 Vite dev server proxy。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 前端开发环境现在支持通过环境变量配置 API 代理目标。
  * 容器化开发时可自动将接口请求转发到后端服务，提升本地联调体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->