### PR TITLE
fix(activity): 完善活动管理角色权限边界

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1160,7 +1160,10 @@ paths:
                   $ref: "#/components/schemas/Activity"
     post:
       summary: 创建活动并提交审核
+      description: 需要登录，并具备目标社团的 activity:create 权限。创建人由服务端从 Bearer 令牌解析，不接受客户端传入创建人用户 ID。
       operationId: createActivity
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -1176,6 +1179,10 @@ paths:
                 $ref: "#/components/schemas/Activity"
         "400":
           description: 请求参数或业务规则不合法
+        "401":
+          description: 当前用户未登录或登录状态已失效
+        "403":
+          description: 当前用户没有该社团的活动创建权限
 
   /api/activities/{activityId}:
     get:
@@ -1246,7 +1253,10 @@ paths:
   /api/activities/{activityId}/review:
     post:
       summary: 审核活动并发布或驳回
+      description: 需要登录，并具备目标社团的 activity:review 权限。审核人由服务端从 Bearer 令牌解析。
       operationId: reviewActivity
+      security:
+        - bearerAuth: []
       parameters:
         - name: activityId
           in: path
@@ -1268,6 +1278,10 @@ paths:
                 $ref: "#/components/schemas/Activity"
         "400":
           description: 当前活动状态不允许审核
+        "401":
+          description: 当前用户未登录或登录状态已失效
+        "403":
+          description: 当前用户没有该社团的活动审核权限
         "404":
           description: 活动不存在
 
@@ -1340,7 +1354,10 @@ paths:
   /api/activities/{activityId}/checkin-settings:
     put:
       summary: 设置活动签到签退码和有效时间
+      description: 需要登录，并具备目标社团的 activity:checkin:manage 权限。
       operationId: updateActivityCheckinSettings
+      security:
+        - bearerAuth: []
       parameters:
         - name: activityId
           in: path
@@ -1362,13 +1379,20 @@ paths:
                 $ref: "#/components/schemas/Activity"
         "400":
           description: 签到或签退时间段不合法
+        "401":
+          description: 当前用户未登录或登录状态已失效
+        "403":
+          description: 当前用户没有该社团的签到管理权限
         "404":
           description: 活动不存在
 
   /api/activities/{activityId}/participations:
     get:
       summary: 获取活动参与记录
+      description: 需要登录。具备 activity:checkin:manage 或 activity:review 时返回全部记录；其他登录用户仅返回本人记录。
       operationId: getActivityParticipations
+      security:
+        - bearerAuth: []
       parameters:
         - name: activityId
           in: path
@@ -1384,13 +1408,20 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ActivityParticipation"
+        "401":
+          description: 当前用户未登录或登录状态已失效
+        "403":
+          description: 当前用户没有查看参与记录的权限
         "404":
           description: 活动不存在
 
   /api/activities/{activityId}/checkin:
     post:
       summary: 活动签到
+      description: 需要登录，并具备 activity:checkin 权限。签到用户由服务端从 Bearer 令牌解析。
       operationId: checkinActivity
+      security:
+        - bearerAuth: []
       parameters:
         - name: activityId
           in: path
@@ -1412,13 +1443,20 @@ paths:
                 $ref: "#/components/schemas/ActivityParticipation"
         "400":
           description: 签到码、时间窗口或活动状态不合法
+        "401":
+          description: 当前用户未登录或登录状态已失效
+        "403":
+          description: 当前用户没有活动签到权限
         "404":
           description: 活动不存在
 
   /api/activities/{activityId}/checkout:
     post:
       summary: 活动签退
+      description: 需要登录，并具备 activity:checkin 权限。签退用户由服务端从 Bearer 令牌解析。
       operationId: checkoutActivity
+      security:
+        - bearerAuth: []
       parameters:
         - name: activityId
           in: path
@@ -1440,6 +1478,10 @@ paths:
                 $ref: "#/components/schemas/ActivityParticipation"
         "400":
           description: 签退码、时间窗口或活动状态不合法
+        "401":
+          description: 当前用户未登录或登录状态已失效
+        "403":
+          description: 当前用户没有活动签退权限
         "404":
           description: 活动不存在
 
@@ -4289,12 +4331,10 @@ components:
 
     CreateActivityRequest:
       type: object
+      description: 创建活动请求。创建人由服务端从登录态写入，客户端无需也不应提交 creatorUserId。
       properties:
         clubId:
           type: integer
-        creatorUserId:
-          type: integer
-          nullable: true
         title:
           type: string
           minLength: 1
@@ -4332,12 +4372,10 @@ components:
 
     ReviewActivityRequest:
       type: object
+      description: 审核活动请求。审核人由服务端从登录态写入，客户端无需也不应提交 reviewerUserId。
       properties:
         approved:
           type: boolean
-          nullable: true
-        reviewerUserId:
-          type: integer
           nullable: true
         comment:
           type: string
@@ -4418,15 +4456,13 @@ components:
 
     ActivitySignRequest:
       type: object
+      description: 活动签到/签退请求。签到用户由服务端从登录态确定，客户端只需提交签到或签退码。
       properties:
-        userId:
-          type: integer
         code:
           type: string
           minLength: 1
           maxLength: 255
       required:
-        - userId
         - code
 
     ActivityParticipation:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1211,19 +1211,16 @@ paths:
   /api/activities/{activityId}/registrations:
     post:
       summary: 报名活动
+      description: 需要登录。报名人由服务端从 Bearer 令牌解析，不接受客户端指定用户 ID。
       operationId: registerActivity
+      security:
+        - bearerAuth: []
       parameters:
         - name: activityId
           in: path
           required: true
           schema:
             type: integer
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RegisterActivityRequest"
       responses:
         "201":
           description: 报名成功
@@ -1237,6 +1234,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+        "401":
+          description: 当前用户未登录或登录状态已失效
         "404":
           description: 活动或用户不存在
           content:
@@ -1410,8 +1409,6 @@ paths:
                   $ref: "#/components/schemas/ActivityParticipation"
         "401":
           description: 当前用户未登录或登录状态已失效
-        "403":
-          description: 当前用户没有查看参与记录的权限
         "404":
           description: 活动不存在
 
@@ -4202,15 +4199,6 @@ components:
       required:
         - clubId
         - clubName
-
-    RegisterActivityRequest:
-      type: object
-      properties:
-        userId:
-          type: integer
-          description: 报名用户 ID
-      required:
-        - userId
 
     Activity:
       type: object

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -32,6 +32,11 @@ public class ActivitiesController : ControllerBase
     private const int BudgetPurposeMaxLength = 255;
     private const int BudgetCommentMaxLength = 255;
     private const int BudgetDetailMaxLength = 4000;
+    private const string ActivityCreatePermission = "activity:create";
+    private const string ActivityReviewPermission = "activity:review";
+    private const string ActivityCheckinManagePermission = "activity:checkin:manage";
+    private const string ActivityCheckinPermission = "activity:checkin";
+    private const string OwnRecordsViewPermission = "own:records:view";
 
     private readonly ClubHubDbContext _db;
     private readonly AuthService _authService;
@@ -96,8 +101,15 @@ public class ActivitiesController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize]
     public async Task<IActionResult> Create([FromBody] CreateActivityRequest req)
     {
+        var currentUserId = GetAuthenticatedUserId();
+        if (currentUserId is null)
+        {
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+        }
+
         if (string.IsNullOrWhiteSpace(req.Title))
         {
             return BadRequest(new { message = "活动标题不能为空。" });
@@ -119,19 +131,23 @@ public class ActivitiesController : ControllerBase
             return BadRequest(new { message = "指定社团不存在，不能创建活动。" });
         }
 
-        if (req.CreatorUserId is not null && !await UserExists(req.CreatorUserId.Value))
+        var permissionError = await EnsurePermissionAsync(
+            currentUserId.Value,
+            ActivityCreatePermission,
+            req.ClubId,
+            "当前用户没有该社团的活动创建权限。");
+        if (permissionError is not null)
         {
-            return BadRequest(new { message = "创建人用户不存在，请留空或填写有效用户 ID。" });
+            return permissionError;
         }
 
-        // TODO(#81): creatorUserId 目前可手工填写，仅用于 demo；正式版应从认证上下文写入，忽略请求体该字段。
         var maxId = await _db.Activities.MaxAsync(a => (int?)a.ActivityId) ?? 0;
         var now = DateTime.Now;
         var activity = new Activity
         {
             ActivityId = maxId + 1,
             ClubId = req.ClubId,
-            CreatorUserId = req.CreatorUserId,
+            CreatorUserId = currentUserId.Value,
             Title = req.Title.Trim(),
             ActivityType = req.ActivityType,
             Description = req.Description,
@@ -314,8 +330,15 @@ public class ActivitiesController : ControllerBase
     }
 
     [HttpPost("{activityId:int}/review")]
+    [Authorize]
     public async Task<IActionResult> Review(int activityId, [FromBody] ReviewActivityRequest req)
     {
+        var currentUserId = GetAuthenticatedUserId();
+        if (currentUserId is null)
+        {
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+        }
+
         var activity = await _db.Activities
             .Include(a => a.Club)
             .FirstOrDefaultAsync(a => a.ActivityId == activityId);
@@ -331,12 +354,17 @@ public class ActivitiesController : ControllerBase
             return BadRequest(new { message = "已发布或已结束的活动不能重复审核。" });
         }
 
-        if (req.ReviewerUserId is not null && !await UserExists(req.ReviewerUserId.Value))
+        var permissionError = await EnsurePermissionAsync(
+            currentUserId.Value,
+            ActivityReviewPermission,
+            activity.ClubId,
+            "当前用户没有该社团的活动审核权限。");
+        if (permissionError is not null)
         {
-            return BadRequest(new { message = "审核人用户不存在，请留空或填写有效用户 ID。" });
+            return permissionError;
         }
 
-        activity.ReviewerUserId = req.ReviewerUserId;
+        activity.ReviewerUserId = currentUserId.Value;
         activity.ReviewComment = req.Comment;
         activity.ActivityStatus = req.Approved.Value ? "published" : "rejected";
         activity.PublishedAt = req.Approved.Value ? DateTime.Now : null;
@@ -458,13 +486,31 @@ public class ActivitiesController : ControllerBase
     }
 
     [HttpPut("{activityId:int}/checkin-settings")]
+    [Authorize]
     public async Task<IActionResult> UpdateCheckinSettings(int activityId, [FromBody] UpdateCheckinSettingsRequest req)
     {
+        var currentUserId = GetAuthenticatedUserId();
+        if (currentUserId is null)
+        {
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+        }
+
         var activity = await _db.Activities
             .Include(a => a.Club)
             .FirstOrDefaultAsync(a => a.ActivityId == activityId);
 
         if (activity is null) return NotFound();
+
+        var permissionError = await EnsurePermissionAsync(
+            currentUserId.Value,
+            ActivityCheckinManagePermission,
+            activity.ClubId,
+            "当前用户没有该社团的签到管理权限。");
+        if (permissionError is not null)
+        {
+            return permissionError;
+        }
+
         if (activity.ActivityStatus is not "published" and not "ongoing")
         {
             return BadRequest(new { message = "只有已发布或进行中的活动才能设置签到签退规则。" });
@@ -518,41 +564,80 @@ public class ActivitiesController : ControllerBase
     }
 
     [HttpGet("{activityId:int}/participations")]
+    [Authorize]
     public async Task<IActionResult> GetParticipations(int activityId)
     {
-        var activityExists = await _db.Activities.AnyAsync(a => a.ActivityId == activityId);
-        if (!activityExists) return NotFound();
+        var currentUserId = GetAuthenticatedUserId();
+        if (currentUserId is null)
+        {
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+        }
 
-        var participations = await (
+        var activity = await _db.Activities.FirstOrDefaultAsync(a => a.ActivityId == activityId);
+        if (activity is null) return NotFound();
+
+        var canManage = await IsPermissionAllowedAsync(
+            currentUserId.Value,
+            ActivityCheckinManagePermission,
+            activity.ClubId);
+        var canReview = await IsPermissionAllowedAsync(
+            currentUserId.Value,
+            ActivityReviewPermission,
+            activity.ClubId);
+        var canViewOwn = await IsPermissionAllowedAsync(
+            currentUserId.Value,
+            OwnRecordsViewPermission,
+            null) ||
+            await IsPermissionAllowedAsync(
+                currentUserId.Value,
+                ActivityCheckinPermission,
+                activity.ClubId);
+
+        if (!canManage && !canReview && !canViewOwn)
+        {
+            return StatusCode(StatusCodes.Status403Forbidden, new { message = "当前用户没有查看参与记录的权限。" });
+        }
+
+        var query =
             from participation in _db.ActivityParticipations
             join user in _db.Users on participation.UserId equals user.UserId
             where participation.ActivityId == activityId
-            orderby participation.ParticipationId
-            select new ActivityParticipationDto(
-                participation.ParticipationId,
-                participation.ActivityId,
-                participation.UserId,
-                string.IsNullOrWhiteSpace(user.RealName) ? user.Username : user.RealName,
-                user.StudentNo,
-                participation.RegisterStatus,
-                participation.RegisteredAt,
-                participation.CheckinAt,
-                participation.CheckoutAt,
-                participation.SignStatus,
-                participation.Remark
-            )).ToListAsync();
+            select new { participation, user };
+
+        if (!canManage && !canReview)
+        {
+            query = query.Where(row => row.participation.UserId == currentUserId.Value);
+        }
+
+        var participations = await query
+            .OrderBy(row => row.participation.ParticipationId)
+            .Select(row => new ActivityParticipationDto(
+                row.participation.ParticipationId,
+                row.participation.ActivityId,
+                row.participation.UserId,
+                string.IsNullOrWhiteSpace(row.user.RealName) ? row.user.Username : row.user.RealName,
+                row.user.StudentNo,
+                row.participation.RegisterStatus,
+                row.participation.RegisteredAt,
+                row.participation.CheckinAt,
+                row.participation.CheckoutAt,
+                row.participation.SignStatus,
+                row.participation.Remark
+            ))
+            .ToListAsync();
 
         return Ok(participations);
     }
 
     [HttpPost("{activityId:int}/checkin")]
+    [Authorize]
     public async Task<IActionResult> Checkin(int activityId, [FromBody] ActivitySignRequest req)
     {
-        // TODO(#81): userId 目前由请求体传入，仅用于 demo；正式版应从 HttpContext.User 读取，禁止客户端指定。
         return await Sign(activityId, req, isCheckin: true);
     }
 
     [HttpPost("{activityId:int}/checkout")]
+    [Authorize]
     public async Task<IActionResult> Checkout(int activityId, [FromBody] ActivitySignRequest req)
     {
         return await Sign(activityId, req, isCheckin: false);
@@ -560,11 +645,28 @@ public class ActivitiesController : ControllerBase
 
     private async Task<IActionResult> Sign(int activityId, ActivitySignRequest req, bool isCheckin)
     {
+        var currentUserId = GetAuthenticatedUserId();
+        if (currentUserId is null)
+        {
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+        }
+
         var activity = await _db.Activities
             .Include(a => a.Participations)
             .FirstOrDefaultAsync(a => a.ActivityId == activityId);
 
         if (activity is null) return NotFound();
+
+        var permissionError = await EnsurePermissionAsync(
+            currentUserId.Value,
+            ActivityCheckinPermission,
+            activity.ClubId,
+            isCheckin ? "当前用户没有活动签到权限。" : "当前用户没有活动签退权限。");
+        if (permissionError is not null)
+        {
+            return permissionError;
+        }
+
         if (string.IsNullOrWhiteSpace(req.Code))
         {
             return BadRequest(new { message = isCheckin ? "签到码不能为空。" : "签退码不能为空。" });
@@ -576,7 +678,7 @@ public class ActivitiesController : ControllerBase
         }
 
         var participantUser = await _db.Users
-            .Where(user => user.UserId == req.UserId)
+            .Where(user => user.UserId == currentUserId.Value)
             .Select(user => new
             {
                 UserName = string.IsNullOrWhiteSpace(user.RealName) ? user.Username : user.RealName,
@@ -608,7 +710,7 @@ public class ActivitiesController : ControllerBase
             return BadRequest(new { message = isCheckin ? "当前不在签到有效时间内。" : "当前不在签退有效时间内。" });
         }
 
-        var participation = activity.Participations.FirstOrDefault(p => p.UserId == req.UserId);
+        var participation = activity.Participations.FirstOrDefault(p => p.UserId == currentUserId.Value);
         if (participation is null)
         {
             var maxId = await _db.ActivityParticipations.MaxAsync(p => (int?)p.ParticipationId) ?? 0;
@@ -616,7 +718,7 @@ public class ActivitiesController : ControllerBase
             {
                 ParticipationId = maxId + 1,
                 ActivityId = activity.ActivityId,
-                UserId = req.UserId,
+                UserId = currentUserId.Value,
                 RegisterStatus = RegisterStatusOnsite,
                 RegisteredAt = now,
                 SignStatus = "registered",
@@ -694,6 +796,32 @@ public class ActivitiesController : ControllerBase
     {
         var rawUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         return int.TryParse(rawUserId, out var userId) && userId > 0 ? userId : null;
+    }
+
+    private async Task<IActionResult?> EnsurePermissionAsync(
+        int userId,
+        string permission,
+        int? clubId,
+        string forbiddenMessage)
+    {
+        var result = await _authService.CheckPermissionAsync(userId, permission, clubId);
+        if (!result.Succeeded)
+        {
+            return StatusCode(result.StatusCode, new { message = result.ErrorMessage ?? "权限校验失败。" });
+        }
+
+        if (result.Value?.Allowed != true)
+        {
+            return StatusCode(StatusCodes.Status403Forbidden, new { message = forbiddenMessage });
+        }
+
+        return null;
+    }
+
+    private async Task<bool> IsPermissionAllowedAsync(int userId, string permission, int? clubId)
+    {
+        var result = await _authService.CheckPermissionAsync(userId, permission, clubId);
+        return result.Succeeded && result.Value?.Allowed == true;
     }
 
     private Task<int> CountActiveParticipants(int activityId)
@@ -802,8 +930,6 @@ public class CreateActivityRequest
     [Required]
     public int ClubId { get; set; }
 
-    public int? CreatorUserId { get; set; }
-
     [Required, StringLength(100, MinimumLength = 1)]
     public string Title { get; set; } = string.Empty;
 
@@ -832,8 +958,6 @@ public class ReviewActivityRequest
     [Required]
     public bool? Approved { get; set; }
 
-    public int? ReviewerUserId { get; set; }
-
     public string? Comment { get; set; }
 }
 
@@ -860,9 +984,6 @@ public class UpdateCheckinSettingsRequest
 
 public class ActivitySignRequest
 {
-    [Required]
-    public int UserId { get; set; }
-
     [Required, StringLength(50, MinimumLength = 1)]
     public string Code { get; set; } = string.Empty;
 }

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 using ActivityRegistrationResult = Org.OpenAPITools.Models.ActivityRegistrationResult;
 using ApiError = Org.OpenAPITools.Models.ApiError;
 using ApplyActivityBudgetRequest = Org.OpenAPITools.Models.ApplyActivityBudgetRequest;
-using RegisterActivityRequest = Org.OpenAPITools.Models.RegisterActivityRequest;
 using ReviewActivityBudgetRequest = Org.OpenAPITools.Models.ReviewActivityBudgetRequest;
 
 namespace ClubHub.Api.Controllers;
@@ -36,8 +35,6 @@ public class ActivitiesController : ControllerBase
     private const string ActivityReviewPermission = "activity:review";
     private const string ActivityCheckinManagePermission = "activity:checkin:manage";
     private const string ActivityCheckinPermission = "activity:checkin";
-    private const string OwnRecordsViewPermission = "own:records:view";
-
     private readonly ClubHubDbContext _db;
     private readonly AuthService _authService;
 
@@ -221,16 +218,13 @@ public class ActivitiesController : ControllerBase
     }
 
     [HttpPost("{activityId:int}/registrations")]
-    public async Task<IActionResult> Register(int activityId, [FromBody] RegisterActivityRequest? request)
+    [Authorize]
+    public async Task<IActionResult> Register(int activityId)
     {
-        if (request is null)
+        var currentUserId = GetAuthenticatedUserId();
+        if (currentUserId is null)
         {
-            return Error(StatusCodes.Status400BadRequest, "REQUEST_BODY_REQUIRED", "请提交报名用户信息");
-        }
-
-        if (request.UserId <= 0)
-        {
-            return Error(StatusCodes.Status400BadRequest, "INVALID_USER_ID", "报名用户 ID 不合法");
+            return Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "登录状态已失效，请重新登录。");
         }
 
         for (var attempt = 1; attempt <= MaxRegisterRetries; attempt++)
@@ -254,7 +248,7 @@ public class ActivitiesController : ControllerBase
                 return Error(StatusCodes.Status400BadRequest, "REGISTRATION_CLOSED", "报名已截止");
             }
 
-            var userExists = await _db.Users.AnyAsync(u => u.UserId == request.UserId);
+            var userExists = await _db.Users.AnyAsync(u => u.UserId == currentUserId.Value);
             if (!userExists)
             {
                 return Error(StatusCodes.Status404NotFound, "USER_NOT_FOUND", "用户不存在");
@@ -262,7 +256,7 @@ public class ActivitiesController : ControllerBase
 
             var isClubMember = await _db.ClubMembers.AnyAsync(m =>
                 m.ClubId == activity.ClubId &&
-                m.UserId == request.UserId &&
+                m.UserId == currentUserId.Value &&
                 (m.MemberStatus == null || m.MemberStatus.ToLower() == MemberStatusActive));
             if (!isClubMember)
             {
@@ -271,7 +265,7 @@ public class ActivitiesController : ControllerBase
 
             var alreadyRegistered = await _db.ActivityParticipations.AnyAsync(p =>
                 p.ActivityId == activityId &&
-                p.UserId == request.UserId &&
+                p.UserId == currentUserId.Value &&
                 (p.RegisterStatus == RegisterStatusPending ||
                  p.RegisterStatus == RegisterStatusAccepted ||
                  p.RegisterStatus == RegisterStatusOnsite));
@@ -290,7 +284,7 @@ public class ActivitiesController : ControllerBase
             {
                 ParticipationId = await NextParticipationId(),
                 ActivityId = activityId,
-                UserId = request.UserId,
+                UserId = currentUserId.Value,
                 RegisterStatus = RegisterStatusAccepted,
                 RegisteredAt = now,
                 SignStatus = "registered"
@@ -316,7 +310,7 @@ public class ActivitiesController : ControllerBase
 
                 return CreatedAtAction(
                     nameof(GetById),
-                    new { activityId, currentUserId = request.UserId },
+                    new { activityId, currentUserId = currentUserId.Value },
                     result);
             }
             catch (DbUpdateException)
@@ -584,19 +578,6 @@ public class ActivitiesController : ControllerBase
             currentUserId.Value,
             ActivityReviewPermission,
             activity.ClubId);
-        var canViewOwn = await IsPermissionAllowedAsync(
-            currentUserId.Value,
-            OwnRecordsViewPermission,
-            null) ||
-            await IsPermissionAllowedAsync(
-                currentUserId.Value,
-                ActivityCheckinPermission,
-                activity.ClubId);
-
-        if (!canManage && !canReview && !canViewOwn)
-        {
-            return StatusCode(StatusCodes.Status403Forbidden, new { message = "当前用户没有查看参与记录的权限。" });
-        }
 
         var query =
             from participation in _db.ActivityParticipations
@@ -925,7 +906,7 @@ public class CreateActivityRequest
     [Required]
     public int ClubId { get; set; }
 
-    [Required, StringLength(100, MinimumLength = 1)]
+    [Required, StringLength(255, MinimumLength = 1)]
     public string Title { get; set; } = string.Empty;
 
     [StringLength(255)]

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -876,11 +876,6 @@ public class ActivitiesController : ControllerBase
         );
     }
 
-    private async Task<bool> UserExists(int userId)
-    {
-        return await _db.Users.AnyAsync(u => u.UserId == userId);
-    }
-
     private static ObjectResult Error(int statusCode, string code, string message)
     {
         return new ObjectResult(new ApiError

--- a/backend/Models/ActivitySignRequest.cs
+++ b/backend/Models/ActivitySignRequest.cs
@@ -20,18 +20,11 @@ using System.Text.Json;
 namespace Org.OpenAPITools.Models
 { 
     /// <summary>
-    /// 
+    /// 活动签到/签退请求。签到用户由服务端从登录态确定，客户端只需提交签到或签退码。
     /// </summary>
     [DataContract]
     public partial class ActivitySignRequest 
     {
-        /// <summary>
-        /// Gets or Sets UserId
-        /// </summary>
-        [Required]
-        [DataMember(Name="userId", EmitDefaultValue=true)]
-        public int UserId { get; set; }
-
         /// <summary>
         /// Gets or Sets Code
         /// </summary>

--- a/backend/Models/CreateActivityRequest.cs
+++ b/backend/Models/CreateActivityRequest.cs
@@ -20,7 +20,7 @@ using System.Text.Json;
 namespace Org.OpenAPITools.Models
 { 
     /// <summary>
-    /// 
+    /// 创建活动请求。创建人由服务端从登录态写入，客户端无需也不应提交 creatorUserId。
     /// </summary>
     [DataContract]
     public partial class CreateActivityRequest 
@@ -31,12 +31,6 @@ namespace Org.OpenAPITools.Models
         [Required]
         [DataMember(Name="clubId", EmitDefaultValue=true)]
         public int ClubId { get; set; }
-
-        /// <summary>
-        /// Gets or Sets CreatorUserId
-        /// </summary>
-        [DataMember(Name="creatorUserId", EmitDefaultValue=true)]
-        public int? CreatorUserId { get; set; }
 
         /// <summary>
         /// Gets or Sets Title

--- a/backend/Models/ReviewActivityRequest.cs
+++ b/backend/Models/ReviewActivityRequest.cs
@@ -20,7 +20,7 @@ using System.Text.Json;
 namespace Org.OpenAPITools.Models
 { 
     /// <summary>
-    /// 
+    /// 审核活动请求。审核人由服务端从登录态写入，客户端无需也不应提交 reviewerUserId。
     /// </summary>
     [DataContract]
     public partial class ReviewActivityRequest 
@@ -30,12 +30,6 @@ namespace Org.OpenAPITools.Models
         /// </summary>
         [DataMember(Name="approved", EmitDefaultValue=true)]
         public bool? Approved { get; set; }
-
-        /// <summary>
-        /// Gets or Sets ReviewerUserId
-        /// </summary>
-        [DataMember(Name="reviewerUserId", EmitDefaultValue=true)]
-        public int? ReviewerUserId { get; set; }
 
         /// <summary>
         /// Gets or Sets Comment

--- a/docs/branch-notes/fix-103-activity-permissions.md
+++ b/docs/branch-notes/fix-103-activity-permissions.md
@@ -1,0 +1,5 @@
+﻿# fix/103-activity-permissions
+
+关联 Issue: #103
+
+本分支用于修复活动管理缺少完整角色权限边界的问题。

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,15 +16,17 @@ const accountLabel = computed(() => {
   if (!user) return "账号与权限";
   return user.studentNo ? `${user.realName} / ${user.studentNo}` : user.realName;
 });
-const roleSummary = computed(() => {
+const roleLabels = computed(() => {
   const roles = auth.value?.roles ?? [];
-  if (roles.length === 0) return "暂无角色";
-  return roles.map((role) => role.displayName || role.name).join("、");
+  if (roles.length === 0) return ["暂无角色"];
+  return roles.map((role) => role.displayName || role.name);
 });
+const roleSummary = computed(() => roleLabels.value.join("、"));
 const activeMenu = computed(() => {
   if (route.path.startsWith("/recruitments")) return "/recruitments";
   if (route.path.startsWith("/evaluations")) return "/evaluations";
   if (route.path.startsWith("/awards")) return "/awards";
+  if (route.path.startsWith("/learning")) return "/learning";
   return route.path;
 });
 const canManageVenues = computed(() => {
@@ -96,33 +98,39 @@ onUnmounted(() => {
           场地预约
         </el-menu-item>
         <el-menu-item index="/learning">课程</el-menu-item>
-        <div class="session">
-          <el-tag class="role-tag" type="success" size="small" :title="roleSummary">{{
-            roleSummary
-          }}</el-tag>
-          <el-button link type="danger" @click="logout">退出</el-button>
-        </div>
-        <div class="health">
+      </el-menu>
+      <div class="header-aside">
+        <div class="role-tags" :title="roleSummary">
           <el-tag
-            :type="healthOk ? 'success' : 'danger'"
+            v-for="(label, index) in roleLabels"
+            :key="`${label}-${index}`"
+            class="role-tag"
+            type="success"
             size="small"
-            role="button"
-            tabindex="0"
-            :aria-label="
-              healthOk ? '后端已连接，回车或空格重新检测' : '点击、回车或空格检测后端健康状态'
-            "
-            :aria-busy="healthChecking"
-            @click="checkHealth"
-            @keyup.enter="checkHealth"
-            @keydown.space.prevent
-            @keyup.space="checkHealth"
           >
-            {{ healthChecking ? "检测中..." : healthOk ? "后端已连接" : "点击检测" }}
+            {{ label }}
           </el-tag>
         </div>
-      </el-menu>
+        <el-button link type="danger" @click="logout">退出</el-button>
+        <el-tag
+          class="health-tag"
+          :type="healthOk ? 'success' : 'danger'"
+          size="small"
+          role="button"
+          tabindex="0"
+          :aria-label="
+            healthOk ? '后端已连接，回车或空格重新检测' : '点击、回车或空格检测后端健康状态'
+          "
+          :aria-busy="healthChecking"
+          @click="checkHealth"
+          @keyup.enter="checkHealth"
+          @keyup.space.prevent="checkHealth"
+        >
+          {{ healthChecking ? "检测中..." : healthOk ? "后端已连接" : "点击检测" }}
+        </el-tag>
+      </div>
     </el-header>
-    <el-main>
+    <el-main class="main">
       <router-view />
     </el-main>
   </el-container>
@@ -132,34 +140,50 @@ onUnmounted(() => {
 .el-header {
   display: flex;
   align-items: center;
+  gap: 12px;
   border-bottom: 1px solid var(--el-border-color-light);
   padding: 0 16px;
 }
 .brand {
   font-size: 18px;
   font-weight: 600;
-  margin-right: 16px;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 .nav {
   flex: 1;
+  min-width: 0;
   border-bottom: none !important;
 }
-.health {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-}
-.session {
+.header-aside {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
   margin-left: auto;
 }
+.role-tags {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+  width: 320px;
+  max-height: 52px;
+  overflow: hidden;
+}
 .role-tag {
-  max-width: 260px;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.health-tag {
+  width: 88px;
+  justify-content: center;
+  cursor: pointer;
+}
+.main {
+  scrollbar-gutter: stable;
 }
 </style>

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -206,11 +206,6 @@ import {
   RecruitmentApplicationToJSON,
 } from "../models/RecruitmentApplication";
 import {
-  type RegisterActivityRequest,
-  RegisterActivityRequestFromJSON,
-  RegisterActivityRequestToJSON,
-} from "../models/RegisterActivityRequest";
-import {
   type RegisterRequest,
   RegisterRequestFromJSON,
   RegisterRequestToJSON,
@@ -564,9 +559,8 @@ export interface MarkNoticeReadOperationRequest {
   markNoticeReadRequest: MarkNoticeReadRequest;
 }
 
-export interface RegisterActivityOperationRequest {
+export interface RegisterActivityRequest {
   activityId: number;
-  registerActivityRequest: RegisterActivityRequest;
 }
 
 export interface RegisterUserRequest {
@@ -3973,7 +3967,7 @@ export class DefaultApi extends runtime.BaseAPI {
    * Creates request options for registerActivity without sending the request
    */
   async registerActivityRequestOpts(
-    requestParameters: RegisterActivityOperationRequest,
+    requestParameters: RegisterActivityRequest,
   ): Promise<runtime.RequestOpts> {
     if (requestParameters["activityId"] == null) {
       throw new runtime.RequiredError(
@@ -3982,18 +3976,18 @@ export class DefaultApi extends runtime.BaseAPI {
       );
     }
 
-    if (requestParameters["registerActivityRequest"] == null) {
-      throw new runtime.RequiredError(
-        "registerActivityRequest",
-        'Required parameter "registerActivityRequest" was null or undefined when calling registerActivity().',
-      );
-    }
-
     const queryParameters: any = {};
 
     const headerParameters: runtime.HTTPHeaders = {};
 
-    headerParameters["Content-Type"] = "application/json";
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
 
     let urlPath = `/api/activities/{activityId}/registrations`;
     urlPath = urlPath.replace(
@@ -4006,15 +4000,15 @@ export class DefaultApi extends runtime.BaseAPI {
       method: "POST",
       headers: headerParameters,
       query: queryParameters,
-      body: RegisterActivityRequestToJSON(requestParameters["registerActivityRequest"]),
     };
   }
 
   /**
+   * 需要登录。报名人由服务端从 Bearer 令牌解析，不接受客户端指定用户 ID。
    * 报名活动
    */
   async registerActivityRaw(
-    requestParameters: RegisterActivityOperationRequest,
+    requestParameters: RegisterActivityRequest,
     initOverrides?: RequestInit | runtime.InitOverrideFunction,
   ): Promise<runtime.ApiResponse<ActivityRegistrationResult>> {
     const requestOptions = await this.registerActivityRequestOpts(requestParameters);
@@ -4026,10 +4020,11 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录。报名人由服务端从 Bearer 令牌解析，不接受客户端指定用户 ID。
    * 报名活动
    */
   async registerActivity(
-    requestParameters: RegisterActivityOperationRequest,
+    requestParameters: RegisterActivityRequest,
     initOverrides?: RequestInit | runtime.InitOverrideFunction,
   ): Promise<ActivityRegistrationResult> {
     const response = await this.registerActivityRaw(requestParameters, initOverrides);

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -1087,6 +1087,15 @@ export class DefaultApi extends runtime.BaseAPI {
 
     headerParameters["Content-Type"] = "application/json";
 
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
+
     let urlPath = `/api/activities/{activityId}/checkin`;
     urlPath = urlPath.replace(
       "{activityId}",
@@ -1103,6 +1112,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备 activity:checkin 权限。签到用户由服务端从 Bearer 令牌解析。
    * 活动签到
    */
   async checkinActivityRaw(
@@ -1118,6 +1128,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备 activity:checkin 权限。签到用户由服务端从 Bearer 令牌解析。
    * 活动签到
    */
   async checkinActivity(
@@ -1154,6 +1165,15 @@ export class DefaultApi extends runtime.BaseAPI {
 
     headerParameters["Content-Type"] = "application/json";
 
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
+
     let urlPath = `/api/activities/{activityId}/checkout`;
     urlPath = urlPath.replace(
       "{activityId}",
@@ -1170,6 +1190,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备 activity:checkin 权限。签退用户由服务端从 Bearer 令牌解析。
    * 活动签退
    */
   async checkoutActivityRaw(
@@ -1185,6 +1206,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备 activity:checkin 权限。签退用户由服务端从 Bearer 令牌解析。
    * 活动签退
    */
   async checkoutActivity(
@@ -1214,6 +1236,15 @@ export class DefaultApi extends runtime.BaseAPI {
 
     headerParameters["Content-Type"] = "application/json";
 
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
+
     let urlPath = `/api/activities`;
 
     return {
@@ -1226,6 +1257,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备目标社团的 activity:create 权限。创建人由服务端从 Bearer 令牌解析，不接受客户端传入创建人用户 ID。
    * 创建活动并提交审核
    */
   async createActivityRaw(
@@ -1239,6 +1271,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备目标社团的 activity:create 权限。创建人由服务端从 Bearer 令牌解析，不接受客户端传入创建人用户 ID。
    * 创建活动并提交审核
    */
   async createActivity(
@@ -2411,6 +2444,15 @@ export class DefaultApi extends runtime.BaseAPI {
 
     const headerParameters: runtime.HTTPHeaders = {};
 
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
+
     let urlPath = `/api/activities/{activityId}/participations`;
     urlPath = urlPath.replace(
       "{activityId}",
@@ -2426,6 +2468,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录。具备 activity:checkin:manage 或 activity:review 时返回全部记录；其他登录用户仅返回本人记录。
    * 获取活动参与记录
    */
   async getActivityParticipationsRaw(
@@ -2441,6 +2484,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录。具备 activity:checkin:manage 或 activity:review 时返回全部记录；其他登录用户仅返回本人记录。
    * 获取活动参与记录
    */
   async getActivityParticipations(
@@ -4146,6 +4190,15 @@ export class DefaultApi extends runtime.BaseAPI {
 
     headerParameters["Content-Type"] = "application/json";
 
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
+
     let urlPath = `/api/activities/{activityId}/review`;
     urlPath = urlPath.replace(
       "{activityId}",
@@ -4162,6 +4215,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备目标社团的 activity:review 权限。审核人由服务端从 Bearer 令牌解析。
    * 审核活动并发布或驳回
    */
   async reviewActivityRaw(
@@ -4175,6 +4229,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备目标社团的 activity:review 权限。审核人由服务端从 Bearer 令牌解析。
    * 审核活动并发布或驳回
    */
   async reviewActivity(
@@ -4621,6 +4676,15 @@ export class DefaultApi extends runtime.BaseAPI {
 
     headerParameters["Content-Type"] = "application/json";
 
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
+
     let urlPath = `/api/activities/{activityId}/checkin-settings`;
     urlPath = urlPath.replace(
       "{activityId}",
@@ -4637,6 +4701,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备目标社团的 activity:checkin:manage 权限。
    * 设置活动签到签退码和有效时间
    */
   async updateActivityCheckinSettingsRaw(
@@ -4650,6 +4715,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
+   * 需要登录，并具备目标社团的 activity:checkin:manage 权限。
    * 设置活动签到签退码和有效时间
    */
   async updateActivityCheckinSettings(

--- a/frontend/src/api/models/ActivitySignRequest.ts
+++ b/frontend/src/api/models/ActivitySignRequest.ts
@@ -15,17 +15,11 @@
 
 import { mapValues } from "../runtime";
 /**
- *
+ * 活动签到/签退请求。签到用户由服务端从登录态确定，客户端只需提交签到或签退码。
  * @export
  * @interface ActivitySignRequest
  */
 export interface ActivitySignRequest {
-  /**
-   *
-   * @type {number}
-   * @memberof ActivitySignRequest
-   */
-  userId: number;
   /**
    *
    * @type {string}
@@ -38,7 +32,6 @@ export interface ActivitySignRequest {
  * Check if a given object implements the ActivitySignRequest interface.
  */
 export function instanceOfActivitySignRequest(value: object): value is ActivitySignRequest {
-  if (!("userId" in value) || value["userId"] === undefined) return false;
   if (!("code" in value) || value["code"] === undefined) return false;
   return true;
 }
@@ -55,7 +48,6 @@ export function ActivitySignRequestFromJSONTyped(
     return json;
   }
   return {
-    userId: json["userId"],
     code: json["code"],
   };
 }
@@ -73,7 +65,6 @@ export function ActivitySignRequestToJSONTyped(
   }
 
   return {
-    userId: value["userId"],
     code: value["code"],
   };
 }

--- a/frontend/src/api/models/CreateActivityRequest.ts
+++ b/frontend/src/api/models/CreateActivityRequest.ts
@@ -15,7 +15,7 @@
 
 import { mapValues } from "../runtime";
 /**
- *
+ * 创建活动请求。创建人由服务端从登录态写入，客户端无需也不应提交 creatorUserId。
  * @export
  * @interface CreateActivityRequest
  */
@@ -26,12 +26,6 @@ export interface CreateActivityRequest {
    * @memberof CreateActivityRequest
    */
   clubId: number;
-  /**
-   *
-   * @type {number}
-   * @memberof CreateActivityRequest
-   */
-  creatorUserId?: number | null;
   /**
    *
    * @type {string}
@@ -106,7 +100,6 @@ export function CreateActivityRequestFromJSONTyped(
   }
   return {
     clubId: json["clubId"],
-    creatorUserId: json["creatorUserId"] == null ? undefined : json["creatorUserId"],
     title: json["title"],
     activityType: json["activityType"] == null ? undefined : json["activityType"],
     description: json["description"] == null ? undefined : json["description"],
@@ -133,7 +126,6 @@ export function CreateActivityRequestToJSONTyped(
 
   return {
     clubId: value["clubId"],
-    creatorUserId: value["creatorUserId"],
     title: value["title"],
     activityType: value["activityType"],
     description: value["description"],

--- a/frontend/src/api/models/RegisterActivityRequest.ts
+++ b/frontend/src/api/models/RegisterActivityRequest.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/RegisterActivityRequest.ts
+++ b/frontend/src/api/models/RegisterActivityRequest.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/RegisterActivityRequest.ts
+++ b/frontend/src/api/models/RegisterActivityRequest.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/ReviewActivityRequest.ts
+++ b/frontend/src/api/models/ReviewActivityRequest.ts
@@ -15,7 +15,7 @@
 
 import { mapValues } from "../runtime";
 /**
- *
+ * 审核活动请求。审核人由服务端从登录态写入，客户端无需也不应提交 reviewerUserId。
  * @export
  * @interface ReviewActivityRequest
  */
@@ -26,12 +26,6 @@ export interface ReviewActivityRequest {
    * @memberof ReviewActivityRequest
    */
   approved?: boolean | null;
-  /**
-   *
-   * @type {number}
-   * @memberof ReviewActivityRequest
-   */
-  reviewerUserId?: number | null;
   /**
    *
    * @type {string}
@@ -60,7 +54,6 @@ export function ReviewActivityRequestFromJSONTyped(
   }
   return {
     approved: json["approved"] == null ? undefined : json["approved"],
-    reviewerUserId: json["reviewerUserId"] == null ? undefined : json["reviewerUserId"],
     comment: json["comment"] == null ? undefined : json["comment"],
   };
 }
@@ -79,7 +72,6 @@ export function ReviewActivityRequestToJSONTyped(
 
   return {
     approved: value["approved"],
-    reviewerUserId: value["reviewerUserId"],
     comment: value["comment"],
   };
 }

--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -17,6 +17,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -16,6 +16,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/index.ts
+++ b/frontend/src/api/models/index.ts
@@ -47,7 +47,6 @@ export * from "./Project";
 export * from "./Recruitment";
 export * from "./RecruitmentApplication";
 export * from "./RecruitmentWorkflowStatus";
-export * from "./RegisterActivityRequest";
 export * from "./RegisterRequest";
 export * from "./ReviewActivityBudgetRequest";
 export * from "./ReviewActivityRequest";

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -54,8 +54,7 @@ interface ClubOption {
 }
 
 interface CreateActivityForm {
-  clubId: number;
-  creatorUserId: number | null;
+  clubId: number | null;
   title: string;
   activityType: string;
   description: string;
@@ -68,7 +67,6 @@ interface CreateActivityForm {
 
 interface ReviewActivityForm {
   approved: boolean;
-  reviewerUserId: number | null;
   comment: string;
 }
 
@@ -117,10 +115,37 @@ const currentUserDisplay = computed(() => {
   if (!user) return "未登录";
   return user.realName?.trim() || user.username?.trim() || "未知用户";
 });
+const currentRoles = computed(() => auth.value?.roles ?? []);
+const creatableClubs = computed<ClubOption[]>(() => {
+  const fromRoles = clubIdsWithPermission("activity:create");
+  const clubMap = new Map<number, string>();
+
+  for (const activity of activities.value) {
+    clubMap.set(activity.clubId, activity.clubName || `社团 ${activity.clubId}`);
+  }
+
+  if ((auth.value?.permissions ?? []).includes("*")) {
+    return [...clubMap.entries()].map(([id, name]) => ({ id, name })).sort((a, b) => a.id - b.id);
+  }
+
+  return fromRoles.map((id) => ({
+    id,
+    name: clubMap.get(id) ?? `社团 ${id}`,
+  }));
+});
+const canCreateActivity = computed(() => hasPermission("activity:create"));
+const pageTitle = computed(() =>
+  canCreateActivity.value ||
+  hasPermission("activity:review") ||
+  hasPermission("activity:checkin:manage") ||
+  hasPermission("budget:apply") ||
+  hasPermission("budget:review")
+    ? "活动管理"
+    : "活动",
+);
 
 const createForm = ref<CreateActivityForm>({
-  clubId: 0,
-  creatorUserId: null,
+  clubId: null,
   title: "",
   activityType: "",
   description: "",
@@ -133,7 +158,6 @@ const createForm = ref<CreateActivityForm>({
 
 const reviewForm = ref<ReviewActivityForm>({
   approved: true,
-  reviewerUserId: null,
   comment: "",
 });
 
@@ -311,6 +335,88 @@ function emptyToNull(value: string) {
   return value ? value : null;
 }
 
+function hasPermission(permission: string) {
+  const permissions = auth.value?.permissions ?? [];
+  return permissions.includes("*") || permissions.includes(permission);
+}
+
+function clubIdsWithPermission(permission: string) {
+  return [
+    ...new Set(
+      currentRoles.value
+        .filter(
+          (role) =>
+            (role.permissions ?? []).includes("*") || (role.permissions ?? []).includes(permission),
+        )
+        .flatMap((role) => role.clubIds ?? [])
+        .filter((clubId): clubId is number => Number.isFinite(clubId)),
+    ),
+  ].sort((a, b) => a - b);
+}
+
+function hasScopedPermission(permission: string, clubId: number) {
+  if ((auth.value?.permissions ?? []).includes("*")) return true;
+
+  return currentRoles.value.some((role) => {
+    const permissions = role.permissions ?? [];
+    if (!permissions.includes("*") && !permissions.includes(permission)) return false;
+    if (permissions.includes("*")) return true;
+    if ((role.scope ?? "").toLowerCase() === "system") return true;
+    return (role.clubIds ?? []).includes(clubId) || role.clubId === clubId;
+  });
+}
+
+function canReviewActivity(activity: Activity) {
+  return (
+    activity.status === "pending_review" && hasScopedPermission("activity:review", activity.clubId)
+  );
+}
+
+function canManageCheckin(activity: Activity) {
+  return (
+    (activity.status === "published" || activity.status === "ongoing") &&
+    hasScopedPermission("activity:checkin:manage", activity.clubId)
+  );
+}
+
+function canSignActivity(activity: Activity) {
+  return (
+    (activity.status === "published" || activity.status === "ongoing") &&
+    hasScopedPermission("activity:checkin", activity.clubId)
+  );
+}
+
+function canViewParticipations(activity: Activity) {
+  return (
+    hasScopedPermission("activity:checkin:manage", activity.clubId) ||
+    hasScopedPermission("activity:review", activity.clubId) ||
+    hasPermission("own:records:view") ||
+    hasScopedPermission("activity:checkin", activity.clubId)
+  );
+}
+
+function canApplyBudget(activity: Activity) {
+  return hasScopedPermission("budget:apply", activity.clubId);
+}
+
+function canReviewBudget(activity: Activity) {
+  return (
+    activity.budgetStatus === "pending" && hasScopedPermission("budget:review", activity.clubId)
+  );
+}
+
+function canManageMaterial(activity: Activity) {
+  return hasScopedPermission("material:borrow:manage", activity.clubId);
+}
+
+function showBudgetMenu(activity: Activity) {
+  return canApplyBudget(activity) || canReviewBudget(activity);
+}
+
+function showCheckinMenu(activity: Activity) {
+  return canManageCheckin(activity) || canSignActivity(activity);
+}
+
 async function loadActivities() {
   loading.value = true;
   error.value = "";
@@ -321,10 +427,8 @@ async function loadActivities() {
     }
 
     const url = query.toString() ? `/api/activities?${query}` : "/api/activities";
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = (await res.json()) as Activity[];
-    activities.value = data.map((activity) => ({
+    activities.value = await requestJson<Activity[]>(url);
+    activities.value = activities.value.map((activity) => ({
       ...activity,
       currentParticipants: activity.currentParticipants ?? 0,
       isRegistered: activity.isRegistered ?? false,
@@ -371,10 +475,14 @@ function registerButtonText(activity: Activity) {
 }
 
 function openCreate() {
+  if (!canCreateActivity.value) {
+    ElMessage.warning("当前账号没有创建活动权限。");
+    return;
+  }
+
   const defaults = buildDefaultCreateTimes();
   createForm.value = {
-    clubId: clubOptions.value[0]?.id ?? 0,
-    creatorUserId: currentUserId.value,
+    clubId: creatableClubs.value[0]?.id ?? null,
     title: "",
     activityType: "",
     description: "",
@@ -388,25 +496,25 @@ function openCreate() {
 }
 
 async function createActivity() {
-  if (
-    !createForm.value.clubId ||
-    !createForm.value.title ||
-    !createForm.value.startTime ||
-    !createForm.value.endTime
-  ) {
-    error.value = "请选择主办社团，并填写活动标题、开始时间和结束时间。";
+  if (!createForm.value.clubId) {
+    error.value = "请选择可管理的主办社团。";
+    ElMessage.error(error.value);
+    return;
+  }
+
+  if (!createForm.value.title || !createForm.value.startTime || !createForm.value.endTime) {
+    error.value = "请填写活动标题、开始时间和结束时间。";
     ElMessage.error(error.value);
     return;
   }
 
   saving.value = true;
   try {
-    const res = await fetch("/api/activities", {
+    await requestJson<Activity>("/api/activities", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         clubId: createForm.value.clubId,
-        creatorUserId: currentUserId.value,
         title: createForm.value.title,
         activityType: emptyToNull(createForm.value.activityType),
         description: emptyToNull(createForm.value.description),
@@ -417,7 +525,6 @@ async function createActivity() {
         registrationDeadline: emptyToNull(createForm.value.registrationDeadline),
       }),
     });
-    if (!res.ok) throw new Error(await res.text());
     createDialogVisible.value = false;
     ElMessage.success("活动已提交审核");
     await loadActivities();
@@ -438,14 +545,15 @@ async function registerActivity(activity: Activity) {
 
   registeringActivityId.value = activity.id;
   try {
-    const res = await fetch(`/api/activities/${activity.id}/registrations`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userId }),
-    });
-    if (!res.ok) throw new Error(await readErrorMessage(res));
+    const result = await requestJson<{ currentParticipants?: number; message?: string }>(
+      `/api/activities/${activity.id}/registrations`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId }),
+      },
+    );
 
-    const result = (await res.json()) as { currentParticipants?: number; message?: string };
     activity.currentParticipants = result.currentParticipants ?? activity.currentParticipants + 1;
     activity.isRegistered = true;
     ElMessage.success(result.message || "报名成功");
@@ -457,15 +565,14 @@ async function registerActivity(activity: Activity) {
 }
 
 function openReview(activity: Activity) {
-  if (!currentUserId.value) {
-    ElMessage.warning("请先登录后再审核活动");
+  if (!canReviewActivity(activity)) {
+    ElMessage.warning("当前账号没有审核该活动的权限。");
     return;
   }
 
   currentActivity.value = activity;
   reviewForm.value = {
     approved: true,
-    reviewerUserId: currentUserId.value,
     comment: "",
   };
   reviewDialogVisible.value = true;
@@ -476,15 +583,14 @@ async function reviewActivity() {
 
   saving.value = true;
   try {
-    const res = await fetch(`/api/activities/${currentActivity.value.id}/review`, {
+    await requestJson<Activity>(`/api/activities/${currentActivity.value.id}/review`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        ...reviewForm.value,
-        reviewerUserId: currentUserId.value,
+        approved: reviewForm.value.approved,
+        comment: emptyToNull(reviewForm.value.comment),
       }),
     });
-    if (!res.ok) throw new Error(await res.text());
     reviewDialogVisible.value = false;
     ElMessage.success("审核结果已保存");
     await loadActivities();
@@ -497,8 +603,8 @@ async function reviewActivity() {
 }
 
 function openBudget(activity: Activity) {
-  if (!currentUserId.value) {
-    ElMessage.warning("请先登录后再提交经费申请");
+  if (!canApplyBudget(activity)) {
+    ElMessage.warning("当前账号没有该社团的经费申请权限。");
     return;
   }
 
@@ -542,8 +648,8 @@ async function applyBudget() {
 }
 
 function openBudgetReview(activity: Activity) {
-  if (!currentUserId.value) {
-    ElMessage.warning("请先登录后再审批经费申请");
+  if (!canReviewBudget(activity)) {
+    ElMessage.warning("当前账号没有该社团的经费审批权限。");
     return;
   }
 
@@ -556,6 +662,11 @@ function openBudgetReview(activity: Activity) {
 }
 
 function openMaterialPlaceholder(activity: Activity) {
+  if (!canManageMaterial(activity)) {
+    ElMessage.warning("当前账号没有该社团的物资借用管理权限。");
+    return;
+  }
+
   currentActivity.value = activity;
   ElMessage.info("活动物资借用、归还与损坏登记将在 #23 接入。");
 }
@@ -585,6 +696,11 @@ async function reviewBudget() {
 }
 
 function openSettings(activity: Activity) {
+  if (!canManageCheckin(activity)) {
+    ElMessage.warning("当前账号没有该社团的签到管理权限。");
+    return;
+  }
+
   currentActivity.value = activity;
   const recommended = buildRecommendedCheckinSettings(activity);
   const useRecommended = !hasExistingCheckinSettings(activity);
@@ -643,12 +759,11 @@ async function saveCheckinSettings() {
 
   saving.value = true;
   try {
-    const res = await fetch(`/api/activities/${currentActivity.value.id}/checkin-settings`, {
+    await requestJson<Activity>(`/api/activities/${currentActivity.value.id}/checkin-settings`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(settingsForm.value),
     });
-    if (!res.ok) throw new Error(await res.text());
     settingsDialogVisible.value = false;
     ElMessage.success("签到签退设置已保存");
     await loadActivities();
@@ -661,16 +776,14 @@ async function saveCheckinSettings() {
 }
 
 function openSign(activity: Activity, type: "checkin" | "checkout") {
-  const userId = currentUserId.value;
-  if (!userId) {
-    ElMessage.warning("请先登录后再签到签退");
+  if (!canSignActivity(activity)) {
+    ElMessage.warning("当前账号没有该社团的签到签退权限。");
     return;
   }
 
   currentActivity.value = activity;
   signForm.value = {
     type,
-    userId,
     code: "",
   };
   signDialogVisible.value = true;
@@ -681,15 +794,13 @@ async function submitSign() {
 
   saving.value = true;
   try {
-    const res = await fetch(`/api/activities/${currentActivity.value.id}/${signForm.value.type}`, {
+    await requestJson(`/api/activities/${currentActivity.value.id}/${signForm.value.type}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        userId: signForm.value.userId,
         code: signForm.value.code,
       }),
     });
-    if (!res.ok) throw new Error(await res.text());
     signDialogVisible.value = false;
     ElMessage.success(signForm.value.type === "checkin" ? "签到成功" : "签退成功");
     await loadActivities();
@@ -702,13 +813,18 @@ async function submitSign() {
 }
 
 async function openParticipations(activity: Activity) {
+  if (!canViewParticipations(activity)) {
+    ElMessage.warning("当前账号没有查看参与记录的权限。");
+    return;
+  }
+
   currentActivity.value = activity;
   participationsDialogVisible.value = true;
   participationLoading.value = true;
   try {
-    const res = await fetch(`/api/activities/${activity.id}/participations`);
-    if (!res.ok) throw new Error(await res.text());
-    participations.value = await res.json();
+    participations.value = await requestJson<ActivityParticipation[]>(
+      `/api/activities/${activity.id}/participations`,
+    );
   } catch (e) {
     error.value = e instanceof Error ? e.message : "加载参与记录失败";
     ElMessage.error(error.value);
@@ -716,26 +832,12 @@ async function openParticipations(activity: Activity) {
     participationLoading.value = false;
   }
 }
-
-async function readErrorMessage(res: Response) {
-  const body = await res.text();
-  if (!body) {
-    return `请求失败（${res.status}）`;
-  }
-
-  try {
-    const parsed = JSON.parse(body) as { message?: string };
-    return parsed.message || `请求失败（${res.status}）`;
-  } catch {
-    return body;
-  }
-}
 </script>
 
 <template>
   <div class="page">
     <div class="toolbar">
-      <h2>活动管理</h2>
+      <h2>{{ pageTitle }}</h2>
       <div class="toolbar-actions">
         <el-select v-model="statusFilter" placeholder="筛选状态" class="status-filter">
           <el-option
@@ -745,7 +847,7 @@ async function readErrorMessage(res: Response) {
             :value="option.value"
           />
         </el-select>
-        <el-button type="primary" @click="openCreate">创建活动</el-button>
+        <el-button v-if="canCreateActivity" type="primary" @click="openCreate">创建活动</el-button>
       </div>
     </div>
 
@@ -788,7 +890,12 @@ async function readErrorMessage(res: Response) {
               <el-button size="small" plain>活动详情</el-button>
               <template #dropdown>
                 <el-dropdown-menu>
-                  <el-dropdown-item @click="openParticipations(row)">参与记录</el-dropdown-item>
+                  <el-dropdown-item
+                    v-if="canViewParticipations(row)"
+                    @click="openParticipations(row)"
+                  >
+                    参与记录
+                  </el-dropdown-item>
                   <el-dropdown-item
                     v-if="row.status === 'published'"
                     :disabled="!canRegister(row) || registeringActivityId === row.id"
@@ -796,38 +903,41 @@ async function readErrorMessage(res: Response) {
                   >
                     {{ registerButtonText(row) }}
                   </el-dropdown-item>
-                  <el-dropdown-item v-if="row.status === 'pending_review'" @click="openReview(row)">
+                  <el-dropdown-item v-if="canReviewActivity(row)" @click="openReview(row)">
                     活动审核
                   </el-dropdown-item>
                 </el-dropdown-menu>
               </template>
             </el-dropdown>
 
-            <el-dropdown trigger="click">
+            <el-dropdown v-if="showBudgetMenu(row)" trigger="click">
               <el-button size="small" type="primary" plain>经费管理</el-button>
               <template #dropdown>
                 <el-dropdown-menu>
                   <el-dropdown-item
+                    v-if="canApplyBudget(row)"
                     :disabled="row.budgetStatus === 'approved'"
                     @click="openBudget(row)"
                   >
                     经费申请
                   </el-dropdown-item>
-                  <el-dropdown-item
-                    v-if="row.budgetStatus === 'pending'"
-                    @click="openBudgetReview(row)"
-                  >
+                  <el-dropdown-item v-if="canReviewBudget(row)" @click="openBudgetReview(row)">
                     经费审批
                   </el-dropdown-item>
                 </el-dropdown-menu>
               </template>
             </el-dropdown>
 
-            <el-button size="small" plain @click="openMaterialPlaceholder(row)">
+            <el-button
+              v-if="canManageMaterial(row)"
+              size="small"
+              plain
+              @click="openMaterialPlaceholder(row)"
+            >
               物资借用
             </el-button>
 
-            <el-dropdown trigger="click">
+            <el-dropdown v-if="showCheckinMenu(row)" trigger="click">
               <el-button
                 size="small"
                 type="success"
@@ -838,9 +948,15 @@ async function readErrorMessage(res: Response) {
               </el-button>
               <template #dropdown>
                 <el-dropdown-menu>
-                  <el-dropdown-item @click="openSettings(row)">签到设置</el-dropdown-item>
-                  <el-dropdown-item @click="openSign(row, 'checkin')">签到</el-dropdown-item>
-                  <el-dropdown-item @click="openSign(row, 'checkout')">签退</el-dropdown-item>
+                  <el-dropdown-item v-if="canManageCheckin(row)" @click="openSettings(row)">
+                    签到设置
+                  </el-dropdown-item>
+                  <el-dropdown-item v-if="canSignActivity(row)" @click="openSign(row, 'checkin')">
+                    签到
+                  </el-dropdown-item>
+                  <el-dropdown-item v-if="canSignActivity(row)" @click="openSign(row, 'checkout')">
+                    签退
+                  </el-dropdown-item>
                 </el-dropdown-menu>
               </template>
             </el-dropdown>
@@ -852,9 +968,13 @@ async function readErrorMessage(res: Response) {
     <el-dialog v-model="createDialogVisible" title="创建活动" width="620px">
       <el-form label-position="top">
         <el-form-item label="主办社团" required>
-          <el-select v-model="createForm.clubId" filterable placeholder="请选择主办社团">
+          <el-select
+            v-model="createForm.clubId"
+            placeholder="请选择可管理的社团"
+            style="width: 100%"
+          >
             <el-option
-              v-for="club in clubOptions"
+              v-for="club in creatableClubs"
               :key="club.id"
               :label="club.name"
               :value="club.id"

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -118,19 +118,21 @@ const currentUserDisplay = computed(() => {
 const currentRoles = computed(() => auth.value?.roles ?? []);
 const creatableClubs = computed<ClubOption[]>(() => {
   const fromRoles = clubIdsWithPermission("activity:create");
-  const clubMap = new Map<number, string>();
-
-  for (const activity of activities.value) {
-    clubMap.set(activity.clubId, activity.clubName || `社团 ${activity.clubId}`);
-  }
 
   if ((auth.value?.permissions ?? []).includes("*")) {
-    return [...clubMap.entries()].map(([id, name]) => ({ id, name })).sort((a, b) => a.id - b.id);
+    return [...clubOptions.value].sort((a, b) => a.id - b.id);
   }
+
+  const clubMap = new Map<number, string>(
+    activities.value.map((activity) => [
+      activity.clubId,
+      activity.clubName || `社团 ${activity.clubId}`,
+    ]),
+  );
 
   return fromRoles.map((id) => ({
     id,
-    name: clubMap.get(id) ?? `社团 ${id}`,
+    name: clubMap.get(id) ?? clubOptions.value.find((club) => club.id === id)?.name ?? `社团 ${id}`,
   }));
 });
 const canCreateActivity = computed(() => hasPermission("activity:create"));
@@ -548,8 +550,7 @@ async function createActivity() {
 }
 
 async function registerActivity(activity: Activity) {
-  const userId = currentUserId.value;
-  if (!userId) {
+  if (!currentUserId.value) {
     ElMessage.warning("请先登录后再报名");
     return;
   }
@@ -560,8 +561,6 @@ async function registerActivity(activity: Activity) {
       `/api/activities/${activity.id}/registrations`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId }),
       },
     );
 

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -359,10 +359,25 @@ function hasScopedPermission(permission: string, clubId: number) {
 
   return currentRoles.value.some((role) => {
     const permissions = role.permissions ?? [];
-    if (!permissions.includes("*") && !permissions.includes(permission)) return false;
     if (permissions.includes("*")) return true;
-    if ((role.scope ?? "").toLowerCase() === "system") return true;
-    return (role.clubIds ?? []).includes(clubId) || role.clubId === clubId;
+    if (!permissions.includes(permission)) return false;
+
+    const code = (role.code ?? "").toUpperCase();
+    const scope = (role.scope ?? "").toLowerCase();
+    const clubIds = role.clubIds ?? [];
+    const matchesClub = clubIds.includes(clubId) || role.clubId === clubId;
+
+    // 与后端 AuthService.RoleAllows 对齐：指导老师、社团范围角色必须匹配社团。
+    if (code === "ADVISOR" || scope === "club") {
+      return matchesClub;
+    }
+
+    // 系统范围角色（如社团管理员的审核权限）可跨社团生效。
+    if (scope === "system") {
+      return true;
+    }
+
+    return matchesClub;
   });
 }
 
@@ -415,6 +430,10 @@ function showBudgetMenu(activity: Activity) {
 
 function showCheckinMenu(activity: Activity) {
   return canManageCheckin(activity) || canSignActivity(activity);
+}
+
+function checkinMenuLabel(activity: Activity) {
+  return canManageCheckin(activity) ? "签到管理" : "签到签退";
 }
 
 async function loadActivities() {
@@ -883,7 +902,7 @@ async function openParticipations(activity: Activity) {
           >
         </template>
       </el-table-column>
-      <el-table-column label="操作" width="360" align="center">
+      <el-table-column label="操作" min-width="380" width="380" align="center" fixed="right">
         <template #default="{ row }">
           <div class="action-buttons">
             <el-dropdown trigger="click">
@@ -944,7 +963,7 @@ async function openParticipations(activity: Activity) {
                 plain
                 :disabled="row.status !== 'published' && row.status !== 'ongoing'"
               >
-                签到管理
+                {{ checkinMenuLabel(row) }}
               </el-button>
               <template #dropdown>
                 <el-dropdown-menu>
@@ -1304,6 +1323,7 @@ async function openParticipations(activity: Activity) {
   margin: 0 auto;
   padding: 0 12px;
   box-sizing: border-box;
+  scrollbar-gutter: stable;
 }
 .toolbar {
   display: flex;
@@ -1324,6 +1344,9 @@ async function openParticipations(activity: Activity) {
 }
 .activity-table {
   width: 100%;
+}
+.activity-table :deep(.el-table__inner-wrapper) {
+  overflow-x: auto;
 }
 .time-range {
   display: inline-block;
@@ -1352,15 +1375,20 @@ async function openParticipations(activity: Activity) {
 }
 .action-buttons {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: center;
   gap: 6px;
+  min-width: 360px;
+  min-height: 32px;
 }
 .action-buttons :deep(.el-dropdown) {
   display: inline-flex;
+  flex-shrink: 0;
 }
 .action-buttons :deep(.el-button) {
   margin-left: 0;
+  flex-shrink: 0;
 }
 .settings-hint {
   margin-bottom: 12px;

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -428,14 +428,6 @@ function showBudgetMenu(activity: Activity) {
   return canApplyBudget(activity) || canReviewBudget(activity);
 }
 
-function showCheckinMenu(activity: Activity) {
-  return canManageCheckin(activity) || canSignActivity(activity);
-}
-
-function checkinMenuLabel(activity: Activity) {
-  return canManageCheckin(activity) ? "签到管理" : "签到签退";
-}
-
 async function loadActivities() {
   loading.value = true;
   error.value = "";
@@ -902,7 +894,7 @@ async function openParticipations(activity: Activity) {
           >
         </template>
       </el-table-column>
-      <el-table-column label="操作" min-width="380" width="380" align="center" fixed="right">
+      <el-table-column label="操作" min-width="420" width="420" align="center" fixed="right">
         <template #default="{ row }">
           <div class="action-buttons">
             <el-dropdown trigger="click">
@@ -956,26 +948,22 @@ async function openParticipations(activity: Activity) {
               物资借用
             </el-button>
 
-            <el-dropdown v-if="showCheckinMenu(row)" trigger="click">
-              <el-button
-                size="small"
-                type="success"
-                plain
-                :disabled="row.status !== 'published' && row.status !== 'ongoing'"
-              >
-                {{ checkinMenuLabel(row) }}
-              </el-button>
+            <el-button
+              v-if="canManageCheckin(row)"
+              size="small"
+              type="warning"
+              plain
+              @click="openSettings(row)"
+            >
+              签到设置
+            </el-button>
+
+            <el-dropdown v-if="canSignActivity(row)" trigger="click">
+              <el-button size="small" type="success" plain>签到签退</el-button>
               <template #dropdown>
                 <el-dropdown-menu>
-                  <el-dropdown-item v-if="canManageCheckin(row)" @click="openSettings(row)">
-                    签到设置
-                  </el-dropdown-item>
-                  <el-dropdown-item v-if="canSignActivity(row)" @click="openSign(row, 'checkin')">
-                    签到
-                  </el-dropdown-item>
-                  <el-dropdown-item v-if="canSignActivity(row)" @click="openSign(row, 'checkout')">
-                    签退
-                  </el-dropdown-item>
+                  <el-dropdown-item @click="openSign(row, 'checkin')">签到</el-dropdown-item>
+                  <el-dropdown-item @click="openSign(row, 'checkout')">签退</el-dropdown-item>
                 </el-dropdown-menu>
               </template>
             </el-dropdown>
@@ -1379,7 +1367,7 @@ async function openParticipations(activity: Activity) {
   justify-content: flex-start;
   align-items: center;
   gap: 6px;
-  min-width: 360px;
+  min-width: 400px;
   min-height: 32px;
 }
 .action-buttons :deep(.el-dropdown) {


### PR DESCRIPTION
## 改动内容

- 更新 OpenAPI：活动创建、审核、签到设置、参与记录、签到/签退、报名声明 `bearerAuth`；移除创建人/审核人/签到人/报名人请求体用户 ID。
- 后端 `ActivitiesController`：写操作与参与记录查询从 Bearer token 解析当前用户，并按权限做社团范围校验。
- 参与记录：管理/审核看全部；其他登录用户仅本人；保留 #105 姓名/学号展示。
- 前端按权限隐藏管理入口；创建人等只读登录态；管理员创建活动社团下拉使用完整社团列表。
- UI：拆分「签到设置」与「签到签退」；缓解布局抖动。
- 跟进 CodeRabbit：对齐参与记录契约、Title 255、报名身份取自 token。

## 改动原因

Issue #103 活动管理缺少完整角色权限边界；并吸收 CodeRabbit 对契约一致性与报名身份的建议。

---

## 关联 Issue

Closes #103

Related to #81

Related to #90

## 审查关注点

- 权限码与社团范围是否正确。
- 身份是否仅来自认证上下文。
- 前端入口与后端校验是否一致。
- CodeRabbit 延后项（#90 主键、角色标签 UI）是否可接受。

## 测试说明

- [x] 后端/前端构建通过
- [x] 多角色手工测试（权限边界）
- [x] 已 rebase 最新 `dev`，并处理 CodeRabbit 采纳项

### 检查清单

- [x] 后端构建通过
- [x] 前端构建通过
- [x] 已本地手工测试主要场景
- [x] 无表结构变化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 活动创建/审核/签到签退/报名与参与记录等操作现按登录态与权限进行访问控制，界面按权限启用或隐藏对应按钮。
* **改进**
  * 创建人/审核人/签到签退用户由服务端从认证信息确定；报名仅提交活动标识；签到/签退仅提交码。
  * 参与记录按权限返回全部或仅本人；鉴权失败按 401/403 规范返回。
* **文档**
  * 同步更新活动接口契约与请求体字段语义，并调整前端 API 调用与模型。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->