### PR TITLE
fix(ci): 正确排除自动生成后端模型

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -76,4 +76,4 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: dotnet format
-        run: dotnet format backend/ClubHub.Api.csproj --verify-no-changes --exclude "Models/**"
+        run: dotnet format backend/ClubHub.Api.csproj --verify-no-changes --exclude "backend/Models/**"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,6 +450,7 @@ ClubHub 采用 API-first 开发模式：**先定义 API 契约，再自动生成
 > 需要修改 API 行为时，请改 `api/openapi.yaml`，然后让流水线重新生成。
 > 如果只是同步了生成 workflow 的修复、但 `api/openapi.yaml` 没有新变化，可以在 GitHub Actions 中手动运行 `生成 API 代码`，选择自己的 feature 分支重新生成。
 > 维护生成 workflow 时，后端 `aspnetcore` generator 使用 `aspnetCoreVersion=8.0,pocoModels=true,useNewtonsoft=false,nullableReferenceTypes=true`。不要加入 `classModifier=public`；当前生成器会直接报错。生成后会删除无用的 `Org.OpenAPITools.Converters` 引用并运行格式化，避免生成代码破坏 CI。
+> `code-check.yml` 中排除自动生成后端模型时必须写仓库相对路径 `backend/Models/**`，不能写 `Models/**`；后者不会命中生成目录。
 
 ## 本地运行
 


### PR DESCRIPTION
## 关联 Issue

Closes #67

## 根因

PR #66 已经合入 dev，但 code-check 仍使用：

```bash
dotnet format backend/ClubHub.Api.csproj --verify-no-changes --exclude "Models/**"
```

PR #52 日志证明该路径没有命中 `backend/Models/*.cs`，所以自动生成模型仍被 dotnet format 扫描并因 whitespace 失败。PR #51 的提交 `ddc2d306566e3024a8b7e169afb5b683d19e9e55` 将路径改成 `backend/Models/**`，方向正确。

## 修改内容

- 将 `.github/workflows/code-check.yml` 的后端格式检查排除路径改为 `backend/Models/**`。
- 在 `CONTRIBUTING.md` 中补充说明，避免后续再次写成 `Models/**`。

## 验证

- `code-check.yml` YAML 语法检查通过。
- `gen-api-code.yml` YAML 语法检查通过。
- `git diff --check` 通过。
- 已核对 PR #52 失败日志，失败命令正是旧的 `--exclude "Models/**"`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整代码检查流程的排除路径，使其更准确地跳过后端模型目录，避免误匹配。
* **Documentation**
  * 更新开发流程说明，补充相关路径配置要求，帮助保持代码检查规则一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->