### PR TITLE
fix(ci): 清理 OpenAPI 生成器前端垃圾文件

### DIFF
--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -80,6 +80,15 @@ jobs:
             --additional-properties=supportsES6=true,withSeparateModelsAndApi=true,apiPackage=api,modelPackage=models
 
           npx --yes prettier@3.9.4 --write frontend/src/api
+
+          # 清理生成器自带文件（模板脚本、忽略文件、元数据、文档）
+          rm -f frontend/src/api/git_push.sh
+          rm -f frontend/src/api/.gitignore
+          rm -f frontend/src/api/.npmignore
+          rm -f frontend/src/api/.openapi-generator-ignore
+          rm -rf frontend/src/api/.openapi-generator
+          rm -rf frontend/src/api/docs
+
           echo "前端 TypeScript Axios 客户端已生成。"
 
       - name: Setup .NET


### PR DESCRIPTION
## 改动内容

在 gen-api-code.yml 前端生成步骤中，prettier 格式化之后、提交之前，新增清理步骤：

- 删除 `git_push.sh`（生成器通用模板脚本）
- 删除 `.gitignore`、`.npmignore`、`.openapi-generator-ignore`（生成器自带忽略文件）
- 删除 `.openapi-generator/`（生成器元数据目录）
- 删除 `docs/`（自动生成的 API 文档）

## 改动原因

OpenAPI 生成器的 `typescript-axios` 模板在前端输出目录中自动附带 6 类无关文件。后端步骤已有完整清理逻辑（`rm -rf backend/Generated`），前端步骤缺少同等处理，导致垃圾文件被 CI 自动提交到仓库（见 #42、#47 的 CI 提交）。

---

## 关联 Issue

Closes #63

## 审查关注点

- 删除的文件清单是否完整，是否有遗漏的生成器自带文件
- 清理步骤的位置（在 prettier 之后、echo 之前）是否合理

## UI 改动

无。

## 测试说明

修改 api/openapi.yaml 后 push 到此分支，观察 CI 自动提交的文件列表是否不再包含上述垃圾文件。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过 — 不涉及
- [x] 前端代码已构建通过 — 不涉及
- [x] 已本地手工测试主要场景 — 不涉及

**数据库（仅涉及时勾选）**
- [x] 无表结构变化

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新 — 不涉及
- [ ] 需要新增或修改 GitHub Secrets
- [ ] 需要修改服务器配置或手动迁移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 精简了前端接口客户端的自动生成产物，移除了不必要的附加文件与文档目录，减少仓库体积并让提交内容更干净。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->