### PR TITLE
fix(deploy): 同步生产登录令牌签名密钥配置

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,9 +41,14 @@ jobs:
         shell: bash
         env:
           DB_CONNECTION_STRING: ${{ secrets.DB_CONNECTION_STRING }}
+          AUTH_TOKEN_SIGNING_KEY: ${{ secrets.AUTH_TOKEN_SIGNING_KEY }}
         run: |
           if [ -z "${DB_CONNECTION_STRING:-}" ]; then
             echo "::error::缺少 GitHub Secret：DB_CONNECTION_STRING。请先在仓库或目标环境的 Secrets 中配置 Oracle 连接串。"
+            exit 1
+          fi
+          if [ -z "${AUTH_TOKEN_SIGNING_KEY:-}" ]; then
+            echo "::error::缺少 GitHub Secret：AUTH_TOKEN_SIGNING_KEY。请先在仓库或目标环境的 Secrets 中配置生产环境登录令牌签名密钥。"
             exit 1
           fi
 
@@ -117,6 +122,7 @@ jobs:
         uses: appleboy/ssh-action@v1
         env:
           DB_CONNECTION_STRING: ${{ secrets.DB_CONNECTION_STRING }}
+          AUTH_TOKEN_SIGNING_KEY: ${{ secrets.AUTH_TOKEN_SIGNING_KEY }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER: ${{ github.actor }}
         with:
@@ -126,7 +132,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           timeout: 60s
           command_timeout: 20m
-          envs: DB_CONNECTION_STRING,GHCR_TOKEN,GHCR_USER
+          envs: DB_CONNECTION_STRING,AUTH_TOKEN_SIGNING_KEY,GHCR_TOKEN,GHCR_USER
           script: |
             set -e
             cd "${{ secrets.DEPLOY_PATH }}"
@@ -184,6 +190,13 @@ jobs:
                 return 1
               fi
               write_env_var DB_CONNECTION_STRING "$DB_CONNECTION_STRING" || return 1
+
+              echo "=== 写入登录令牌签名密钥 ==="
+              if [ -z "${AUTH_TOKEN_SIGNING_KEY:-}" ]; then
+                echo "!!! AUTH_TOKEN_SIGNING_KEY 为空，请检查 GitHub Secret 配置 !!!"
+                return 1
+              fi
+              write_env_var AUTH_TOKEN_SIGNING_KEY "$AUTH_TOKEN_SIGNING_KEY" || return 1
 
               echo "=== 登录 ghcr.io ==="
               printf "%s" "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin || return 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: http://+:5000
       ConnectionStrings__Default: ${DB_CONNECTION_STRING}
+      Authentication__TokenSigningKey: ${AUTH_TOKEN_SIGNING_KEY}
     expose:
       - "5000"
     networks:


### PR DESCRIPTION
## 概要

将 #101 的部署修复从 dev 同步到 main，解决 main 部署时后端容器因缺少 Authentication:TokenSigningKey 无法启动的问题。

## 包含内容

- 部署 workflow 校验 AUTH_TOKEN_SIGNING_KEY
- 部署脚本将 AUTH_TOKEN_SIGNING_KEY 写入服务器 .env
- docker-compose.yml 将 Authentication__TokenSigningKey 注入后端容器

## 合并前确认

- GitHub Secret AUTH_TOKEN_SIGNING_KEY 已配置
- CI / CodeRabbit 通过

## 备注

本 PR 只同步部署修复，不在本次操作中直接 merge。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 部署前会检查签名密钥是否已配置，避免因空值继续发布并导致服务异常。
  * 远端部署时会同步写入登录令牌签名密钥，确保后端认证配置完整。
  * 容器启动配置新增签名密钥环境变量，提升认证相关功能的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->