### PR TITLE
fix(frontend): 隐藏业务页面内部编号

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3762,6 +3762,13 @@ components:
           type: integer
         userId:
           type: integer
+        userName:
+          type: string
+          description: 参与者姓名；姓名为空时回退为用户名。
+        studentNo:
+          type: string
+          nullable: true
+          description: 参与者学号或工号。
         registerStatus:
           type: string
           nullable: true
@@ -3787,6 +3794,7 @@ components:
         - id
         - activityId
         - userId
+        - userName
 
     Venue:
       type: object

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -507,21 +507,24 @@ public class ActivitiesController : ControllerBase
         var activityExists = await _db.Activities.AnyAsync(a => a.ActivityId == activityId);
         if (!activityExists) return NotFound();
 
-        var participations = await _db.ActivityParticipations
-            .Where(p => p.ActivityId == activityId)
-            .OrderBy(p => p.ParticipationId)
-            .Select(p => new ActivityParticipationDto(
-                p.ParticipationId,
-                p.ActivityId,
-                p.UserId,
-                p.RegisterStatus,
-                p.RegisteredAt,
-                p.CheckinAt,
-                p.CheckoutAt,
-                p.SignStatus,
-                p.Remark
-            ))
-            .ToListAsync();
+        var participations = await (
+            from participation in _db.ActivityParticipations
+            join user in _db.Users on participation.UserId equals user.UserId
+            where participation.ActivityId == activityId
+            orderby participation.ParticipationId
+            select new ActivityParticipationDto(
+                participation.ParticipationId,
+                participation.ActivityId,
+                participation.UserId,
+                string.IsNullOrWhiteSpace(user.RealName) ? user.Username : user.RealName,
+                user.StudentNo,
+                participation.RegisterStatus,
+                participation.RegisteredAt,
+                participation.CheckinAt,
+                participation.CheckoutAt,
+                participation.SignStatus,
+                participation.Remark
+            )).ToListAsync();
 
         return Ok(participations);
     }
@@ -556,7 +559,15 @@ public class ActivitiesController : ControllerBase
             return BadRequest(new { message = "只有已发布或进行中的活动可以签到或签退。" });
         }
 
-        if (!await UserExists(req.UserId))
+        var participantUser = await _db.Users
+            .Where(user => user.UserId == req.UserId)
+            .Select(user => new
+            {
+                UserName = string.IsNullOrWhiteSpace(user.RealName) ? user.Username : user.RealName,
+                user.StudentNo
+            })
+            .FirstOrDefaultAsync();
+        if (participantUser is null)
         {
             return BadRequest(new { message = "用户不存在，不能签到或签退。" });
         }
@@ -629,6 +640,8 @@ public class ActivitiesController : ControllerBase
             participation.ParticipationId,
             participation.ActivityId,
             participation.UserId,
+            participantUser.UserName,
+            participantUser.StudentNo,
             participation.RegisterStatus,
             participation.RegisteredAt,
             participation.CheckinAt,
@@ -840,6 +853,8 @@ public record ActivityParticipationDto(
     int Id,
     int ActivityId,
     int UserId,
+    string UserName,
+    string? StudentNo,
     string? RegisterStatus,
     DateTime? RegisteredAt,
     DateTime? CheckinAt,

--- a/backend/Models/ActivityParticipation.cs
+++ b/backend/Models/ActivityParticipation.cs
@@ -47,6 +47,21 @@ namespace Org.OpenAPITools.Models
         public int UserId { get; set; }
 
         /// <summary>
+        /// 参与者姓名；姓名为空时回退为用户名。
+        /// </summary>
+        /// <value>参与者姓名；姓名为空时回退为用户名。</value>
+        [Required]
+        [DataMember(Name="userName", EmitDefaultValue=false)]
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// 参与者学号或工号。
+        /// </summary>
+        /// <value>参与者学号或工号。</value>
+        [DataMember(Name="studentNo", EmitDefaultValue=true)]
+        public string? StudentNo { get; set; }
+
+        /// <summary>
         /// Gets or Sets RegisterStatus
         /// </summary>
         [DataMember(Name="registerStatus", EmitDefaultValue=true)]

--- a/frontend/src/api/models/ActivityParticipation.ts
+++ b/frontend/src/api/models/ActivityParticipation.ts
@@ -39,6 +39,18 @@ export interface ActivityParticipation {
    */
   userId: number;
   /**
+   * 参与者姓名；姓名为空时回退为用户名。
+   * @type {string}
+   * @memberof ActivityParticipation
+   */
+  userName: string;
+  /**
+   * 参与者学号或工号。
+   * @type {string}
+   * @memberof ActivityParticipation
+   */
+  studentNo?: string | null;
+  /**
    *
    * @type {string}
    * @memberof ActivityParticipation
@@ -83,6 +95,7 @@ export function instanceOfActivityParticipation(value: object): value is Activit
   if (!("id" in value) || value["id"] === undefined) return false;
   if (!("activityId" in value) || value["activityId"] === undefined) return false;
   if (!("userId" in value) || value["userId"] === undefined) return false;
+  if (!("userName" in value) || value["userName"] === undefined) return false;
   return true;
 }
 
@@ -101,6 +114,8 @@ export function ActivityParticipationFromJSONTyped(
     id: json["id"],
     activityId: json["activityId"],
     userId: json["userId"],
+    userName: json["userName"],
+    studentNo: json["studentNo"] == null ? undefined : json["studentNo"],
     registerStatus: json["registerStatus"] == null ? undefined : json["registerStatus"],
     registeredAt: json["registeredAt"] == null ? undefined : new Date(json["registeredAt"]),
     checkinAt: json["checkinAt"] == null ? undefined : new Date(json["checkinAt"]),
@@ -126,6 +141,8 @@ export function ActivityParticipationToJSONTyped(
     id: value["id"],
     activityId: value["activityId"],
     userId: value["userId"],
+    userName: value["userName"],
+    studentNo: value["studentNo"],
     registerStatus: value["registerStatus"],
     registeredAt:
       value["registeredAt"] == null ? value["registeredAt"] : value["registeredAt"].toISOString(),

--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -13,6 +13,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -38,12 +38,19 @@ interface Activity {
 interface ActivityParticipation {
   id: number;
   userId: number;
+  userName: string;
+  studentNo: string | null;
   registerStatus: string | null;
   registeredAt: string | null;
   checkinAt: string | null;
   checkoutAt: string | null;
   signStatus: string | null;
   remark: string | null;
+}
+
+interface ClubOption {
+  id: number;
+  name: string;
 }
 
 interface CreateActivityForm {
@@ -77,6 +84,7 @@ interface BudgetReviewForm {
 }
 
 const activities = ref<Activity[]>([]);
+const clubOptions = ref<ClubOption[]>([]);
 const auth = ref(readAuth());
 const statusFilter = ref("all");
 const loading = ref(true);
@@ -101,11 +109,11 @@ const currentUserId = computed(() => auth.value?.user.id ?? null);
 const currentUserDisplay = computed(() => {
   const user = auth.value?.user;
   if (!user) return "未登录";
-  return user.realName || user.username || `用户 #${user.id}`;
+  return user.realName || user.username || "未知用户";
 });
 
 const createForm = ref<CreateActivityForm>({
-  clubId: 1,
+  clubId: 0,
   creatorUserId: null,
   title: "",
   activityType: "",
@@ -203,9 +211,9 @@ const SIGN_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 onMounted(async () => {
   stopSessionListener = onSessionChange(() => {
     auth.value = readAuth();
-    void loadActivities();
+    void Promise.all([loadActivities(), loadClubOptions()]);
   });
-  await loadActivities();
+  await Promise.all([loadActivities(), loadClubOptions()]);
 });
 
 onUnmounted(() => {
@@ -324,6 +332,21 @@ async function loadActivities() {
   }
 }
 
+async function loadClubOptions() {
+  const userId = currentUserId.value;
+  if (!userId) {
+    clubOptions.value = [];
+    return;
+  }
+
+  try {
+    clubOptions.value = await requestJson<ClubOption[]>(`/api/clubs?viewerUserId=${userId}`);
+  } catch (e) {
+    clubOptions.value = [];
+    ElMessage.error(e instanceof Error ? e.message : "社团列表加载失败");
+  }
+}
+
 function canRegister(activity: Activity) {
   const deadlinePassed =
     activity.registrationDeadline != null &&
@@ -346,8 +369,8 @@ function registerButtonText(activity: Activity) {
 function openCreate() {
   const defaults = buildDefaultCreateTimes();
   createForm.value = {
-    clubId: 1,
-    creatorUserId: null,
+    clubId: clubOptions.value[0]?.id ?? 0,
+    creatorUserId: currentUserId.value,
     title: "",
     activityType: "",
     description: "",
@@ -361,8 +384,13 @@ function openCreate() {
 }
 
 async function createActivity() {
-  if (!createForm.value.title || !createForm.value.startTime || !createForm.value.endTime) {
-    error.value = "请填写活动标题、开始时间和结束时间。";
+  if (
+    !createForm.value.clubId ||
+    !createForm.value.title ||
+    !createForm.value.startTime ||
+    !createForm.value.endTime
+  ) {
+    error.value = "请选择主办社团，并填写活动标题、开始时间和结束时间。";
     ElMessage.error(error.value);
     return;
   }
@@ -374,7 +402,7 @@ async function createActivity() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         clubId: createForm.value.clubId,
-        creatorUserId: createForm.value.creatorUserId,
+        creatorUserId: currentUserId.value,
         title: createForm.value.title,
         activityType: emptyToNull(createForm.value.activityType),
         description: emptyToNull(createForm.value.description),
@@ -425,24 +453,32 @@ async function registerActivity(activity: Activity) {
 }
 
 function openReview(activity: Activity) {
+  if (!currentUserId.value) {
+    ElMessage.warning("请先登录后再审核活动");
+    return;
+  }
+
   currentActivity.value = activity;
   reviewForm.value = {
     approved: true,
-    reviewerUserId: null,
+    reviewerUserId: currentUserId.value,
     comment: "",
   };
   reviewDialogVisible.value = true;
 }
 
 async function reviewActivity() {
-  if (!currentActivity.value) return;
+  if (!currentActivity.value || !currentUserId.value) return;
 
   saving.value = true;
   try {
     const res = await fetch(`/api/activities/${currentActivity.value.id}/review`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(reviewForm.value),
+      body: JSON.stringify({
+        ...reviewForm.value,
+        reviewerUserId: currentUserId.value,
+      }),
     });
     if (!res.ok) throw new Error(await res.text());
     reviewDialogVisible.value = false;
@@ -719,7 +755,6 @@ async function readErrorMessage(res: Response) {
       empty-text="暂无活动数据"
       class="activity-table"
     >
-      <el-table-column prop="id" label="ID" width="60" />
       <el-table-column prop="title" label="标题" min-width="180" show-overflow-tooltip />
       <el-table-column prop="clubName" label="主办社团" width="120" />
       <el-table-column label="时间" min-width="260">
@@ -812,11 +847,18 @@ async function readErrorMessage(res: Response) {
 
     <el-dialog v-model="createDialogVisible" title="创建活动" width="620px">
       <el-form label-position="top">
-        <el-form-item label="社团 ID" required>
-          <el-input-number v-model="createForm.clubId" :min="1" />
+        <el-form-item label="主办社团" required>
+          <el-select v-model="createForm.clubId" filterable placeholder="请选择主办社团">
+            <el-option
+              v-for="club in clubOptions"
+              :key="club.id"
+              :label="club.name"
+              :value="club.id"
+            />
+          </el-select>
         </el-form-item>
-        <el-form-item label="创建人用户 ID（可留空）">
-          <el-input-number v-model="createForm.creatorUserId" :min="1" placeholder="可留空" />
+        <el-form-item label="创建人">
+          <span class="readonly-user">{{ currentUserDisplay }}</span>
         </el-form-item>
         <el-form-item label="活动标题" required>
           <el-input v-model="createForm.title" placeholder="请输入活动标题" />
@@ -899,8 +941,8 @@ async function readErrorMessage(res: Response) {
             <el-radio :value="false">驳回</el-radio>
           </el-radio-group>
         </el-form-item>
-        <el-form-item label="审核人用户 ID（可留空）">
-          <el-input-number v-model="reviewForm.reviewerUserId" :min="1" placeholder="可留空" />
+        <el-form-item label="审核人">
+          <span class="readonly-user">{{ currentUserDisplay }}</span>
         </el-form-item>
         <el-form-item label="审核意见">
           <el-input
@@ -1108,8 +1150,12 @@ async function readErrorMessage(res: Response) {
         stripe
         empty-text="暂无参与记录"
       >
-        <el-table-column prop="id" label="ID" width="70" />
-        <el-table-column prop="userId" label="用户 ID" width="90" />
+        <el-table-column label="参与者" min-width="150">
+          <template #default="{ row }">
+            <div>{{ row.userName || "未知用户" }}</div>
+            <div v-if="row.studentNo" class="participant-secondary">{{ row.studentNo }}</div>
+          </template>
+        </el-table-column>
         <el-table-column label="状态" width="100">
           <template #default="{ row }">
             {{ signStatusLabel[row.signStatus] || row.signStatus || "-" }}
@@ -1170,6 +1216,11 @@ async function readErrorMessage(res: Response) {
 .readonly-user {
   color: var(--el-text-color-primary);
   font-weight: 500;
+}
+.participant-secondary {
+  margin-top: 2px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
 }
 .quota-text {
   font-variant-numeric: tabular-nums;

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -109,7 +109,7 @@ const currentUserId = computed(() => auth.value?.user.id ?? null);
 const currentUserDisplay = computed(() => {
   const user = auth.value?.user;
   if (!user) return "未登录";
-  return user.realName || user.username || "未知用户";
+  return user.realName?.trim() || user.username?.trim() || "未知用户";
 });
 
 const createForm = ref<CreateActivityForm>({

--- a/frontend/src/views/ProjectList.vue
+++ b/frontend/src/views/ProjectList.vue
@@ -546,7 +546,7 @@ function normalizeRoleText(value?: string | null) {
 }
 
 function leaderCandidateLabel(user: UserSummary) {
-  const name = user.realName || user.username || `用户 ${user.id}`;
+  const name = user.realName || user.username || "未知用户";
   const identity = user.studentNo || user.username;
   return identity ? `${name}（${identity}）` : name;
 }
@@ -555,7 +555,7 @@ function leaderDisplayName(leaderUserId?: number | null) {
   if (!leaderUserId) return "未分配";
 
   const user = leaderUserMap.value.get(leaderUserId);
-  return user ? leaderCandidateLabel(user) : `用户 ${leaderUserId}`;
+  return user ? leaderCandidateLabel(user) : "未知负责人";
 }
 
 function formatDate(value?: Date | null) {
@@ -623,11 +623,10 @@ onUnmounted(() => {
     </el-card>
 
     <el-table v-loading="loading" :data="projects" stripe empty-text="暂无项目数据">
-      <el-table-column prop="id" label="ID" width="70" />
       <el-table-column prop="projectName" label="项目名称" min-width="180" show-overflow-tooltip />
       <el-table-column label="所属社团" min-width="140">
         <template #default="{ row }">
-          {{ clubNameMap.get(row.clubId) || `社团 ${row.clubId}` }}
+          {{ clubNameMap.get(row.clubId) || "未知社团" }}
         </template>
       </el-table-column>
       <el-table-column label="负责人" min-width="150" show-overflow-tooltip>

--- a/frontend/src/views/VenueManage.vue
+++ b/frontend/src/views/VenueManage.vue
@@ -54,11 +54,20 @@ interface VenueForm {
   building: string;
   roomNo: string;
   capacity: number;
-  managerUserId: string;
+  managerUserId?: number;
   status: "available" | "maintenance" | "disabled";
 }
 
+interface UserOption {
+  id: number;
+  displayName: string;
+  realName?: string | null;
+  username?: string | null;
+  studentNo?: string | null;
+}
+
 const venues = ref<Venue[]>([]);
+const managerOptions = ref<UserOption[]>([]);
 const loading = ref(false);
 const saving = ref(false);
 const statusChangingId = ref<number>();
@@ -77,7 +86,7 @@ const form = reactive<VenueForm>({
   building: "",
   roomNo: "",
   capacity: 1,
-  managerUserId: "",
+  managerUserId: undefined,
   status: "available",
 });
 
@@ -133,7 +142,6 @@ const rules: FormRules<VenueForm> = {
   building: [{ max: 255, message: "楼栋最多 255 个字符", trigger: "blur" }],
   roomNo: [{ max: 255, message: "房间号最多 255 个字符", trigger: "blur" }],
   capacity: [{ required: true, message: "请输入容量", trigger: "change" }],
-  managerUserId: [{ validator: validateOptionalUserId, trigger: "blur" }],
   status: [{ required: true, message: "请选择状态", trigger: "change" }],
 };
 
@@ -160,16 +168,6 @@ function hasPermission(permission: string) {
   return permissions.value.includes(permission) || permissions.value.includes("*");
 }
 
-function validateOptionalUserId(_rule: unknown, value: string, callback: (error?: Error) => void) {
-  const normalized = value.trim();
-  if (!normalized || /^[1-9]\d*$/.test(normalized)) {
-    callback();
-    return;
-  }
-
-  callback(new Error("负责人 ID 必须为正整数"));
-}
-
 async function readErrorMessage(res: Response) {
   try {
     const payload = (await res.json()) as ApiErrorPayload;
@@ -193,6 +191,33 @@ async function loadVenues() {
   }
 }
 
+async function loadManagerOptions() {
+  const user = auth.value?.user;
+  if (!user) {
+    managerOptions.value = [];
+    return;
+  }
+
+  const currentUserOption: UserOption = {
+    id: user.id,
+    displayName: user.realName || user.username || "当前用户",
+    realName: user.realName,
+    username: user.username,
+    studentNo: user.studentNo,
+  };
+
+  try {
+    const res = await fetch(`/api/users?viewerUserId=${user.id}`);
+    if (!res.ok) throw new Error(await readErrorMessage(res));
+    const users = (await res.json()) as UserOption[];
+    managerOptions.value = users.some((option) => option.id === user.id)
+      ? users
+      : [currentUserOption, ...users];
+  } catch {
+    managerOptions.value = [currentUserOption];
+  }
+}
+
 function openCreate() {
   editingVenue.value = null;
   resetForm();
@@ -205,7 +230,8 @@ function openEdit(venue: Venue) {
   form.building = venue.building ?? "";
   form.roomNo = venue.roomNo ?? "";
   form.capacity = venue.capacity || 1;
-  form.managerUserId = venue.managerUserId ? String(venue.managerUserId) : "";
+  ensureManagerOption(venue.managerUserId);
+  form.managerUserId = venue.managerUserId ?? undefined;
   form.status = normalizeStatus(venue.status);
   dialogVisible.value = true;
 }
@@ -480,7 +506,7 @@ function venuePayload() {
     building: optionalText(form.building),
     roomNo: optionalText(form.roomNo),
     capacity: form.capacity,
-    managerUserId: optionalNumber(form.managerUserId),
+    managerUserId: form.managerUserId ?? null,
   };
 }
 
@@ -489,16 +515,34 @@ function resetForm() {
   form.building = "";
   form.roomNo = "";
   form.capacity = 1;
-  form.managerUserId = "";
+  form.managerUserId = operatorUserId.value;
   form.status = "available";
 }
 
 function createVenueIndex(venue: Venue) {
   const location = formatVenueLocation(venue.building, venue.roomNo);
   return createVenueSearchIndex({
-    ids: [venue.id],
     texts: [venue.name, venue.building, venue.roomNo, location],
   });
+}
+
+function ensureManagerOption(managerUserId?: number | null) {
+  if (!managerUserId || managerOptions.value.some((user) => user.id === managerUserId)) return;
+  managerOptions.value.push({
+    id: managerUserId,
+    displayName: "当前负责人（姓名未加载）",
+  });
+}
+
+function managerOptionLabel(user: UserOption) {
+  const name = user.displayName || user.realName || user.username || "未知用户";
+  return user.studentNo ? `${name}（${user.studentNo}）` : name;
+}
+
+function managerDisplayName(managerUserId?: number | null) {
+  if (!managerUserId) return "未指定";
+  const user = managerOptions.value.find((option) => option.id === managerUserId);
+  return user ? managerOptionLabel(user) : "未知负责人";
 }
 
 function formatLocation(venue: Venue) {
@@ -529,12 +573,7 @@ function optionalText(value: string) {
   return normalized ? normalized : null;
 }
 
-function optionalNumber(value: string) {
-  const normalized = value.trim();
-  return normalized ? Number(normalized) : null;
-}
-
-onMounted(loadVenues);
+onMounted(() => Promise.all([loadVenues(), loadManagerOptions()]));
 </script>
 
 <template>
@@ -563,14 +602,13 @@ onMounted(loadVenues);
       <el-input
         v-model="venueSearch"
         clearable
-        placeholder="搜索 ID、场地名称或位置"
+        placeholder="搜索场地名称或位置"
         class="search-input"
       />
       <span class="search-summary">{{ searchSummary }}</span>
     </div>
 
     <el-table v-loading="loading" :data="filteredVenues" stripe :empty-text="tableEmptyText">
-      <el-table-column prop="id" label="ID" width="70" />
       <el-table-column prop="name" label="场地名称" min-width="160" />
       <el-table-column label="位置" min-width="180">
         <template #default="{ row }">{{ formatLocation(row) }}</template>
@@ -586,7 +624,9 @@ onMounted(loadVenues);
           </div>
         </template>
       </el-table-column>
-      <el-table-column prop="managerUserId" label="负责人 ID" width="110" />
+      <el-table-column label="负责人" min-width="150">
+        <template #default="{ row }">{{ managerDisplayName(row.managerUserId) }}</template>
+      </el-table-column>
       <el-table-column label="操作" width="320" fixed="right">
         <template #default="{ row }">
           <div class="row-actions">
@@ -656,8 +696,21 @@ onMounted(loadVenues);
               class="full-width"
             />
           </el-form-item>
-          <el-form-item label="负责人用户 ID" prop="managerUserId">
-            <el-input v-model="form.managerUserId" placeholder="可选" />
+          <el-form-item label="负责人" prop="managerUserId">
+            <el-select
+              v-model="form.managerUserId"
+              clearable
+              filterable
+              placeholder="请选择负责人"
+              class="full-width"
+            >
+              <el-option
+                v-for="user in managerOptions"
+                :key="user.id"
+                :label="managerOptionLabel(user)"
+                :value="user.id"
+              />
+            </el-select>
           </el-form-item>
         </div>
         <el-form-item label="状态" prop="status">
@@ -720,7 +773,6 @@ onMounted(loadVenues);
         class="notice"
       />
       <el-table :data="statusConflictReservations" stripe>
-        <el-table-column prop="id" label="ID" width="70" />
         <el-table-column label="预约时间" min-width="220">
           <template #default="{ row }">
             <div>{{ formatVenueReservationDateTime(row.startTime) }}</div>
@@ -729,7 +781,7 @@ onMounted(loadVenues);
         </el-table-column>
         <el-table-column label="申请人" min-width="130">
           <template #default="{ row }">
-            {{ row.applicantName || `用户 ${row.applicantUserId}` }}
+            {{ row.applicantName || "未知用户" }}
           </template>
         </el-table-column>
         <el-table-column label="状态" width="100">

--- a/frontend/src/views/VenueReservationApply.vue
+++ b/frontend/src/views/VenueReservationApply.vue
@@ -841,7 +841,7 @@ onMounted(refreshVenueData);
             class="full-width"
           >
             <el-option
-              v-for="club in clubs.filter(c => reserveClubIds.includes(c.id))"
+              v-for="club in clubs.filter((c) => reserveClubIds.includes(c.id))"
               :key="club.id"
               :label="club.name"
               :value="club.id"

--- a/frontend/src/views/VenueReservationApply.vue
+++ b/frontend/src/views/VenueReservationApply.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from "vue";
+import { computed, onMounted, reactive, ref, watch } from "vue";
 import { ElMessage, ElMessageBox, type FormInstance, type FormRules } from "element-plus";
 import { readAuth } from "../authSession";
 import { requestJson } from "../composables/useApiRequest";
@@ -76,7 +76,23 @@ interface ReservationForm {
   purpose: string;
 }
 
+interface ClubOption {
+  id: number;
+  name: string;
+}
+
+interface ActivityOption {
+  id: number;
+  title: string;
+  clubId: number;
+  clubName: string;
+  startTime?: string | null;
+  status?: string | null;
+}
+
 const venues = ref<Venue[]>([]);
+const clubs = ref<ClubOption[]>([]);
+const activities = ref<ActivityOption[]>([]);
 const loading = ref(false);
 const error = ref("");
 const dialogVisible = ref(false);
@@ -121,6 +137,9 @@ const form = reactive<ReservationForm>({
 });
 
 const selectedVenue = computed(() => venues.value.find((venue) => venue.id === form.venueId));
+const selectableActivities = computed(() =>
+  activities.value.filter((activity) => activity.clubId === form.clubId),
+);
 const selectedVenueApprovedSlots = computed(() => {
   if (!approvedSlotsVenue.value) return [];
   return approvedReservationsForVenue(approvedSlotsVenue.value.id);
@@ -214,7 +233,7 @@ const reservationStatusType: Record<string, "success" | "warning" | "info" | "da
 };
 
 const rules: FormRules<ReservationForm> = {
-  clubId: [{ required: true, message: "请输入申请社团 ID", trigger: "blur" }],
+  clubId: [{ required: true, message: "请选择申请社团", trigger: "change" }],
   startTime: [
     { required: true, message: "请选择开始时间", trigger: "change" },
     {
@@ -299,6 +318,30 @@ async function loadVenues() {
   }
 }
 
+async function loadReservationOptions() {
+  const userId = auth.value?.user.id;
+  if (!userId) {
+    clubs.value = [];
+    activities.value = [];
+    return;
+  }
+
+  try {
+    const [clubRes, activityRes] = await Promise.all([
+      fetch(`/api/clubs?viewerUserId=${userId}`),
+      fetch(`/api/activities?currentUserId=${userId}`),
+    ]);
+    if (!clubRes.ok) throw new Error(await readErrorMessage(clubRes));
+    if (!activityRes.ok) throw new Error(await readErrorMessage(activityRes));
+    clubs.value = await clubRes.json();
+    activities.value = await activityRes.json();
+  } catch (e) {
+    clubs.value = [];
+    activities.value = [];
+    ElMessage.error(e instanceof Error ? e.message : "预约选项加载失败");
+  }
+}
+
 async function loadApprovedReservations() {
   try {
     const slots = await requestJson<VenueOccupiedSlotPayload[]>(
@@ -339,13 +382,13 @@ async function loadMyReservations() {
 }
 
 async function refreshVenueData() {
-  await Promise.all([loadVenues(), loadApprovedReservations()]);
+  await Promise.all([loadVenues(), loadApprovedReservations(), loadReservationOptions()]);
 }
 
 function openReservation(venue: Venue) {
   latestReservation.value = null;
   form.venueId = venue.id;
-  form.clubId = firstClubId.value;
+  form.clubId = clubs.value[0]?.id ?? firstClubId.value;
   form.activityId = undefined;
   form.startTime = "";
   form.endTime = "";
@@ -421,7 +464,7 @@ async function deleteReservation(reservation: VenueReservation) {
 
   try {
     await ElMessageBox.confirm(
-      `确定删除预约 #${reservation.id} 吗？删除后不可恢复。`,
+      `确定删除「${reservation.venueName}」在 ${formatDateTime(reservation.startTime)} 的预约吗？删除后不可恢复。`,
       "确认删除预约",
       {
         confirmButtonText: "确定删除",
@@ -463,7 +506,6 @@ function formatLocation(venue: Venue) {
 function createVenueIndex(venue: Venue) {
   const location = formatVenueLocation(venue.building, venue.roomNo);
   return createVenueSearchIndex({
-    ids: [venue.id],
     texts: [venue.name, venue.building, venue.roomNo, location],
   });
 }
@@ -473,9 +515,13 @@ function createApprovedSlotIndex(slot: VenueReservation) {
   const location = venue ? formatVenueLocation(venue.building, venue.roomNo) : "";
 
   return createVenueSearchIndex({
-    ids: [slot.id, slot.venueId],
     texts: [slot.venueName, venue?.name, venue?.building, venue?.roomNo, location],
   });
+}
+
+function activityOptionLabel(activity: ActivityOption) {
+  const time = activity.startTime ? ` · ${formatDateTime(activity.startTime)}` : "";
+  return `${activity.title}（${activity.clubName || "未知社团"}${time}）`;
 }
 
 function formatDateTime(value: string) {
@@ -640,6 +686,15 @@ function myReservationRowClass({ row }: { row: VenueReservation }) {
   return isExpiredReservation(row) ? "expired-reservation-row" : "";
 }
 
+watch(
+  () => form.clubId,
+  () => {
+    if (!selectableActivities.value.some((activity) => activity.id === form.activityId)) {
+      form.activityId = undefined;
+    }
+  },
+);
+
 onMounted(refreshVenueData);
 </script>
 
@@ -711,14 +766,13 @@ onMounted(refreshVenueData);
       <el-input
         v-model="venueSearch"
         clearable
-        placeholder="搜索 ID、场地名称或位置"
+        placeholder="搜索场地名称或位置"
         class="search-input"
       />
       <span class="search-summary">{{ venueSearchSummary }}</span>
     </div>
 
     <el-table v-loading="loading" :data="filteredVenues" stripe :empty-text="venueTableEmptyText">
-      <el-table-column prop="id" label="ID" width="70" />
       <el-table-column prop="name" label="场地名称" min-width="160" />
       <el-table-column label="位置" min-width="180">
         <template #default="{ row }">
@@ -736,7 +790,6 @@ onMounted(refreshVenueData);
           </div>
         </template>
       </el-table-column>
-      <el-table-column prop="managerUserId" label="管理员 ID" width="110" />
       <el-table-column label="操作" width="210" fixed="right">
         <template #default="{ row }">
           <div class="row-actions">
@@ -783,21 +836,34 @@ onMounted(refreshVenueData);
           <el-select
             v-if="reserveClubIds.length > 0"
             v-model="form.clubId"
+            filterable
             placeholder="选择有预约权限的社团"
             class="full-width"
           >
             <el-option
-              v-for="clubId in reserveClubIds"
-              :key="clubId"
-              :label="`社团 ${clubId}`"
-              :value="clubId"
+              v-for="club in clubs.filter(c => reserveClubIds.includes(c.id))"
+              :key="club.id"
+              :label="club.name"
+              :value="club.id"
             />
           </el-select>
-          <el-input-number v-else v-model="form.clubId" :min="1" :controls="false" />
           <span v-if="firstClubId" class="field-hint">仅显示当前角色有权预约的社团。</span>
         </el-form-item>
-        <el-form-item label="关联活动 ID（可选）" prop="activityId">
-          <el-input-number v-model="form.activityId" :min="1" :controls="false" />
+        <el-form-item label="关联活动（可选）" prop="activityId">
+          <el-select
+            v-model="form.activityId"
+            clearable
+            filterable
+            placeholder="请选择本社团活动"
+            class="full-width"
+          >
+            <el-option
+              v-for="activity in selectableActivities"
+              :key="activity.id"
+              :label="activityOptionLabel(activity)"
+              :value="activity.id"
+            />
+          </el-select>
         </el-form-item>
         <el-form-item label="开始时间" prop="startTime">
           <el-date-picker
@@ -854,7 +920,7 @@ onMounted(refreshVenueData);
         <el-input
           v-model="approvedSlotSearch"
           clearable
-          placeholder="搜索预约 ID、场地名称或位置"
+          placeholder="搜索场地名称或位置"
           class="search-input"
         />
         <span class="search-summary">{{ approvedSlotSearchSummary }}</span>
@@ -928,11 +994,10 @@ onMounted(refreshVenueData);
         :empty-text="myReservationEmptyText"
         :row-class-name="myReservationRowClass"
       >
-        <el-table-column prop="id" label="ID" width="70" />
         <el-table-column label="场地/社团" min-width="180">
           <template #default="{ row }">
             <div class="primary-text">{{ row.venueName }}</div>
-            <div class="muted">{{ row.clubName || `社团 ${row.clubId ?? "-"}` }}</div>
+            <div class="muted">{{ row.clubName || "未知社团" }}</div>
           </template>
         </el-table-column>
         <el-table-column label="预约时间" min-width="220">

--- a/frontend/src/views/VenueReservationReview.vue
+++ b/frontend/src/views/VenueReservationReview.vue
@@ -364,18 +364,17 @@ function approveDisabledReason(reservation: VenueReservation) {
   return canApprove(reservation) ? "" : "开始时间必须晚于当前时间";
 }
 
-function createVenueIndex(venueId: number, venueName: string, extraIds: number[] = []) {
+function createVenueIndex(venueId: number, venueName: string) {
   const venue = venueLookup.value.get(venueId);
   const location = venue ? formatVenueLocation(venue.building, venue.roomNo) : "";
 
   return createVenueSearchIndex({
-    ids: [venueId, ...extraIds],
     texts: [venueName, venue?.name, venue?.building, venue?.roomNo, location],
   });
 }
 
 function createReservationIndex(reservation: VenueReservation) {
-  return createVenueIndex(reservation.venueId, reservation.venueName, [reservation.id]);
+  return createVenueIndex(reservation.venueId, reservation.venueName);
 }
 
 function venueLocationText(venueId: number) {
@@ -457,7 +456,7 @@ watch(filteredVenueGroups, syncSelectedVenue);
         <el-input
           v-model="venueSearch"
           clearable
-          placeholder="搜索 ID、场地名称或位置"
+          placeholder="搜索场地名称或位置"
           class="panel-search"
         />
       </div>
@@ -472,7 +471,6 @@ watch(filteredVenueGroups, syncSelectedVenue);
         <el-table-column label="场地" min-width="220">
           <template #default="{ row }">
             <div class="primary-text">{{ row.venueName }}</div>
-            <div class="muted">ID {{ row.venueId }}</div>
           </template>
         </el-table-column>
         <el-table-column label="位置" min-width="180">
@@ -498,7 +496,7 @@ watch(filteredVenueGroups, syncSelectedVenue);
         <el-input
           v-model="selectedReservationSearch"
           clearable
-          placeholder="搜索预约 ID、场地名称或位置"
+          placeholder="搜索场地名称或位置"
           class="panel-search"
         />
       </div>
@@ -508,11 +506,10 @@ watch(filteredVenueGroups, syncSelectedVenue);
         stripe
         :empty-text="selectedReservationEmptyText"
       >
-        <el-table-column prop="id" label="ID" width="70" />
         <el-table-column label="申请人/社团" min-width="180">
           <template #default="{ row }">
-            <div class="primary-text">{{ row.applicantName || `用户 ${row.applicantUserId}` }}</div>
-            <div class="muted">{{ row.clubName || `社团 ${row.clubId}` }}</div>
+            <div class="primary-text">{{ row.applicantName || "未知用户" }}</div>
+            <div class="muted">{{ row.clubName || "未知社团" }}</div>
           </template>
         </el-table-column>
         <el-table-column label="预约时间" min-width="220">
@@ -564,10 +561,10 @@ watch(filteredVenueGroups, syncSelectedVenue);
       <el-descriptions v-if="reviewTarget" :column="1" size="small" border class="review-detail">
         <el-descriptions-item label="场地">{{ reviewTarget.venueName }}</el-descriptions-item>
         <el-descriptions-item label="社团">{{
-          reviewTarget.clubName || `社团 ${reviewTarget.clubId}`
+          reviewTarget.clubName || "未知社团"
         }}</el-descriptions-item>
         <el-descriptions-item label="申请人">{{
-          reviewTarget.applicantName || `用户 ${reviewTarget.applicantUserId}`
+          reviewTarget.applicantName || "未知用户"
         }}</el-descriptions-item>
         <el-descriptions-item label="时间">
           {{ formatDateTime(reviewTarget.startTime) }} 至
@@ -611,7 +608,7 @@ watch(filteredVenueGroups, syncSelectedVenue);
           <el-input
             v-model="historySearch"
             clearable
-            placeholder="搜索预约 ID、场地名称或位置"
+            placeholder="搜索场地名称或位置"
             class="history-search"
           />
         </div>
@@ -636,12 +633,11 @@ watch(filteredVenueGroups, syncSelectedVenue);
         stripe
         :empty-text="historyEmptyText"
       >
-        <el-table-column prop="id" label="ID" width="70" />
         <el-table-column label="场地/社团" min-width="180">
           <template #default="{ row }">
             <div class="primary-text">{{ row.venueName }}</div>
             <div class="muted">{{ venueLocationText(row.venueId) }}</div>
-            <div class="muted">{{ row.clubName || `社团 ${row.clubId}` }}</div>
+            <div class="muted">{{ row.clubName || "未知社团" }}</div>
           </template>
         </el-table-column>
         <el-table-column label="预约时间" min-width="220">


### PR DESCRIPTION
## 改动内容

本 PR 用于完成 #105，移除活动、场地预约、场地管理和项目页面中直接展示或要求输入的内部数据库 ID。

已完成：
- 活动创建改为按社团名称选择，创建人和审核人使用当前登录态。
- 活动列表移除内部 ID 列。
- 活动参与记录接口补充姓名和学号/工号，页面不再展示记录 ID 与用户 ID。
- 场地预约申请社团/活动改为名称下拉选择，基于 `reserveClubIds` 权限过滤。
- 场地管理移除负责人内部 ID 交互，改为名称选择。
- 项目列表移除内部 ID 列和 ID 兜底文案。

## 改动原因

内部数据库 ID 对业务用户没有可识别含义，直接展示或要求输入容易误填、误选，也影响答辩演示。本 PR 在保持请求实际 ID 字段不变的前提下，将交互改为名称选择、当前登录态和业务友好占位。

---

## 关联 Issue

Closes #105

## 审查关注点

- 页面是否完全避免向业务用户暴露内部 ID。
- 名称选择后提交给后端的 ID 是否仍保持正确。
- 场地预约社团下拉是否基于 `reserveClubIds` 做权限过滤。
- 活动参与记录新增姓名与学号/工号字段是否遵循 API-first。
- 各逻辑 commit 是否保持单一职责、便于独立审查。

## UI 改动

| 改动前 | 改动后 |
|--------|--------|
| 表格直接展示活动、用户、场地、预约或项目 ID | 表格仅展示标题、名称、位置、姓名等业务信息 |
| 表单要求手动输入社团、用户或活动 ID | 使用名称下拉选择或当前登录用户 |
| 名称缺失时回退为"用户 123""社团 456" | 使用"未知用户""未知社团"等业务化占位 |

## 测试说明

本地手工测试：
- `stu_leader`（CLUB_LEADER@1）：场地预约社团下拉显示名称"计算机协会"、关联活动显示名称+时间，完整提交成功。
- `stu_public`（STUDENT）：无 `venue:reserve` 权限，页面不显示申请预约入口。
- 与 dev 合并时解决 `VenueReservationApply.vue` 冲突：保留 `reserveClubIds` 权限过滤的同时，社团选项改为名称展示。

CI：
- `dotnet build` / `pnpm run build` 通过
- Prettier / 前端代码检查通过

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过（`dotnet build`）
- [x] 前端代码已构建通过（`pnpm build`）
- [x] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets（请在 PR 描述中注明）
- [ ] 需要修改服务器配置或手动迁移


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 活动参与记录新增参与者姓名及学号展示。
  - 创建活动和活动审核自动使用当前登录用户信息。
  - 场地管理支持选择、清空及展示负责人。
  - 场地预约申请支持选择社团并联动可选活动。

- **改进**
  - 优化项目、场地及预约列表展示，移除部分内部 ID。
  - 搜索提示和预约确认文案更加直观。
  - 缺少用户、负责人或社团信息时显示友好提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->