### PR TITLE
meta: CodeRabbit 跳过自动生成代码审查

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -55,5 +55,13 @@ reviews:
         - 条件触发是否合理（paths、branches）。
         - Action 版本是否明确。
         - Docker 镜像标签策略。
+    - path: "frontend/src/api/**"
+      instructions: |
+        这些文件由 OpenAPI Generator（typescript-axios）自动生成，修改 API 契约后会重新生成。
+        请跳过对此路径的所有审查，不要提出任何修改建议。
+    - path: "backend/Models/**"
+      instructions: |
+        这些文件由 OpenAPI Generator（aspnetcore）自动生成，修改 API 契约后会重新生成。
+        请跳过对此路径的所有审查，不要提出任何修改建议。
 chat:
   auto_reply: true


### PR DESCRIPTION
## 改动内容

在 .coderabbit.yaml 中新增两条 path_instructions，对自动生成代码路径设置跳过审查：

- `frontend/src/api/**`（TypeScript Axios 客户端，由 OpenAPI Generator 生成）
- `backend/Models/**`（ASP.NET Core 数据模型，由 OpenAPI Generator 生成）

## 改动原因

CodeRabbit 对自动生成代码提出了大量 review 意见（TypeScript 类型改进、文档示例修正、shell 脚本安全等），但这些文件由 CI 工作流自动生成，不应手动修改。见 #42 和 #47 的 CodeRabbit review 列表。

---

## 关联 Issue

Closes #69

## 审查关注点

- 是否还有其他自动生成路径未被排除
- 跳过审查的表述是否清晰

## UI 改动

无。

## 测试说明

修改 api/openapi.yaml 触发 gen-api-code.yml 后，检查 CodeRabbit 是否不再对生成代码提 review。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过 — 不涉及
- [x] 前端代码已构建通过 — 不涉及
- [x] 已本地手工测试主要场景 — 不涉及

**数据库（仅涉及时勾选）**
- [x] 无表结构变化

**文档与部署（仅涉及时勾选）**
- [x] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets
- [ ] 需要修改服务器配置或手动迁移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了自动审查规则，跳过对两类自动生成代码的修改建议，减少无关审查干扰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->