### PR TITLE
chore(gitignore): 忽略 openapitools.json 和 .pnpm-store/ 本地工具残留

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ wallet/
 Wallet_*/
 tnsnames.ora.local
 
+# OpenAPI generator (local CLI artifact)
+openapitools.json
+
 # Course scratch exports
 .claude/
 .codex-extracted/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# pnpm store
+.pnpm-store/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## 改动

- `.gitignore`：添加 `openapitools.json`（OpenAPI Generator CLI 本地残留文件，CI 硬编码版本，不读取此文件）
- `frontend/.gitignore`：添加 `.pnpm-store/`（pnpm 本地包缓存，类似 `node_modules/`，含 10,588 个文件）

## 缘由

`.pnpm-store/` 导致本地 git 显示过万未追踪文件，严重影响 IDE 性能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了忽略规则，避免本地生成的 OpenAPI 配置文件被提交到版本控制。
  * 补充了前端的忽略规则，屏蔽 pnpm 本地存储目录，减少无关文件干扰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->