### PR TITLE
fix(ci): 清理 kebab-case 文件避免 Windows 大小写冲突

### DIFF
--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -92,6 +92,10 @@ jobs:
           rm -rf frontend/src/api/.openapi-generator
           rm -rf frontend/src/api/docs
 
+          # 删除 kebab-case 文件（未被引用，且与 PascalCase 在 Windows 上冲突）
+          rm -f frontend/src/api/models/activity.ts
+          rm -f frontend/src/api/models/club.ts
+
           echo "前端 TypeScript Fetch 客户端已生成。"
 
       - name: Setup .NET

--- a/.github/workflows/gen-api-code.yml
+++ b/.github/workflows/gen-api-code.yml
@@ -92,9 +92,15 @@ jobs:
           rm -rf frontend/src/api/.openapi-generator
           rm -rf frontend/src/api/docs
 
-          # 删除 kebab-case 文件（未被引用，且与 PascalCase 在 Windows 上冲突）
-          rm -f frontend/src/api/models/activity.ts
-          rm -f frontend/src/api/models/club.ts
+          # 删除与 PascalCase 同名的小写文件（Windows 大小写冲突）
+          # 逻辑：小写 + 无连字符 → 猜测有 PascalCase 对应文件 → 有则删除
+          for f in frontend/src/api/models/[a-z]*.ts; do
+            [[ ! -f "$f" ]] && continue
+            base=$(basename "$f")
+            [[ "$base" == *-* ]] && continue  # 连字符文件不冲突（如 api-error.ts ≠ ApiError.ts）
+            pascal="${base^}"                   # bash: 首字母大写
+            [[ -f "$(dirname "$f")/${pascal}" ]] && rm -f "$f"
+          done
 
           echo "前端 TypeScript Fetch 客户端已生成。"
 


### PR DESCRIPTION
## 改动内容

在 gen-api-code.yml 清理步骤中新增删除 kebab-case 模型文件：

- `activity.ts`（与 `Activity.ts` 在 Windows 上冲突）
- `club.ts`（与 `Club.ts` 在 Windows 上冲突）

## 改动原因

typescript-fetch 生成器在 `models/` 下同时生成 PascalCase 完整版和 kebab-case 精简版。kebab-case 文件未被 `models/index.ts` 引用，全局搜索无调用，且与 PascalCase 在 Windows 上被视为同一文件，导致 `git status` 永久 modified。

---

## 关联 Issue

Closes #73

## 审查关注点

- 是否还有其他可能与 PascalCase 冲突的 kebab-case 文件遗漏
- 确认 `models/index.ts` 确实只 export 了 PascalCase

## UI 改动

无。

## 测试说明

修改 api/openapi.yaml 并 push，观察 CI 提交的 models/ 目录是否只包含 PascalCase 文件。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过 — 不涉及
- [x] 前端代码已构建通过 — 不涉及
- [x] 已本地手工测试主要场景 — 不涉及

**数据库（仅涉及时勾选）**
- [x] 无表结构变化

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新 — 不涉及
- [ ] 需要新增或修改 GitHub Secrets
- [ ] 需要修改服务器配置或手动迁移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化前端代码生成后的清理流程：自动检测并移除在 Windows 大小写不敏感环境下可能产生冲突的重复模型文件。
  * 减少生成产物中的冗余文件，降低后续构建与维护中潜在问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->