### PR TITLE
fix(frontend): 修复健康状态检测交互

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -54,6 +54,7 @@ function logout() {
 
 onMounted(() => {
   refreshSession();
+  checkHealth();
   stopSessionListener = onSessionChange(refreshSession);
 });
 
@@ -82,7 +83,14 @@ onUnmounted(() => {
           <el-button link type="danger" @click="logout">退出</el-button>
         </div>
         <div class="health">
-          <el-tag :type="healthOk ? 'success' : 'danger'" size="small" @click="checkHealth">
+          <el-tag
+            :type="healthOk ? 'success' : 'danger'"
+            size="small"
+            role="button"
+            tabindex="0"
+            @click="checkHealth"
+            @keyup.enter="checkHealth"
+          >
             {{ healthOk ? "后端已连接" : "点击检测" }}
           </el-tag>
         </div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from "vue-router";
 import { type AuthResponse, clearSession, onSessionChange, readAuth } from "./authSession";
 
 const healthOk = ref(false);
+const healthChecking = ref(false);
 const route = useRoute();
 const router = useRouter();
 const auth = ref<AuthResponse | null>(null);
@@ -38,11 +39,14 @@ function refreshSession() {
 }
 
 async function checkHealth() {
+  healthChecking.value = true;
   try {
     const res = await fetch("/api/health");
     healthOk.value = res.ok;
   } catch {
     healthOk.value = false;
+  } finally {
+    healthChecking.value = false;
   }
 }
 
@@ -88,10 +92,15 @@ onUnmounted(() => {
             size="small"
             role="button"
             tabindex="0"
+            :aria-label="
+              healthOk ? '后端已连接，回车或空格重新检测' : '点击、回车或空格检测后端健康状态'
+            "
+            :aria-busy="healthChecking"
             @click="checkHealth"
             @keyup.enter="checkHealth"
+            @keyup.space.prevent="checkHealth"
           >
-            {{ healthOk ? "后端已连接" : "点击检测" }}
+            {{ healthChecking ? "检测中..." : healthOk ? "后端已连接" : "点击检测" }}
           </el-tag>
         </div>
       </el-menu>


### PR DESCRIPTION
## 改动内容

- 页面挂载后自动调用健康检查，首屏可主动反映后端连接状态。
- 将健康状态标签补充为可键盘聚焦的按钮语义，并支持 Enter 键重新检测。

## 改动原因

修复 #36 中首屏健康状态不会自动检测的问题，以及 #37 中健康检测入口无法通过键盘触发的无障碍问题。

---

## 关联 Issue

Closes #36
Closes #37

## 审查关注点

- 健康状态检测是否只在页面挂载和用户主动触发时执行。
- Element Plus 标签补充 role/tabindex/keyup 后是否符合当前导航布局。

## UI 改动

| 改动前 | 改动后 |
|--------|--------|
| 首屏显示点击检测，只能鼠标点击触发 | 首屏自动检测，健康标签可通过 Tab 聚焦并按 Enter 触发 |

## 测试说明

- 静态行为检查：确认 onMounted 调用 checkHealth，健康标签包含 role、tabindex、Enter 键处理。
- frontend：prettier --check src/App.vue 通过。
- frontend：vue-tsc -b 通过。
- frontend：vite build 通过；仍有既有 VueUse pure annotation 与 chunk size 警告。

---

### 检查清单

**代码质量**
- [ ] 后端代码已构建通过（本次仅前端 App.vue 改动，未运行）
- [x] 前端代码已构建通过（vite build）
- [x] 已本地手工测试主要场景（静态行为检查覆盖 #36/#37）

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 database/
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets（请在 PR 描述中注明）
- [ ] 需要修改服务器配置或手动迁移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 页面加载后会自动检查后端健康状态，并在检测期间显示“检测中...”，成功/失败状态会相应更新。
* **改进**
  * 健康状态标签交互增强：支持点击、回车键与空格键触发，并增加可访问性属性（如可聚焦与忙碌状态提示）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->