### PR TITLE
fix(project): 修复公网项目列表请求地址

### DIFF
--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -12,7 +12,6 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
-// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -12,6 +12,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/apiClient.ts
+++ b/frontend/src/apiClient.ts
@@ -1,0 +1,3 @@
+import { Configuration, DefaultApi } from "./api";
+
+export const apiClient = new DefaultApi(new Configuration({ basePath: "" }));

--- a/frontend/src/views/ProjectList.vue
+++ b/frontend/src/views/ProjectList.vue
@@ -2,8 +2,6 @@
 import { computed, onMounted, onUnmounted, reactive, ref } from "vue";
 import { ElMessage, ElMessageBox, type FormInstance, type FormRules } from "element-plus";
 import {
-  Configuration,
-  DefaultApi,
   ProjectProjectStatusEnum,
   ReviewProjectRequestProjectStatusEnum,
   type CancelProjectRequest,
@@ -11,9 +9,8 @@ import {
   type Project,
   type UserSummary,
 } from "../api";
+import { apiClient as api } from "../apiClient";
 import { onSessionChange, readAuth, type AuthRole } from "../authSession";
-
-const api = new DefaultApi(new Configuration({ basePath: "" }));
 
 const projectReviewPermission = "project:review";
 const projectTaskManagePermission = "project:task:manage";

--- a/frontend/src/views/ProjectList.vue
+++ b/frontend/src/views/ProjectList.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, reactive, ref } from "vue";
 import { ElMessage, ElMessageBox, type FormInstance, type FormRules } from "element-plus";
 import {
+  Configuration,
   DefaultApi,
   ProjectProjectStatusEnum,
   ReviewProjectRequestProjectStatusEnum,
@@ -12,7 +13,7 @@ import {
 } from "../api";
 import { onSessionChange, readAuth, type AuthRole } from "../authSession";
 
-const api = new DefaultApi();
+const api = new DefaultApi(new Configuration({ basePath: "" }));
 
 const projectReviewPermission = "project:review";
 const projectTaskManagePermission = "project:task:manage";


### PR DESCRIPTION
﻿## 改动内容

- 修复项目管理页在公网环境下使用生成 API 客户端时请求 `localhost:5000` 的问题。
- 将项目页 `DefaultApi` 初始化改为同源 `basePath: ""`，与其他前端页面通过 `/api` 访问后端的设计保持一致。
- 保持项目管理页面现有布局、交互和 Element Plus 组件设计不变。

## 改动原因

公网访问时，手机或其他设备中的 `localhost` 指向访问者本机，导致项目列表请求失败并显示通用拦截器错误。本次修复让项目页请求公网同源 `/api/projects`，避免部署环境访问失败。

---

## 关联 Issue

Closes #104

- 对应 Issue：#104
- 课程功能点（如有）：无
- 覆盖的业务规则（如有）：项目列表应在公网部署环境正常加载；前端请求路径应与其他模块保持一致。

## 审查关注点

- 项目页生成 API 客户端是否正确走同源 `/api`。
- 是否保持现有前端设计风格和交互逻辑不变。
- 是否避免修改自动生成的 `frontend/src/api/runtime.ts`。

## UI 改动

| 改动前 | 改动后 |
|--------|--------|
| 公网设备访问项目页时请求本机 `localhost:5000` 并报错 | 公网设备访问项目页时请求同源 `/api` |

## 测试说明

- `git diff --check`
- `pnpm --dir frontend run format:ci`
- `pnpm --dir frontend run build`
- 检查生产构建包中项目页使用同源 `basePath`，并保留 `/api/projects` 路径。

---

### 检查清单

**代码质量**
- [ ] 后端代码已构建通过（`dotnet build`）
- [x] 前端代码已构建通过（`pnpm build`）
- [x] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets（请在 PR 描述中注明）
- [ ] 需要修改服务器配置或手动迁移


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 调整项目列表页面的接口调用方式，改为统一使用新的全局 API 客户端，并显式设置请求基础地址，提升接口调用的稳定性。
* **Chores**
  * 新增对外封装的 API 客户端模块，用于集中管理默认 API 实例。
  * 在活动注册结果模型中补充了重复的类型检查跳过注释。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->