### PR TITLE
fix(club): 补齐创建社团请求校验

### DIFF
--- a/backend/Controllers/ClubsController.cs
+++ b/backend/Controllers/ClubsController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
 using Microsoft.AspNetCore.Mvc;
@@ -1540,9 +1541,15 @@ public record ClubApplicationDto(
 
 public class CreateClubRequest
 {
+    [Required]
     public int CurrentUserId { get; set; }
+
+    [Required, StringLength(255, MinimumLength = 1)]
     public string Name { get; set; } = string.Empty;
-    public string? Category { get; set; }
+
+    [Required, StringLength(255, MinimumLength = 1)]
+    public string Category { get; set; } = string.Empty;
+
     public string? Description { get; set; }
 }
 

--- a/backend/Controllers/ClubsController.cs
+++ b/backend/Controllers/ClubsController.cs
@@ -1541,7 +1541,7 @@ public record ClubApplicationDto(
 
 public class CreateClubRequest
 {
-    [Required]
+    [Range(1, int.MaxValue, ErrorMessage = "CurrentUserId 必须大于或等于 1")]
     public int CurrentUserId { get; set; }
 
     [Required, StringLength(255, MinimumLength = 1)]


### PR DESCRIPTION
## 改动内容

- 为 `ClubsController.cs` 中实际绑定的 `CreateClubRequest` 增加 `DataAnnotations` 校验。
- 将 `Category` 从可空字符串改为必填字符串，并与 `Name` 一样限制为 1-255 字符。

## 改动原因

`api/openapi.yaml` 和自动生成模型已声明 `name`、`category` 必填，但控制器使用的是本地手写 `CreateClubRequest`，缺少 `[Required]` / `[StringLength]`，非法请求可能绕过模型校验后触发数据库异常。

---

## 关联 Issue

Closes #35

## 审查关注点

- 控制器实际绑定的请求类型是否已与 API 契约的必填语义一致。
- 现有 `Create` 方法中的业务校验和错误提示是否保持兼容。

## UI 改动

无。

## 测试说明

- RED：修复前静态校验确认 `CreateClubRequest` 缺少 DataAnnotations 标注。
- GREEN：修复后静态校验确认 `CurrentUserId`、`Name`、`Category` 标注存在。
- `dotnet format whitespace --verify-no-changes --include backend/Controllers/ClubsController.cs`：通过。
- Docker `.NET 10` 环境执行 `dotnet build --configuration Release`：通过；仍有既有自动生成模型 nullable 警告。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过（`dotnet build`）
- [ ] 前端代码已构建通过（`pnpm build`）
- [x] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets（请在 PR 描述中注明）
- [ ] 需要修改服务器配置或手动迁移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 加强了俱乐部创建表单的输入校验，必填项缺失时会更早提示错误。
  * 对名称和分类增加了长度限制，避免提交过短或过长的内容。
  * 分类字段现在为必填项，不再接受空值。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->