### PR TITLE
fix(deploy): 注入生产登录令牌签名密钥

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,9 +41,14 @@ jobs:
         shell: bash
         env:
           DB_CONNECTION_STRING: ${{ secrets.DB_CONNECTION_STRING }}
+          AUTH_TOKEN_SIGNING_KEY: ${{ secrets.AUTH_TOKEN_SIGNING_KEY }}
         run: |
           if [ -z "${DB_CONNECTION_STRING:-}" ]; then
             echo "::error::缺少 GitHub Secret：DB_CONNECTION_STRING。请先在仓库或目标环境的 Secrets 中配置 Oracle 连接串。"
+            exit 1
+          fi
+          if [ -z "${AUTH_TOKEN_SIGNING_KEY:-}" ]; then
+            echo "::error::缺少 GitHub Secret：AUTH_TOKEN_SIGNING_KEY。请先在仓库或目标环境的 Secrets 中配置生产环境登录令牌签名密钥。"
             exit 1
           fi
 
@@ -117,6 +122,7 @@ jobs:
         uses: appleboy/ssh-action@v1
         env:
           DB_CONNECTION_STRING: ${{ secrets.DB_CONNECTION_STRING }}
+          AUTH_TOKEN_SIGNING_KEY: ${{ secrets.AUTH_TOKEN_SIGNING_KEY }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER: ${{ github.actor }}
         with:
@@ -126,7 +132,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           timeout: 60s
           command_timeout: 20m
-          envs: DB_CONNECTION_STRING,GHCR_TOKEN,GHCR_USER
+          envs: DB_CONNECTION_STRING,AUTH_TOKEN_SIGNING_KEY,GHCR_TOKEN,GHCR_USER
           script: |
             set -e
             cd "${{ secrets.DEPLOY_PATH }}"
@@ -184,6 +190,13 @@ jobs:
                 return 1
               fi
               write_env_var DB_CONNECTION_STRING "$DB_CONNECTION_STRING" || return 1
+
+              echo "=== 写入登录令牌签名密钥 ==="
+              if [ -z "${AUTH_TOKEN_SIGNING_KEY:-}" ]; then
+                echo "!!! AUTH_TOKEN_SIGNING_KEY 为空，请检查 GitHub Secret 配置 !!!"
+                return 1
+              fi
+              write_env_var AUTH_TOKEN_SIGNING_KEY "$AUTH_TOKEN_SIGNING_KEY" || return 1
 
               echo "=== 登录 ghcr.io ==="
               printf "%s" "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin || return 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: http://+:5000
       ConnectionStrings__Default: ${DB_CONNECTION_STRING}
+      Authentication__TokenSigningKey: ${AUTH_TOKEN_SIGNING_KEY}
     expose:
       - "5000"
     networks:


### PR DESCRIPTION
## 概要

修复 main 部署后后端容器启动失败的问题。后端在 Production 环境需要显式配置 Authentication:TokenSigningKey，本 PR 将 GitHub Secret AUTH_TOKEN_SIGNING_KEY 写入服务器 .env，并通过 docker-compose.yml 注入后端容器。

## 改动

- deploy.yml 增加 AUTH_TOKEN_SIGNING_KEY 缺失校验
- 部署脚本将 AUTH_TOKEN_SIGNING_KEY 写入服务器 .env
- docker-compose.yml 将 Authentication__TokenSigningKey 传给 backend

## 验证

- git diff --check -- .github/workflows/deploy.yml docker-compose.yml
- 使用 dummy DB_CONNECTION_STRING 和 AUTH_TOKEN_SIGNING_KEY 执行 docker compose -f docker-compose.yml config

## 合并前注意

请先在 GitHub Secrets 中配置 AUTH_TOKEN_SIGNING_KEY，否则部署会在 Secret 校验阶段明确失败。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 部署流程现在会先检查签名密钥是否已配置，避免因空值导致部署出错或生成不可用的服务。
  * 后端部署与容器配置已补齐认证签名密钥设置，提升线上认证稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->