### PR TITLE
fix(ci): 修复前端生成 API 构建失败

### DIFF
--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -1,6 +1,6 @@
 name: 生成 API 代码
 
-# 从 api/openapi.yaml 自动生成前端 TypeScript Axios 客户端和后端 ASP.NET Core 数据模型。
+# 从 api/openapi.yaml 自动生成前端 TypeScript Fetch 客户端和后端 ASP.NET Core 数据模型。
 # 开发者修改 API 契约后 push，本 workflow 自动生成代码并提交回分支。
 
 on:
@@ -64,9 +64,9 @@ jobs:
           echo "OpenAPI 规范语法检查通过。"
 
       # ============================================================
-      # 前端生成：TypeScript Axios 客户端
+      # 前端生成：TypeScript Fetch 客户端
       # ============================================================
-      - name: 生成前端 TypeScript Axios 客户端
+      - name: 生成前端 TypeScript Fetch 客户端
         if: steps.detect.outputs.has_frontend == 'true'
         shell: bash
         run: |
@@ -75,9 +75,12 @@ jobs:
 
           npx --yes @openapitools/openapi-generator-cli@2.39.1 generate \
             -i api/openapi.yaml \
-            -g typescript-axios \
+            -g typescript-fetch \
             -o frontend/src/api \
             --additional-properties=supportsES6=true,withSeparateModelsAndApi=true,apiPackage=api,modelPackage=models
+
+          # 生成代码由 OpenAPI Generator 维护，不按业务源码规则做逐行类型检查。
+          find frontend/src/api -type f -name "*.ts" -exec sed -i '1i// @ts-nocheck' {} +
 
           npx --yes prettier@3.9.4 --no-ignore --write "frontend/src/api"
 
@@ -89,7 +92,7 @@ jobs:
           rm -rf frontend/src/api/.openapi-generator
           rm -rf frontend/src/api/docs
 
-          echo "前端 TypeScript Axios 客户端已生成。"
+          echo "前端 TypeScript Fetch 客户端已生成。"
 
       - name: Setup .NET
         if: steps.detect.outputs.has_backend == 'true'

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -11,5 +11,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "exclude": ["src/api/**/*"]
 }


### PR DESCRIPTION
## 背景
PR #52 的前端代码检查已经通过，但 CI 的前端构建失败。根因是 OpenAPI Generator 生成的 typescript-axios 客户端会被业务 tsconfig 严格检查，并且旧生成物依赖 axios。

## 修改
- 前端 API 生成器从 typescript-axios 切换为无需额外运行时依赖的 typescript-fetch。
- 生成出的 TypeScript 文件自动加 // @ts-nocheck，避免机器生成物受业务源码 noUnusedLocals / erasableSyntaxOnly 规则影响。
- frontend/tsconfig.app.json 排除 src/api/**/*，让已有旧生成物在合入最新 dev 后也不会作为业务源码根目录参与检查。

## 验证
- python YAML 解析 .github/workflows/gen-api-code.yml 通过。
- npx @openapitools/openapi-generator-cli@2.39.1 使用 typescript-fetch 生成临时客户端成功。
- 临时放入 PR #52 的旧 frontend/src/api 生成文件后，npx pnpm@10.34.4 run build 通过。
- git diff --check 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **变更**
  * 前端接口客户端生成方式已切换为新的 Fetch 版本。
  * 生成流程提示信息已更新，生成完成后会显示新的成功提示。
  * 生成的 TypeScript 文件将自动添加忽略类型检查标记，减少生成代码带来的校验干扰。
  * 前端编译范围调整后，接口生成代码不再参与应用的 TypeScript 编译检查。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->