### PR TITLE
fix(ci): 修复自动生成 API 代码格式与模型依赖

### DIFF
--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -10,6 +10,7 @@ on:
       - dev
     paths:
       - api/**
+  workflow_dispatch:
 
 permissions:
   contents: write # 自动提交生成代码
@@ -78,7 +79,14 @@ jobs:
             -o frontend/src/api \
             --additional-properties=supportsES6=true,withSeparateModelsAndApi=true,apiPackage=api,modelPackage=models
 
+          npx --yes prettier@3.9.4 --write frontend/src/api
           echo "前端 TypeScript Axios 客户端已生成。"
+
+      - name: Setup .NET
+        if: steps.detect.outputs.has_backend == 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
 
       # ============================================================
       # 后端生成：ASP.NET Core 数据模型
@@ -94,7 +102,7 @@ jobs:
             -i api/openapi.yaml \
             -g aspnetcore \
             -o backend/Generated \
-            --additional-properties=aspnetCoreVersion=8.0
+            --additional-properties=aspnetCoreVersion=8.0,pocoModels=true,useNewtonsoft=false,nullableReferenceTypes=true
 
           # 只保留 Models 目录（Controller 由开发者手写）
           models_dir="$(find backend/Generated/src -type d -path '*/Models' -print -quit)"
@@ -105,6 +113,11 @@ jobs:
             exit 1
           fi
           rm -rf backend/Generated
+
+          find backend/Models -type f -name "*.cs" -print0 \
+            | xargs -0 sed -i '/^using Org\.OpenAPITools\.Converters;$/d'
+
+          dotnet format backend/ClubHub.Api.csproj --include backend/Models --verbosity minimal
           echo "后端 ASP.NET Core 模型已生成。"
 
       # ============================================================

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,7 +370,8 @@ ClubHub 采用 API-first 开发模式：**先定义 API 契约，再自动生成
 > **注意**：生成的文件（`frontend/src/api/*`、`backend/Models/*`）禁止手动修改。
 > 如果改了它们，下次 `gen-api-code.yml` 运行会覆盖你的改动。
 > 需要修改 API 行为时，请改 `api/openapi.yaml`，然后让流水线重新生成。
-> 维护生成 workflow 时，后端 `aspnetcore` generator 目前只保留 `aspnetCoreVersion=8.0` 参数。不要加入 `classModifier=public`；当前生成器会直接报错。`operationModifier` 只影响生成 Controller，而我们只复制 Models，因此也不需要保留。
+> 如果只是同步了生成 workflow 的修复、但 `api/openapi.yaml` 没有新变化，可以在 GitHub Actions 中手动运行 `生成 API 代码`，选择自己的 feature 分支重新生成。
+> 维护生成 workflow 时，后端 `aspnetcore` generator 使用 `aspnetCoreVersion=8.0,pocoModels=true,useNewtonsoft=false,nullableReferenceTypes=true`。不要加入 `classModifier=public`；当前生成器会直接报错。生成后会删除无用的 `Org.OpenAPITools.Converters` 引用并运行格式化，避免生成代码破坏 CI。
 
 ## 本地运行
 


### PR DESCRIPTION
## 修改摘要
- 前端 API 代码生成后自动运行 Prettier，避免生成目录导致前端格式检查失败。
- 后端 OpenAPI Generator 改为生成 POCO/System.Text.Json 风格模型，避免生成 Models 引用 Newtonsoft.Json。
- 删除生成 Models 中无用的 Org.OpenAPITools.Converters using，并在 workflow 中运行 dotnet format。
- 更新 CONTRIBUTING.md 中的生成器维护说明。
## 验证
- 已使用 PR #47 的 openapi.yaml 本地生成后端 Models，并删除 Converters using。
- 已用临时 net9.0 编译项目验证生成 Models：0 errors，仅 nullable warnings；正式 CI 使用 setup-dotnet 10.0.x。
- 已使用 PR #47 的 openapi.yaml 本地生成前端 TypeScript Axios 客户端，并运行 prettier --write / prettier --check，通过。
- 已通过 gen-api-code.yml YAML 语法检查与 git diff --check。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增手动触发的 API 生成工作流，便于按需重建前后端客户端与模型。
  * 生成前端 API 客户端后自动执行代码格式化，提升代码一致性。
* **改进**
  * 后端模型生成过程增强为使用指定的 .NET 运行环境与更完整的生成参数配置。
  * 生成后对模型代码进行批量清理并执行格式化，提升可读性与规范性。
* **文档**
  * 更新贡献指南，明确推荐的 API 生成参数及生成后处理规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->