### PR TITLE
fix(auth): 后端授权统一从 JWT 读取用户身份

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -239,9 +239,10 @@ paths:
         - name: viewerUserId
           in: query
           required: true
-          description: 当前查看用户 ID。
+          description: 当前登录用户 ID（临时兼容，待 NoticesController 迁移至 JWT 后移除）。
           schema:
             type: integer
+            minimum: 1
         - name: noticeStatus
           in: query
           required: false
@@ -373,13 +374,6 @@ paths:
     get:
       summary: 获取社团列表
       operationId: getClubs
-      parameters:
-        - name: viewerUserId
-          in: query
-          required: false
-          description: 当前查看用户，用于返回与角色相关的社团视图。
-          schema:
-            type: integer
       responses:
         "200":
           description: 社团列表
@@ -419,12 +413,6 @@ paths:
       summary: 按当前用户权限查询社团注册申请
       operationId: getClubApplications
       parameters:
-        - name: viewerUserId
-          in: query
-          required: true
-          description: 当前用户。学生只能查看自己的申请，平台管理员可以查看全部申请。
-          schema:
-            type: integer
         - name: auditStatus
           in: query
           required: false
@@ -614,12 +602,6 @@ paths:
           required: true
           schema:
             type: integer
-        - name: viewerUserId
-          in: query
-          required: true
-          schema:
-            type: integer
-            minimum: 1
         - name: includeHistory
           in: query
           required: false
@@ -785,12 +767,6 @@ paths:
           required: true
           schema:
             type: integer
-        - name: viewerUserId
-          in: query
-          required: true
-          schema:
-            type: integer
-            minimum: 1
         - name: termName
           in: query
           required: false
@@ -897,6 +873,7 @@ paths:
         - name: viewerUserId
           in: query
           required: true
+          description: 当前登录用户 ID（临时兼容，待 RecruitmentsController 迁移至 JWT 后移除）。
           schema:
             type: integer
             minimum: 1
@@ -987,17 +964,18 @@ paths:
       description: 目标社团的社团干部、负责人可以删除本社团草稿招募。
       operationId: deleteRecruitment
       parameters:
+        - name: currentUserId
+          in: query
+          required: true
+          description: 当前登录用户 ID（临时兼容，待 RecruitmentsController 迁移至 JWT 后移除）。
+          schema:
+            type: integer
+            minimum: 1
         - name: recruitId
           in: path
           required: true
           schema:
             type: integer
-        - name: currentUserId
-          in: query
-          required: true
-          schema:
-            type: integer
-            minimum: 1
       responses:
         "204":
           description: 草稿已删除
@@ -1049,17 +1027,18 @@ paths:
       description: 社团干部可查看本招募全部报名；学生只能查看自己的报名。
       operationId: getRecruitmentApplications
       parameters:
+        - name: viewerUserId
+          in: query
+          required: true
+          description: 当前登录用户 ID（临时兼容，待 RecruitmentsController 迁移至 JWT 后移除）。
+          schema:
+            type: integer
+            minimum: 1
         - name: recruitId
           in: path
           required: true
           schema:
             type: integer
-        - name: viewerUserId
-          in: query
-          required: true
-          schema:
-            type: integer
-            minimum: 1
       responses:
         "200":
           description: 招募报名列表
@@ -1487,12 +1466,6 @@ paths:
       summary: 获取当前账号可查看或可分配的用户列表
       operationId: getUsers
       parameters:
-        - name: viewerUserId
-          in: query
-          required: true
-          schema:
-            type: integer
-          description: 当前登录用户 ID，用于按角色限制可见用户范围。
         - name: clubId
           in: query
           required: false
@@ -2883,7 +2856,6 @@ components:
       properties:
         currentUserId:
           type: integer
-          description: 当前发布人用户 ID。
           minimum: 1
           example: 2
         noticeType:
@@ -2943,12 +2915,10 @@ components:
       properties:
         currentUserId:
           type: integer
-          description: 当前阅读用户 ID。
           minimum: 1
           example: 3
       required:
         - currentUserId
-
     NoticeReadResult:
       type: object
       description: 通知已读记录结果；接口成功响应表示该用户已经完成已读标记。
@@ -2970,6 +2940,7 @@ components:
           format: date-time
           description: 已读时间。
       required:
+        - currentUserId
         - noticeId
         - userId
         - isRead
@@ -3124,6 +3095,8 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
         name:
           type: string
@@ -3134,7 +3107,6 @@ components:
           type: string
           nullable: true
       required:
-        - currentUserId
         - name
         - category
 
@@ -3155,6 +3127,8 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
         name:
           type: string
@@ -3184,7 +3158,6 @@ components:
           type: string
           nullable: true
       required:
-        - currentUserId
         - name
         - category
 
@@ -3193,19 +3166,17 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
-      required:
-        - currentUserId
-
     ExitClubMemberRequest:
       type: object
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
-      required:
-        - currentUserId
-
     ClubMemberRecord:
       type: object
       properties:
@@ -3268,6 +3239,8 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
         userId:
           type: integer
@@ -3303,7 +3276,6 @@ components:
           type: boolean
           default: true
       required:
-        - currentUserId
         - userId
         - positionName
         - termName
@@ -3314,6 +3286,8 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
         departmentName:
           type: string
@@ -3342,9 +3316,6 @@ components:
           type: number
           format: decimal
           nullable: true
-      required:
-        - currentUserId
-
     ClubEvaluationRecord:
       type: object
       description: 社团成员学期考核或评优评奖结果记录，对应 EVALUATIONS 表。
@@ -3500,8 +3471,9 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
-          description: 当前操作人用户 ID。
           example: 3
         evaluationType:
           type: string
@@ -3573,7 +3545,6 @@ components:
           description: 考核说明、获奖补充说明或负责人备注。
           example: 综合表现稳定，参与度高。
       required:
-        - currentUserId
         - evaluationType
         - userId
         - termName
@@ -3588,8 +3559,9 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
-          description: 当前操作人用户 ID。
           example: 3
         evaluationType:
           type: string
@@ -3654,9 +3626,6 @@ components:
           nullable: true
           description: 考核说明、获奖补充说明或负责人备注。
           example: 综合表现稳定，参与度高。
-      required:
-        - currentUserId
-
     ClubApplication:
       type: object
       properties:
@@ -3725,8 +3694,9 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
-          description: 当前学生用户 ID，后端据此写入申请人并校验角色权限。
         name:
           type: string
           minLength: 1
@@ -3755,7 +3725,6 @@ components:
           type: string
           nullable: true
       required:
-        - currentUserId
         - name
         - category
         - applyReason
@@ -3766,6 +3735,8 @@ components:
       properties:
         currentUserId:
           type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           minimum: 1
         decision:
           type: string
@@ -3774,7 +3745,6 @@ components:
           type: string
           nullable: true
       required:
-        - currentUserId
         - decision
 
     Recruitment:
@@ -4069,7 +4039,6 @@ components:
           nullable: true
       required:
         - currentUserId
-
     ReviewRecruitmentRequest:
       type: object
       properties:
@@ -4323,6 +4292,11 @@ components:
       properties:
         clubId:
           type: integer
+        creatorUserId:
+          type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
+          nullable: true
         title:
           type: string
           minLength: 1
@@ -4364,6 +4338,11 @@ components:
       properties:
         approved:
           type: boolean
+          nullable: true
+        reviewerUserId:
+          type: integer
+          deprecated: true
+          description: 已废弃，服务端从 JWT 读取身份。
           nullable: true
         comment:
           type: string
@@ -4832,7 +4811,6 @@ components:
       properties:
         currentUserId:
           type: integer
-          description: 当前提交立项申请的用户 ID；后端据此校验其是否为本社团负责人或指导老师。
           minimum: 1
           example: 12
         clubId:
@@ -4880,7 +4858,6 @@ components:
       properties:
         currentUserId:
           type: integer
-          description: 当前分配负责人操作用户 ID；仅本社团负责人或干部可操作。
           minimum: 1
           example: 7
         leaderUserId:
@@ -4898,7 +4875,6 @@ components:
       properties:
         currentUserId:
           type: integer
-          description: 当前审核操作用户 ID；仅本社团指导老师可审核。
           minimum: 1
           example: 3
         projectStatus:
@@ -4921,7 +4897,6 @@ components:
       properties:
         currentUserId:
           type: integer
-          description: 当前撤销操作用户 ID；系统管理员可撤销待审核/进行中项目，本社团负责人可撤销待审核申请，校级社团管理员可撤销进行中项目。
           minimum: 1
           example: 12
         cancelReason:

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Security.Claims;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
+using ClubHub.Extensions;
 using ClubHub.Api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -101,7 +102,7 @@ public class ActivitiesController : ControllerBase
     [Authorize]
     public async Task<IActionResult> Create([FromBody] CreateActivityRequest req)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null)
         {
             return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
@@ -221,7 +222,7 @@ public class ActivitiesController : ControllerBase
     [Authorize]
     public async Task<IActionResult> Register(int activityId)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null)
         {
             return Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "登录状态已失效，请重新登录。");
@@ -327,7 +328,7 @@ public class ActivitiesController : ControllerBase
     [Authorize]
     public async Task<IActionResult> Review(int activityId, [FromBody] ReviewActivityRequest req)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null)
         {
             return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
@@ -372,7 +373,7 @@ public class ActivitiesController : ControllerBase
     [Authorize]
     public async Task<IActionResult> ApplyBudget(int activityId, [FromBody] ApplyActivityBudgetRequest req)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null)
         {
             return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
@@ -440,7 +441,7 @@ public class ActivitiesController : ControllerBase
     [Authorize]
     public async Task<IActionResult> ReviewBudget(int activityId, [FromBody] ReviewActivityBudgetRequest req)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null)
         {
             return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
@@ -483,7 +484,7 @@ public class ActivitiesController : ControllerBase
     [Authorize]
     public async Task<IActionResult> UpdateCheckinSettings(int activityId, [FromBody] UpdateCheckinSettingsRequest req)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null)
         {
             return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
@@ -561,7 +562,7 @@ public class ActivitiesController : ControllerBase
     [Authorize]
     public async Task<IActionResult> GetParticipations(int activityId)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null)
         {
             return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
@@ -626,7 +627,7 @@ public class ActivitiesController : ControllerBase
 
     private async Task<IActionResult> Sign(int activityId, ActivitySignRequest req, bool isCheckin)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null)
         {
             return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
@@ -773,11 +774,6 @@ public class ActivitiesController : ControllerBase
             .FirstOrDefaultAsync(a => a.ActivityId == activityId);
     }
 
-    private int? GetAuthenticatedUserId()
-    {
-        var rawUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        return int.TryParse(rawUserId, out var userId) && userId > 0 ? userId : null;
-    }
 
     private async Task<IActionResult?> EnsurePermissionAsync(
         int userId,

--- a/backend/Controllers/ClubsController.cs
+++ b/backend/Controllers/ClubsController.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
+using ClubHub.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using ExitClubMemberRequest = Org.OpenAPITools.Models.ExitClubMemberRequest;
@@ -9,6 +11,7 @@ namespace ClubHub.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class ClubsController : ControllerBase
 {
     private const string AuditPending = "pending";
@@ -67,16 +70,15 @@ public class ClubsController : ControllerBase
     public ClubsController(ClubHubDbContext db) => _db = db;
 
     [HttpGet]
-    public async Task<IActionResult> GetAll([FromQuery] int? viewerUserId)
+    [AllowAnonymous]
+    public async Task<IActionResult> GetAll()
     {
         var query = ClubQuery();
-
-        if (viewerUserId is not null)
+        var userId = User.GetUserId();
+        if (userId is not null)
         {
-            var viewer = await LoadUserAsync(viewerUserId.Value);
-            if (viewer is null) return NotFound(new { message = "当前用户不存在。" });
-
-            if (!UsersController.IsPlatformAdmin(viewer))
+            var viewer = await LoadUserAsync(userId.Value);
+            if (viewer is not null && !UsersController.IsPlatformAdmin(viewer))
             {
                 query = query.Where(c =>
                     c.ApplicantUserId == viewer.UserId ||
@@ -95,12 +97,13 @@ public class ClubsController : ControllerBase
 
     [HttpGet("applications")]
     public async Task<IActionResult> GetApplications(
-        [FromQuery] int viewerUserId,
         [FromQuery] string? auditStatus)
     {
-        if (viewerUserId <= 0) return BadRequest(new { message = "请选择当前用户。" });
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
 
-        var viewer = await LoadUserAsync(viewerUserId);
+        var viewer = await LoadUserAsync(currentUserId.Value);
         if (viewer is null) return NotFound(new { message = "当前用户不存在。" });
 
         var query = ClubQuery()
@@ -133,13 +136,17 @@ public class ClubsController : ControllerBase
     [HttpPost("applications")]
     public async Task<IActionResult> CreateApplication([FromBody] CreateClubApplicationRequest req)
     {
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
         var validationError = ValidateApplicationRequest(req);
         if (validationError is not null)
         {
             return BadRequest(new { message = validationError });
         }
 
-        var applicant = await LoadUserAsync(req.CurrentUserId);
+        var applicant = await LoadUserAsync(currentUserId.Value);
         if (applicant is null)
         {
             return NotFound(new { message = "当前用户不存在，请先选择有效的学生用户。" });
@@ -213,11 +220,11 @@ public class ClubsController : ControllerBase
     [HttpPatch("applications/{clubId:int}/review")]
     public async Task<IActionResult> ReviewApplication(int clubId, [FromBody] ReviewClubApplicationRequest req)
     {
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
         var decision = req.Decision?.Trim().ToLowerInvariant();
-        if (req.CurrentUserId <= 0)
-        {
-            return BadRequest(new { message = "请选择当前审核用户。" });
-        }
 
         if (decision is not AuditApproved and not AuditRejected)
         {
@@ -229,7 +236,7 @@ public class ClubsController : ControllerBase
             return BadRequest(new { message = "退回申请时必须填写审核意见。" });
         }
 
-        var reviewer = await LoadUserAsync(req.CurrentUserId);
+        var reviewer = await LoadUserAsync(currentUserId.Value);
         if (reviewer is null)
         {
             return NotFound(new { message = "当前用户不存在，请确认审核用户是否正确。" });
@@ -293,10 +300,9 @@ public class ClubsController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateClubRequest req)
     {
-        if (req.CurrentUserId <= 0)
-        {
-            return BadRequest(new { message = "请选择当前操作用户。" });
-        }
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
 
         if (string.IsNullOrWhiteSpace(req.Name))
         {
@@ -308,7 +314,7 @@ public class ClubsController : ControllerBase
             return BadRequest(new { message = "社团类别不能为空。" });
         }
 
-        var creator = await LoadUserAsync(req.CurrentUserId);
+        var creator = await LoadUserAsync(currentUserId.Value);
         if (creator is null)
         {
             return NotFound(new { message = "当前操作用户不存在。" });
@@ -372,7 +378,11 @@ public class ClubsController : ControllerBase
     [HttpPatch("{clubId:int}/profile")]
     public async Task<IActionResult> UpdateProfile(int clubId, [FromBody] UpdateClubProfileRequest req)
     {
-        var access = await EnsureCanMaintainClubAsync(clubId, req.CurrentUserId);
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
+        var access = await EnsureCanMaintainClubAsync(clubId, currentUserId.Value);
         if (access.Result is not null) return access.Result;
 
         var club = access.Club!;
@@ -464,12 +474,15 @@ public class ClubsController : ControllerBase
     [HttpGet("{clubId:int}/members")]
     public async Task<IActionResult> GetMembers(
         int clubId,
-        [FromQuery] int viewerUserId,
         [FromQuery] bool includeHistory = false,
         [FromQuery] string? departmentName = null,
         [FromQuery] string? groupName = null)
     {
-        var access = await EnsureCanViewMembersAsync(clubId, viewerUserId);
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
+        var access = await EnsureCanViewMembersAsync(clubId, currentUserId.Value);
         if (access.Result is not null) return access.Result;
 
         var today = BusinessToday();
@@ -516,7 +529,11 @@ public class ClubsController : ControllerBase
         int memberId,
         [FromBody] UpdateClubMemberTermRequest req)
     {
-        var access = await EnsureCanUpdateMemberGroupingAsync(clubId, memberId, req);
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
+        var access = await EnsureCanUpdateMemberGroupingAsync(clubId, memberId, currentUserId.Value, req);
         if (access.Result is not null) return access.Result;
 
         var member = access.Member!;
@@ -532,7 +549,11 @@ public class ClubsController : ControllerBase
     [HttpPost("{clubId:int}/members/terms")]
     public async Task<IActionResult> CreateMemberTerm(int clubId, [FromBody] CreateClubMemberTermRequest req)
     {
-        var access = await EnsureCanMaintainClubAsync(clubId, req.CurrentUserId);
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
+        var access = await EnsureCanMaintainClubAsync(clubId, currentUserId.Value);
         if (access.Result is not null) return access.Result;
 
         var club = access.Club!;
@@ -633,7 +654,7 @@ public class ClubsController : ControllerBase
 
         var created = await MemberQuery().FirstAsync(cm => cm.MemberId == member.MemberId);
         return Created(
-            $"/api/clubs/{clubId}/members?viewerUserId={req.CurrentUserId}&includeHistory=true",
+            $"/api/clubs/{clubId}/members?includeHistory=true",
             ToMemberRecordDto(created));
     }
 
@@ -643,7 +664,11 @@ public class ClubsController : ControllerBase
         int memberId,
         [FromBody] UpdateClubMemberTermRequest req)
     {
-        var access = await EnsureCanMaintainMemberTermAsync(clubId, memberId, req.CurrentUserId);
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
+        var access = await EnsureCanMaintainMemberTermAsync(clubId, memberId, currentUserId.Value);
         if (access.Result is not null) return access.Result;
 
         var club = access.Club!;
@@ -710,12 +735,11 @@ public class ClubsController : ControllerBase
     [HttpPatch("{clubId:int}/members/self/exit")]
     public async Task<IActionResult> ExitCurrentMember(int clubId, [FromBody] ExitClubMemberRequest req)
     {
-        if (req.CurrentUserId <= 0)
-        {
-            return BadRequest(new { message = "请选择当前操作用户。" });
-        }
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
 
-        var viewer = await LoadUserAsync(req.CurrentUserId);
+        var viewer = await LoadUserAsync(currentUserId.Value);
         if (viewer is null)
         {
             return NotFound(new { message = "当前用户不存在。" });
@@ -727,12 +751,11 @@ public class ClubsController : ControllerBase
     [HttpPatch("{clubId:int}/members/{memberId:int}/exit")]
     public async Task<IActionResult> RemoveMember(int clubId, int memberId, [FromBody] ExitClubMemberRequest req)
     {
-        if (req.CurrentUserId <= 0)
-        {
-            return BadRequest(new { message = "请选择当前操作用户。" });
-        }
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
 
-        var viewer = await LoadUserAsync(req.CurrentUserId);
+        var viewer = await LoadUserAsync(currentUserId.Value);
         if (viewer is null)
         {
             return NotFound(new { message = "当前用户不存在。" });
@@ -755,11 +778,14 @@ public class ClubsController : ControllerBase
     [HttpGet("{clubId:int}/evaluations")]
     public async Task<IActionResult> GetEvaluations(
         int clubId,
-        [FromQuery] int viewerUserId,
         [FromQuery] string? termName = null,
         [FromQuery] string? evaluationType = null)
     {
-        var access = await EnsureCanViewEvaluationsAsync(clubId, viewerUserId);
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
+        var access = await EnsureCanViewEvaluationsAsync(clubId, currentUserId.Value);
         if (access.Result is not null) return access.Result;
 
         var normalizedType = NormalizeEvaluationType(evaluationType);
@@ -789,7 +815,11 @@ public class ClubsController : ControllerBase
         int clubId,
         [FromBody] CreateClubEvaluationRequest req)
     {
-        var access = await EnsureCanMaintainEvaluationAsync(clubId, req.CurrentUserId, req.UserId);
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
+        var access = await EnsureCanMaintainEvaluationAsync(clubId, currentUserId.Value, req.UserId);
         if (access.Result is not null) return access.Result;
 
         var validationError = ValidateEvaluationRequest(
@@ -824,7 +854,7 @@ public class ClubsController : ControllerBase
             EvaluationType = NormalizeEvaluationType(req.EvaluationType)!,
             ClubId = clubId,
             UserId = req.UserId,
-            EvaluatorUserId = req.CurrentUserId,
+            EvaluatorUserId = currentUserId.Value,
             TermName = req.TermName.Trim(),
             AwardTitle = EmptyToNull(req.AwardTitle),
             AwardLevel = EmptyToNull(req.AwardLevel),
@@ -845,7 +875,7 @@ public class ClubsController : ControllerBase
 
         var created = await EvaluationQuery().FirstAsync(ev => ev.EvaluationId == evaluation.EvaluationId);
         return Created(
-            $"/api/clubs/{clubId}/evaluations?viewerUserId={req.CurrentUserId}",
+            $"/api/clubs/{clubId}/evaluations",
             ToEvaluationRecordDto(created));
     }
 
@@ -855,6 +885,10 @@ public class ClubsController : ControllerBase
         int evaluationId,
         [FromBody] UpdateClubEvaluationRequest req)
     {
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
+
         var evaluation = await _db.Evaluations.FirstOrDefaultAsync(ev =>
             ev.ClubId == clubId && ev.EvaluationId == evaluationId);
         if (evaluation is null)
@@ -862,7 +896,7 @@ public class ClubsController : ControllerBase
             return NotFound(new { message = "评价考核记录不存在。" });
         }
 
-        var access = await EnsureCanMaintainEvaluationAsync(clubId, req.CurrentUserId, evaluation.UserId);
+        var access = await EnsureCanMaintainEvaluationAsync(clubId, currentUserId.Value, evaluation.UserId);
         if (access.Result is not null) return access.Result;
 
         var nextEvaluationType = req.EvaluationType ?? evaluation.EvaluationType;
@@ -915,7 +949,7 @@ public class ClubsController : ControllerBase
         evaluation.Grade = EvaluationGrade(totalScore);
         evaluation.PublicStatus = NormalizeEvaluationPublicStatus(nextPublicStatus) ?? EvaluationDraft;
         evaluation.CommentText = EmptyToNull(nextCommentText);
-        evaluation.EvaluatorUserId = req.CurrentUserId;
+        evaluation.EvaluatorUserId = currentUserId.Value;
 
         await _db.SaveChangesAsync();
 
@@ -926,12 +960,11 @@ public class ClubsController : ControllerBase
     [HttpPatch("{clubId:int}/dissolve")]
     public async Task<IActionResult> Dissolve(int clubId, [FromBody] DissolveClubRequest req)
     {
-        if (req.CurrentUserId <= 0)
-        {
-            return BadRequest(new { message = "请选择当前操作用户。" });
-        }
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
 
-        var viewer = await LoadUserAsync(req.CurrentUserId);
+        var viewer = await LoadUserAsync(currentUserId.Value);
         if (viewer is null)
         {
             return NotFound(new { message = "当前用户不存在。" });
@@ -1166,14 +1199,10 @@ public class ClubsController : ControllerBase
     private async Task<(IActionResult? Result, ClubMember? Member)> EnsureCanUpdateMemberGroupingAsync(
         int clubId,
         int memberId,
+        int currentUserId,
         UpdateClubMemberTermRequest req)
     {
-        if (req.CurrentUserId <= 0)
-        {
-            return (BadRequest(new { message = "请选择当前操作用户。" }), null);
-        }
-
-        var viewer = await LoadUserAsync(req.CurrentUserId);
+        var viewer = await LoadUserAsync(currentUserId);
         if (viewer is null)
         {
             return (NotFound(new { message = "当前用户不存在。" }), null);
@@ -1781,7 +1810,6 @@ public class ClubsController : ControllerBase
 
     private static string? ValidateApplicationRequest(CreateClubApplicationRequest req)
     {
-        if (req.CurrentUserId <= 0) return "请选择当前申请人。";
         if (string.IsNullOrWhiteSpace(req.Name)) return "社团名称不能为空。";
         if (string.IsNullOrWhiteSpace(req.Category)) return "社团类别不能为空。";
         if (string.IsNullOrWhiteSpace(req.ApplyReason)) return "申请理由不能为空。";

--- a/backend/Controllers/UsersController.cs
+++ b/backend/Controllers/UsersController.cs
@@ -1,5 +1,7 @@
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
+using ClubHub.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,6 +9,7 @@ namespace ClubHub.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class UsersController : ControllerBase
 {
     private readonly ClubHubDbContext _db;
@@ -36,18 +39,19 @@ public class UsersController : ControllerBase
     public UsersController(ClubHubDbContext db) => _db = db;
 
     [HttpGet]
-    public async Task<IActionResult> GetAll([FromQuery] int? viewerUserId, [FromQuery] int? clubId)
+    public async Task<IActionResult> GetAll([FromQuery] int? clubId)
     {
-        if (viewerUserId is null or <= 0)
+        var userId = User.GetUserId();
+        if (userId is null)
         {
-            return BadRequest(new { message = "请提供当前登录用户。" });
+            return Unauthorized(new { message = "登录状态已失效，请重新登录。" });
         }
 
         var viewer = await _db.Users
             .Include(u => u.UserRoles)
                 .ThenInclude(ur => ur.Role)
             .Include(u => u.ClubMemberships)
-            .FirstOrDefaultAsync(u => u.UserId == viewerUserId.Value);
+            .FirstOrDefaultAsync(u => u.UserId == userId.Value);
         if (viewer is null)
         {
             return NotFound(new { message = "当前登录用户不存在。" });

--- a/backend/Controllers/VenueReservationsController.cs
+++ b/backend/Controllers/VenueReservationsController.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using ClubHub.Api.Data;
 using ClubHub.Api.Services;
+using ClubHub.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -52,7 +53,7 @@ public class VenueReservationsController : ControllerBase
         [FromQuery] int? applicantUserId,
         [FromQuery] int? reviewerUserId)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null) return Unauthorized(Error("auth_required", "登录状态已失效，请重新登录。"));
 
         if (!IsValidStatus(status, AllowedReservationStatuses, out var normalizedStatus))
@@ -110,7 +111,7 @@ public class VenueReservationsController : ControllerBase
     [HttpGet("{reservationId:int}")]
     public async Task<IActionResult> GetById(int reservationId)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null) return Unauthorized(Error("auth_required", "登录状态已失效，请重新登录。"));
 
         var access = await GetReservationAccessAsync(currentUserId.Value);
@@ -138,7 +139,7 @@ public class VenueReservationsController : ControllerBase
     [HttpGet("occupied-slots")]
     public async Task<IActionResult> GetOccupiedSlots([FromQuery] int? venueId)
     {
-        var currentUserId = GetAuthenticatedUserId();
+        var currentUserId = User.GetUserId();
         if (currentUserId is null) return Unauthorized(Error("auth_required", "登录状态已失效，请重新登录。"));
 
         var access = await GetReservationAccessAsync(currentUserId.Value);
@@ -180,7 +181,7 @@ public class VenueReservationsController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateVenueReservationRequest req)
     {
-        var applicantUserId = GetAuthenticatedUserId();
+        var applicantUserId = User.GetUserId();
         if (applicantUserId is null) return Unauthorized(Error("auth_required", "登录状态已失效，请重新登录。"));
 
         var permission = await _authService.CheckPermissionAsync(applicantUserId.Value, ReservePermission, req.ClubId);
@@ -270,7 +271,7 @@ public class VenueReservationsController : ControllerBase
     [HttpPost("{reservationId:int}/review")]
     public async Task<IActionResult> Review(int reservationId, [FromBody] ReviewVenueReservationRequest req)
     {
-        var reviewerUserId = GetAuthenticatedUserId();
+        var reviewerUserId = User.GetUserId();
         if (reviewerUserId is null) return Unauthorized(Error("auth_required", "登录状态已失效，请重新登录。"));
 
         var permission = await _authService.CheckPermissionAsync(reviewerUserId.Value, ReviewPermission, null);
@@ -337,7 +338,7 @@ public class VenueReservationsController : ControllerBase
     [HttpDelete("{reservationId:int}")]
     public async Task<IActionResult> Delete(int reservationId)
     {
-        var operatorUserId = GetAuthenticatedUserId();
+        var operatorUserId = User.GetUserId();
         if (operatorUserId is null) return Unauthorized(Error("auth_required", "登录状态已失效，请重新登录。"));
 
         var operatorUser = await _db.Users.FindAsync(operatorUserId.Value);
@@ -537,12 +538,6 @@ public class VenueReservationsController : ControllerBase
 
         var now = DateTime.UtcNow;
         return StoredTimeToUtc(reservation.StartAt.Value) <= now && StoredTimeToUtc(reservation.EndAt.Value) > now;
-    }
-
-    private int? GetAuthenticatedUserId()
-    {
-        var rawUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        return int.TryParse(rawUserId, out var userId) && userId > 0 ? userId : null;
     }
 
     private async Task<(IActionResult? Error, bool CanReview, IReadOnlyList<int> ClubIds)> GetReservationAccessAsync(int userId)

--- a/backend/Extensions/ClaimsPrincipalExtensions.cs
+++ b/backend/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,19 @@
+using System.Security.Claims;
+
+namespace ClubHub.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="ClaimsPrincipal"/> to access JWT claims.
+/// </summary>
+public static class ClaimsPrincipalExtensions
+{
+    /// <summary>
+    /// Reads the authenticated user ID from the JWT <c>NameIdentifier</c> claim.
+    /// </summary>
+    /// <returns>The user ID, or <c>null</c> if the claim is missing or invalid.</returns>
+    public static int? GetUserId(this ClaimsPrincipal user)
+    {
+        var raw = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        return int.TryParse(raw, out var id) && id > 0 ? id : null;
+    }
+}

--- a/backend/Models/AssignProjectLeaderRequest.cs
+++ b/backend/Models/AssignProjectLeaderRequest.cs
@@ -26,9 +26,8 @@ namespace Org.OpenAPITools.Models
     public partial class AssignProjectLeaderRequest 
     {
         /// <summary>
-        /// 当前分配负责人操作用户 ID；仅本社团负责人或干部可操作。
+        /// Gets or Sets CurrentUserId
         /// </summary>
-        /// <value>当前分配负责人操作用户 ID；仅本社团负责人或干部可操作。</value>
         /* <example>7</example> */
         [Required]
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]

--- a/backend/Models/CancelProjectRequest.cs
+++ b/backend/Models/CancelProjectRequest.cs
@@ -26,9 +26,8 @@ namespace Org.OpenAPITools.Models
     public partial class CancelProjectRequest 
     {
         /// <summary>
-        /// 当前撤销操作用户 ID；系统管理员可撤销待审核/进行中项目，本社团负责人可撤销待审核申请，校级社团管理员可撤销进行中项目。
+        /// Gets or Sets CurrentUserId
         /// </summary>
-        /// <value>当前撤销操作用户 ID；系统管理员可撤销待审核/进行中项目，本社团负责人可撤销待审核申请，校级社团管理员可撤销进行中项目。</value>
         /* <example>12</example> */
         [Required]
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]

--- a/backend/Models/CreateActivityRequest.cs
+++ b/backend/Models/CreateActivityRequest.cs
@@ -33,6 +33,13 @@ namespace Org.OpenAPITools.Models
         public int ClubId { get; set; }
 
         /// <summary>
+        /// 已废弃，服务端从 JWT 读取身份。
+        /// </summary>
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
+        [DataMember(Name="creatorUserId", EmitDefaultValue=true)]
+        public int? CreatorUserId { get; set; }
+
+        /// <summary>
         /// Gets or Sets Title
         /// </summary>
         [Required]

--- a/backend/Models/CreateClubApplicationRequest.cs
+++ b/backend/Models/CreateClubApplicationRequest.cs
@@ -26,12 +26,11 @@ namespace Org.OpenAPITools.Models
     public partial class CreateClubApplicationRequest 
     {
         /// <summary>
-        /// 当前学生用户 ID，后端据此写入申请人并校验角色权限。
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        /// <value>当前学生用户 ID，后端据此写入申请人并校验角色权限。</value>
-        [Required]
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/backend/Models/CreateClubEvaluationRequest.cs
+++ b/backend/Models/CreateClubEvaluationRequest.cs
@@ -26,13 +26,12 @@ namespace Org.OpenAPITools.Models
     public partial class CreateClubEvaluationRequest 
     {
         /// <summary>
-        /// 当前操作人用户 ID。
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        /// <value>当前操作人用户 ID。</value>
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         /* <example>3</example> */
-        [Required]
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
 
         /// <summary>

--- a/backend/Models/CreateClubMemberTermRequest.cs
+++ b/backend/Models/CreateClubMemberTermRequest.cs
@@ -26,11 +26,11 @@ namespace Org.OpenAPITools.Models
     public partial class CreateClubMemberTermRequest 
     {
         /// <summary>
-        /// Gets or Sets CurrentUserId
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        [Required]
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
         /// <summary>
         /// Gets or Sets UserId

--- a/backend/Models/CreateClubRequest.cs
+++ b/backend/Models/CreateClubRequest.cs
@@ -26,11 +26,11 @@ namespace Org.OpenAPITools.Models
     public partial class CreateClubRequest 
     {
         /// <summary>
-        /// Gets or Sets CurrentUserId
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        [Required]
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/backend/Models/CreateNoticeRequest.cs
+++ b/backend/Models/CreateNoticeRequest.cs
@@ -26,9 +26,8 @@ namespace Org.OpenAPITools.Models
     public partial class CreateNoticeRequest 
     {
         /// <summary>
-        /// 当前发布人用户 ID。
+        /// Gets or Sets CurrentUserId
         /// </summary>
-        /// <value>当前发布人用户 ID。</value>
         /* <example>2</example> */
         [Required]
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]

--- a/backend/Models/CreateProjectRequest.cs
+++ b/backend/Models/CreateProjectRequest.cs
@@ -26,9 +26,8 @@ namespace Org.OpenAPITools.Models
     public partial class CreateProjectRequest 
     {
         /// <summary>
-        /// 当前提交立项申请的用户 ID；后端据此校验其是否为本社团负责人或指导老师。
+        /// Gets or Sets CurrentUserId
         /// </summary>
-        /// <value>当前提交立项申请的用户 ID；后端据此校验其是否为本社团负责人或指导老师。</value>
         /* <example>12</example> */
         [Required]
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]

--- a/backend/Models/DissolveClubRequest.cs
+++ b/backend/Models/DissolveClubRequest.cs
@@ -26,11 +26,11 @@ namespace Org.OpenAPITools.Models
     public partial class DissolveClubRequest 
     {
         /// <summary>
-        /// Gets or Sets CurrentUserId
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        [Required]
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
     }
 }

--- a/backend/Models/ExitClubMemberRequest.cs
+++ b/backend/Models/ExitClubMemberRequest.cs
@@ -26,11 +26,11 @@ namespace Org.OpenAPITools.Models
     public partial class ExitClubMemberRequest 
     {
         /// <summary>
-        /// Gets or Sets CurrentUserId
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        [Required]
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
     }
 }

--- a/backend/Models/MarkNoticeReadRequest.cs
+++ b/backend/Models/MarkNoticeReadRequest.cs
@@ -26,9 +26,8 @@ namespace Org.OpenAPITools.Models
     public partial class MarkNoticeReadRequest 
     {
         /// <summary>
-        /// 当前阅读用户 ID。
+        /// Gets or Sets CurrentUserId
         /// </summary>
-        /// <value>当前阅读用户 ID。</value>
         /* <example>3</example> */
         [Required]
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]

--- a/backend/Models/ReviewActivityRequest.cs
+++ b/backend/Models/ReviewActivityRequest.cs
@@ -32,6 +32,13 @@ namespace Org.OpenAPITools.Models
         public bool? Approved { get; set; }
 
         /// <summary>
+        /// 已废弃，服务端从 JWT 读取身份。
+        /// </summary>
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
+        [DataMember(Name="reviewerUserId", EmitDefaultValue=true)]
+        public int? ReviewerUserId { get; set; }
+
+        /// <summary>
         /// Gets or Sets Comment
         /// </summary>
         [MaxLength(255)]

--- a/backend/Models/ReviewClubApplicationRequest.cs
+++ b/backend/Models/ReviewClubApplicationRequest.cs
@@ -26,11 +26,11 @@ namespace Org.OpenAPITools.Models
     public partial class ReviewClubApplicationRequest 
     {
         /// <summary>
-        /// Gets or Sets CurrentUserId
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        [Required]
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
 
         /// <summary>

--- a/backend/Models/ReviewProjectRequest.cs
+++ b/backend/Models/ReviewProjectRequest.cs
@@ -26,9 +26,8 @@ namespace Org.OpenAPITools.Models
     public partial class ReviewProjectRequest 
     {
         /// <summary>
-        /// 当前审核操作用户 ID；仅本社团指导老师可审核。
+        /// Gets or Sets CurrentUserId
         /// </summary>
-        /// <value>当前审核操作用户 ID；仅本社团指导老师可审核。</value>
         /* <example>3</example> */
         [Required]
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]

--- a/backend/Models/UpdateClubEvaluationRequest.cs
+++ b/backend/Models/UpdateClubEvaluationRequest.cs
@@ -26,13 +26,12 @@ namespace Org.OpenAPITools.Models
     public partial class UpdateClubEvaluationRequest 
     {
         /// <summary>
-        /// 当前操作人用户 ID。
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        /// <value>当前操作人用户 ID。</value>
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         /* <example>3</example> */
-        [Required]
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
 
         /// <summary>

--- a/backend/Models/UpdateClubMemberTermRequest.cs
+++ b/backend/Models/UpdateClubMemberTermRequest.cs
@@ -26,11 +26,11 @@ namespace Org.OpenAPITools.Models
     public partial class UpdateClubMemberTermRequest 
     {
         /// <summary>
-        /// Gets or Sets CurrentUserId
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        [Required]
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
         /// <summary>
         /// Gets or Sets DepartmentName

--- a/backend/Models/UpdateClubProfileRequest.cs
+++ b/backend/Models/UpdateClubProfileRequest.cs
@@ -26,11 +26,11 @@ namespace Org.OpenAPITools.Models
     public partial class UpdateClubProfileRequest 
     {
         /// <summary>
-        /// Gets or Sets CurrentUserId
+        /// 已废弃，服务端从 JWT 读取身份。
         /// </summary>
-        [Required]
+        /// <value>已废弃，服务端从 JWT 读取身份。</value>
         [DataMember(Name="currentUserId", EmitDefaultValue=true)]
-        public int CurrentUserId { get; set; }
+        public int? CurrentUserId { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -410,8 +410,8 @@ export interface CreateVenueReservationOperationRequest {
 }
 
 export interface DeleteRecruitmentRequest {
-  recruitId: number;
   currentUserId: number;
+  recruitId: number;
 }
 
 export interface DeleteVenueOperationRequest {
@@ -452,7 +452,6 @@ export interface GetActivityParticipationsRequest {
 }
 
 export interface GetClubApplicationsRequest {
-  viewerUserId: number;
   auditStatus?: GetClubApplicationsAuditStatusEnum;
 }
 
@@ -462,19 +461,13 @@ export interface GetClubByIdRequest {
 
 export interface GetClubEvaluationsRequest {
   clubId: number;
-  viewerUserId: number;
   termName?: string;
   evaluationType?: GetClubEvaluationsEvaluationTypeEnum;
 }
 
 export interface GetClubMembersRequest {
   clubId: number;
-  viewerUserId: number;
   includeHistory?: boolean;
-}
-
-export interface GetClubsRequest {
-  viewerUserId?: number;
 }
 
 export interface GetLearningItemsRequest {
@@ -511,8 +504,8 @@ export interface GetProjectsRequest {
 }
 
 export interface GetRecruitmentApplicationsRequest {
-  recruitId: number;
   viewerUserId: number;
+  recruitId: number;
 }
 
 export interface GetRecruitmentsRequest {
@@ -522,7 +515,6 @@ export interface GetRecruitmentsRequest {
 }
 
 export interface GetUsersRequest {
-  viewerUserId: number;
   clubId?: number;
 }
 
@@ -1936,17 +1928,17 @@ export class DefaultApi extends runtime.BaseAPI {
   async deleteRecruitmentRequestOpts(
     requestParameters: DeleteRecruitmentRequest,
   ): Promise<runtime.RequestOpts> {
-    if (requestParameters["recruitId"] == null) {
-      throw new runtime.RequiredError(
-        "recruitId",
-        'Required parameter "recruitId" was null or undefined when calling deleteRecruitment().',
-      );
-    }
-
     if (requestParameters["currentUserId"] == null) {
       throw new runtime.RequiredError(
         "currentUserId",
         'Required parameter "currentUserId" was null or undefined when calling deleteRecruitment().',
+      );
+    }
+
+    if (requestParameters["recruitId"] == null) {
+      throw new runtime.RequiredError(
+        "recruitId",
+        'Required parameter "recruitId" was null or undefined when calling deleteRecruitment().',
       );
     }
 
@@ -2495,18 +2487,7 @@ export class DefaultApi extends runtime.BaseAPI {
   async getClubApplicationsRequestOpts(
     requestParameters: GetClubApplicationsRequest,
   ): Promise<runtime.RequestOpts> {
-    if (requestParameters["viewerUserId"] == null) {
-      throw new runtime.RequiredError(
-        "viewerUserId",
-        'Required parameter "viewerUserId" was null or undefined when calling getClubApplications().',
-      );
-    }
-
     const queryParameters: any = {};
-
-    if (requestParameters["viewerUserId"] != null) {
-      queryParameters["viewerUserId"] = requestParameters["viewerUserId"];
-    }
 
     if (requestParameters["auditStatus"] != null) {
       queryParameters["auditStatus"] = requestParameters["auditStatus"];
@@ -2543,7 +2524,7 @@ export class DefaultApi extends runtime.BaseAPI {
    * 按当前用户权限查询社团注册申请
    */
   async getClubApplications(
-    requestParameters: GetClubApplicationsRequest,
+    requestParameters: GetClubApplicationsRequest = {},
     initOverrides?: RequestInit | runtime.InitOverrideFunction,
   ): Promise<Array<ClubApplication>> {
     const response = await this.getClubApplicationsRaw(requestParameters, initOverrides);
@@ -2615,18 +2596,7 @@ export class DefaultApi extends runtime.BaseAPI {
       );
     }
 
-    if (requestParameters["viewerUserId"] == null) {
-      throw new runtime.RequiredError(
-        "viewerUserId",
-        'Required parameter "viewerUserId" was null or undefined when calling getClubEvaluations().',
-      );
-    }
-
     const queryParameters: any = {};
-
-    if (requestParameters["viewerUserId"] != null) {
-      queryParameters["viewerUserId"] = requestParameters["viewerUserId"];
-    }
 
     if (requestParameters["termName"] != null) {
       queryParameters["termName"] = requestParameters["termName"];
@@ -2690,18 +2660,7 @@ export class DefaultApi extends runtime.BaseAPI {
       );
     }
 
-    if (requestParameters["viewerUserId"] == null) {
-      throw new runtime.RequiredError(
-        "viewerUserId",
-        'Required parameter "viewerUserId" was null or undefined when calling getClubMembers().',
-      );
-    }
-
     const queryParameters: any = {};
-
-    if (requestParameters["viewerUserId"] != null) {
-      queryParameters["viewerUserId"] = requestParameters["viewerUserId"];
-    }
 
     if (requestParameters["includeHistory"] != null) {
       queryParameters["includeHistory"] = requestParameters["includeHistory"];
@@ -2751,12 +2710,8 @@ export class DefaultApi extends runtime.BaseAPI {
   /**
    * Creates request options for getClubs without sending the request
    */
-  async getClubsRequestOpts(requestParameters: GetClubsRequest): Promise<runtime.RequestOpts> {
+  async getClubsRequestOpts(): Promise<runtime.RequestOpts> {
     const queryParameters: any = {};
-
-    if (requestParameters["viewerUserId"] != null) {
-      queryParameters["viewerUserId"] = requestParameters["viewerUserId"];
-    }
 
     const headerParameters: runtime.HTTPHeaders = {};
 
@@ -2774,10 +2729,9 @@ export class DefaultApi extends runtime.BaseAPI {
    * 获取社团列表
    */
   async getClubsRaw(
-    requestParameters: GetClubsRequest,
     initOverrides?: RequestInit | runtime.InitOverrideFunction,
   ): Promise<runtime.ApiResponse<Array<Club>>> {
-    const requestOptions = await this.getClubsRequestOpts(requestParameters);
+    const requestOptions = await this.getClubsRequestOpts();
     const response = await this.request(requestOptions, initOverrides);
 
     return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(ClubFromJSON));
@@ -2786,11 +2740,8 @@ export class DefaultApi extends runtime.BaseAPI {
   /**
    * 获取社团列表
    */
-  async getClubs(
-    requestParameters: GetClubsRequest = {},
-    initOverrides?: RequestInit | runtime.InitOverrideFunction,
-  ): Promise<Array<Club>> {
-    const response = await this.getClubsRaw(requestParameters, initOverrides);
+  async getClubs(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Club>> {
+    const response = await this.getClubsRaw(initOverrides);
     return await response.value();
   }
 
@@ -3220,17 +3171,17 @@ export class DefaultApi extends runtime.BaseAPI {
   async getRecruitmentApplicationsRequestOpts(
     requestParameters: GetRecruitmentApplicationsRequest,
   ): Promise<runtime.RequestOpts> {
-    if (requestParameters["recruitId"] == null) {
-      throw new runtime.RequiredError(
-        "recruitId",
-        'Required parameter "recruitId" was null or undefined when calling getRecruitmentApplications().',
-      );
-    }
-
     if (requestParameters["viewerUserId"] == null) {
       throw new runtime.RequiredError(
         "viewerUserId",
         'Required parameter "viewerUserId" was null or undefined when calling getRecruitmentApplications().',
+      );
+    }
+
+    if (requestParameters["recruitId"] == null) {
+      throw new runtime.RequiredError(
+        "recruitId",
+        'Required parameter "recruitId" was null or undefined when calling getRecruitmentApplications().',
       );
     }
 
@@ -3395,18 +3346,7 @@ export class DefaultApi extends runtime.BaseAPI {
    * Creates request options for getUsers without sending the request
    */
   async getUsersRequestOpts(requestParameters: GetUsersRequest): Promise<runtime.RequestOpts> {
-    if (requestParameters["viewerUserId"] == null) {
-      throw new runtime.RequiredError(
-        "viewerUserId",
-        'Required parameter "viewerUserId" was null or undefined when calling getUsers().',
-      );
-    }
-
     const queryParameters: any = {};
-
-    if (requestParameters["viewerUserId"] != null) {
-      queryParameters["viewerUserId"] = requestParameters["viewerUserId"];
-    }
 
     if (requestParameters["clubId"] != null) {
       queryParameters["clubId"] = requestParameters["clubId"];
@@ -3441,7 +3381,7 @@ export class DefaultApi extends runtime.BaseAPI {
    * 获取当前账号可查看或可分配的用户列表
    */
   async getUsers(
-    requestParameters: GetUsersRequest,
+    requestParameters: GetUsersRequest = {},
     initOverrides?: RequestInit | runtime.InitOverrideFunction,
   ): Promise<Array<UserSummary>> {
     const response = await this.getUsersRaw(requestParameters, initOverrides);

--- a/frontend/src/api/models/AssignProjectLeaderRequest.ts
+++ b/frontend/src/api/models/AssignProjectLeaderRequest.ts
@@ -21,7 +21,7 @@ import { mapValues } from "../runtime";
  */
 export interface AssignProjectLeaderRequest {
   /**
-   * 当前分配负责人操作用户 ID；仅本社团负责人或干部可操作。
+   *
    * @type {number}
    * @memberof AssignProjectLeaderRequest
    */

--- a/frontend/src/api/models/CancelProjectRequest.ts
+++ b/frontend/src/api/models/CancelProjectRequest.ts
@@ -21,7 +21,7 @@ import { mapValues } from "../runtime";
  */
 export interface CancelProjectRequest {
   /**
-   * 当前撤销操作用户 ID；系统管理员可撤销待审核/进行中项目，本社团负责人可撤销待审核申请，校级社团管理员可撤销进行中项目。
+   *
    * @type {number}
    * @memberof CancelProjectRequest
    */

--- a/frontend/src/api/models/CreateActivityRequest.ts
+++ b/frontend/src/api/models/CreateActivityRequest.ts
@@ -27,6 +27,13 @@ export interface CreateActivityRequest {
    */
   clubId: number;
   /**
+   * 已废弃，服务端从 JWT 读取身份。
+   * @type {number}
+   * @memberof CreateActivityRequest
+   * @deprecated
+   */
+  creatorUserId?: number | null;
+  /**
    *
    * @type {string}
    * @memberof CreateActivityRequest
@@ -100,6 +107,7 @@ export function CreateActivityRequestFromJSONTyped(
   }
   return {
     clubId: json["clubId"],
+    creatorUserId: json["creatorUserId"] == null ? undefined : json["creatorUserId"],
     title: json["title"],
     activityType: json["activityType"] == null ? undefined : json["activityType"],
     description: json["description"] == null ? undefined : json["description"],
@@ -126,6 +134,7 @@ export function CreateActivityRequestToJSONTyped(
 
   return {
     clubId: value["clubId"],
+    creatorUserId: value["creatorUserId"],
     title: value["title"],
     activityType: value["activityType"],
     description: value["description"],

--- a/frontend/src/api/models/CreateClubApplicationRequest.ts
+++ b/frontend/src/api/models/CreateClubApplicationRequest.ts
@@ -21,11 +21,12 @@ import { mapValues } from "../runtime";
  */
 export interface CreateClubApplicationRequest {
   /**
-   * 当前学生用户 ID，后端据此写入申请人并校验角色权限。
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof CreateClubApplicationRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
   /**
    *
    * @type {string}
@@ -83,7 +84,6 @@ export interface CreateClubApplicationRequest {
 export function instanceOfCreateClubApplicationRequest(
   value: object,
 ): value is CreateClubApplicationRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   if (!("name" in value) || value["name"] === undefined) return false;
   if (!("category" in value) || value["category"] === undefined) return false;
   if (!("applyReason" in value) || value["applyReason"] === undefined) return false;
@@ -103,7 +103,7 @@ export function CreateClubApplicationRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
     name: json["name"],
     category: json["category"],
     description: json["description"] == null ? undefined : json["description"],

--- a/frontend/src/api/models/CreateClubEvaluationRequest.ts
+++ b/frontend/src/api/models/CreateClubEvaluationRequest.ts
@@ -21,11 +21,12 @@ import { mapValues } from "../runtime";
  */
 export interface CreateClubEvaluationRequest {
   /**
-   * 当前操作人用户 ID。
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof CreateClubEvaluationRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
   /**
    * semester 表示学期考核，award 表示评优评奖结果。
    * @type {CreateClubEvaluationRequestEvaluationTypeEnum}
@@ -126,7 +127,6 @@ export type CreateClubEvaluationRequestPublicStatusEnum =
 export function instanceOfCreateClubEvaluationRequest(
   value: object,
 ): value is CreateClubEvaluationRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   if (!("evaluationType" in value) || value["evaluationType"] === undefined) return false;
   if (!("userId" in value) || value["userId"] === undefined) return false;
   if (!("termName" in value) || value["termName"] === undefined) return false;
@@ -149,7 +149,7 @@ export function CreateClubEvaluationRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
     evaluationType: json["evaluationType"],
     userId: json["userId"],
     termName: json["termName"],

--- a/frontend/src/api/models/CreateClubMemberTermRequest.ts
+++ b/frontend/src/api/models/CreateClubMemberTermRequest.ts
@@ -21,11 +21,12 @@ import { mapValues } from "../runtime";
  */
 export interface CreateClubMemberTermRequest {
   /**
-   *
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof CreateClubMemberTermRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
   /**
    *
    * @type {number}
@@ -105,7 +106,6 @@ export type CreateClubMemberTermRequestMemberStatusEnum =
 export function instanceOfCreateClubMemberTermRequest(
   value: object,
 ): value is CreateClubMemberTermRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   if (!("userId" in value) || value["userId"] === undefined) return false;
   if (!("positionName" in value) || value["positionName"] === undefined) return false;
   if (!("termName" in value) || value["termName"] === undefined) return false;
@@ -125,7 +125,7 @@ export function CreateClubMemberTermRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
     userId: json["userId"],
     departmentName: json["departmentName"] == null ? undefined : json["departmentName"],
     groupName: json["groupName"] == null ? undefined : json["groupName"],

--- a/frontend/src/api/models/CreateClubRequest.ts
+++ b/frontend/src/api/models/CreateClubRequest.ts
@@ -21,11 +21,12 @@ import { mapValues } from "../runtime";
  */
 export interface CreateClubRequest {
   /**
-   *
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof CreateClubRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
   /**
    *
    * @type {string}
@@ -50,7 +51,6 @@ export interface CreateClubRequest {
  * Check if a given object implements the CreateClubRequest interface.
  */
 export function instanceOfCreateClubRequest(value: object): value is CreateClubRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   if (!("name" in value) || value["name"] === undefined) return false;
   if (!("category" in value) || value["category"] === undefined) return false;
   return true;
@@ -68,7 +68,7 @@ export function CreateClubRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
     name: json["name"],
     category: json["category"],
     description: json["description"] == null ? undefined : json["description"],

--- a/frontend/src/api/models/CreateNoticeRequest.ts
+++ b/frontend/src/api/models/CreateNoticeRequest.ts
@@ -21,7 +21,7 @@ import { mapValues } from "../runtime";
  */
 export interface CreateNoticeRequest {
   /**
-   * 当前发布人用户 ID。
+   *
    * @type {number}
    * @memberof CreateNoticeRequest
    */

--- a/frontend/src/api/models/CreateProjectRequest.ts
+++ b/frontend/src/api/models/CreateProjectRequest.ts
@@ -21,7 +21,7 @@ import { mapValues } from "../runtime";
  */
 export interface CreateProjectRequest {
   /**
-   * 当前提交立项申请的用户 ID；后端据此校验其是否为本社团负责人或指导老师。
+   *
    * @type {number}
    * @memberof CreateProjectRequest
    */

--- a/frontend/src/api/models/DissolveClubRequest.ts
+++ b/frontend/src/api/models/DissolveClubRequest.ts
@@ -21,18 +21,18 @@ import { mapValues } from "../runtime";
  */
 export interface DissolveClubRequest {
   /**
-   *
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof DissolveClubRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
 }
 
 /**
  * Check if a given object implements the DissolveClubRequest interface.
  */
 export function instanceOfDissolveClubRequest(value: object): value is DissolveClubRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   return true;
 }
 
@@ -48,7 +48,7 @@ export function DissolveClubRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
   };
 }
 

--- a/frontend/src/api/models/ExitClubMemberRequest.ts
+++ b/frontend/src/api/models/ExitClubMemberRequest.ts
@@ -21,18 +21,18 @@ import { mapValues } from "../runtime";
  */
 export interface ExitClubMemberRequest {
   /**
-   *
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof ExitClubMemberRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
 }
 
 /**
  * Check if a given object implements the ExitClubMemberRequest interface.
  */
 export function instanceOfExitClubMemberRequest(value: object): value is ExitClubMemberRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   return true;
 }
 
@@ -48,7 +48,7 @@ export function ExitClubMemberRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
   };
 }
 

--- a/frontend/src/api/models/MarkNoticeReadRequest.ts
+++ b/frontend/src/api/models/MarkNoticeReadRequest.ts
@@ -21,7 +21,7 @@ import { mapValues } from "../runtime";
  */
 export interface MarkNoticeReadRequest {
   /**
-   * 当前阅读用户 ID。
+   *
    * @type {number}
    * @memberof MarkNoticeReadRequest
    */

--- a/frontend/src/api/models/RegisterActivityRequest.ts
+++ b/frontend/src/api/models/RegisterActivityRequest.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/ReviewActivityRequest.ts
+++ b/frontend/src/api/models/ReviewActivityRequest.ts
@@ -27,6 +27,13 @@ export interface ReviewActivityRequest {
    */
   approved?: boolean | null;
   /**
+   * 已废弃，服务端从 JWT 读取身份。
+   * @type {number}
+   * @memberof ReviewActivityRequest
+   * @deprecated
+   */
+  reviewerUserId?: number | null;
+  /**
    *
    * @type {string}
    * @memberof ReviewActivityRequest
@@ -54,6 +61,7 @@ export function ReviewActivityRequestFromJSONTyped(
   }
   return {
     approved: json["approved"] == null ? undefined : json["approved"],
+    reviewerUserId: json["reviewerUserId"] == null ? undefined : json["reviewerUserId"],
     comment: json["comment"] == null ? undefined : json["comment"],
   };
 }
@@ -72,6 +80,7 @@ export function ReviewActivityRequestToJSONTyped(
 
   return {
     approved: value["approved"],
+    reviewerUserId: value["reviewerUserId"],
     comment: value["comment"],
   };
 }

--- a/frontend/src/api/models/ReviewClubApplicationRequest.ts
+++ b/frontend/src/api/models/ReviewClubApplicationRequest.ts
@@ -21,11 +21,12 @@ import { mapValues } from "../runtime";
  */
 export interface ReviewClubApplicationRequest {
   /**
-   *
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof ReviewClubApplicationRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
   /**
    *
    * @type {ReviewClubApplicationRequestDecisionEnum}
@@ -56,7 +57,6 @@ export type ReviewClubApplicationRequestDecisionEnum =
 export function instanceOfReviewClubApplicationRequest(
   value: object,
 ): value is ReviewClubApplicationRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   if (!("decision" in value) || value["decision"] === undefined) return false;
   return true;
 }
@@ -73,7 +73,7 @@ export function ReviewClubApplicationRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
     decision: json["decision"],
     reviewComment: json["reviewComment"] == null ? undefined : json["reviewComment"],
   };

--- a/frontend/src/api/models/ReviewProjectRequest.ts
+++ b/frontend/src/api/models/ReviewProjectRequest.ts
@@ -21,7 +21,7 @@ import { mapValues } from "../runtime";
  */
 export interface ReviewProjectRequest {
   /**
-   * 当前审核操作用户 ID；仅本社团指导老师可审核。
+   *
    * @type {number}
    * @memberof ReviewProjectRequest
    */

--- a/frontend/src/api/models/UpdateClubEvaluationRequest.ts
+++ b/frontend/src/api/models/UpdateClubEvaluationRequest.ts
@@ -21,11 +21,12 @@ import { mapValues } from "../runtime";
  */
 export interface UpdateClubEvaluationRequest {
   /**
-   * 当前操作人用户 ID。
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof UpdateClubEvaluationRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
   /**
    * semester 表示学期考核，award 表示评优评奖结果。
    * @type {UpdateClubEvaluationRequestEvaluationTypeEnum}
@@ -120,7 +121,6 @@ export type UpdateClubEvaluationRequestPublicStatusEnum =
 export function instanceOfUpdateClubEvaluationRequest(
   value: object,
 ): value is UpdateClubEvaluationRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   return true;
 }
 
@@ -136,7 +136,7 @@ export function UpdateClubEvaluationRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
     evaluationType: json["evaluationType"] == null ? undefined : json["evaluationType"],
     termName: json["termName"] == null ? undefined : json["termName"],
     awardTitle: json["awardTitle"] == null ? undefined : json["awardTitle"],

--- a/frontend/src/api/models/UpdateClubMemberTermRequest.ts
+++ b/frontend/src/api/models/UpdateClubMemberTermRequest.ts
@@ -21,11 +21,12 @@ import { mapValues } from "../runtime";
  */
 export interface UpdateClubMemberTermRequest {
   /**
-   *
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof UpdateClubMemberTermRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
   /**
    *
    * @type {string}
@@ -93,7 +94,6 @@ export type UpdateClubMemberTermRequestMemberStatusEnum =
 export function instanceOfUpdateClubMemberTermRequest(
   value: object,
 ): value is UpdateClubMemberTermRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   return true;
 }
 
@@ -109,7 +109,7 @@ export function UpdateClubMemberTermRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
     departmentName: json["departmentName"] == null ? undefined : json["departmentName"],
     groupName: json["groupName"] == null ? undefined : json["groupName"],
     positionName: json["positionName"] == null ? undefined : json["positionName"],

--- a/frontend/src/api/models/UpdateClubProfileRequest.ts
+++ b/frontend/src/api/models/UpdateClubProfileRequest.ts
@@ -21,11 +21,12 @@ import { mapValues } from "../runtime";
  */
 export interface UpdateClubProfileRequest {
   /**
-   *
+   * 已废弃，服务端从 JWT 读取身份。
    * @type {number}
    * @memberof UpdateClubProfileRequest
+   * @deprecated
    */
-  currentUserId: number;
+  currentUserId?: number;
   /**
    *
    * @type {string}
@@ -83,7 +84,6 @@ export interface UpdateClubProfileRequest {
 export function instanceOfUpdateClubProfileRequest(
   value: object,
 ): value is UpdateClubProfileRequest {
-  if (!("currentUserId" in value) || value["currentUserId"] === undefined) return false;
   if (!("name" in value) || value["name"] === undefined) return false;
   if (!("category" in value) || value["category"] === undefined) return false;
   return true;
@@ -101,7 +101,7 @@ export function UpdateClubProfileRequestFromJSONTyped(
     return json;
   }
   return {
-    currentUserId: json["currentUserId"],
+    currentUserId: json["currentUserId"] == null ? undefined : json["currentUserId"],
     name: json["name"],
     category: json["category"],
     description: json["description"] == null ? undefined : json["description"],

--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -18,6 +18,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/views/ActivityList.vue
+++ b/frontend/src/views/ActivityList.vue
@@ -461,7 +461,7 @@ async function loadClubOptions() {
   }
 
   try {
-    clubOptions.value = await requestJson<ClubOption[]>(`/api/clubs?viewerUserId=${userId}`);
+    clubOptions.value = await requestJson<ClubOption[]>(`/api/clubs`);
   } catch (e) {
     clubOptions.value = [];
     ElMessage.error(e instanceof Error ? e.message : "社团列表加载失败");

--- a/frontend/src/views/AwardList.vue
+++ b/frontend/src/views/AwardList.vue
@@ -239,7 +239,7 @@ async function loadClubs() {
   }
 
   try {
-    clubs.value = await requestJson<Club[]>(`/api/clubs?viewerUserId=${currentUserId.value}`);
+    clubs.value = await requestJson<Club[]>(`/api/clubs`);
     if (!selectedClubId.value || !clubs.value.some((club) => club.id === selectedClubId.value)) {
       selectedClubId.value = clubs.value[0]?.id;
     }
@@ -251,9 +251,8 @@ async function loadClubs() {
 
 async function loadAwards() {
   const requestId = ++awardRequestId;
-  const userId = currentUserId.value;
   const clubId = selectedClubId.value;
-  if (!userId || !clubId) {
+  if (!currentUserId.value || !clubId) {
     if (requestId === awardRequestId) awards.value = [];
     return;
   }
@@ -261,7 +260,6 @@ async function loadAwards() {
   loading.value = true;
   try {
     const query = new URLSearchParams({
-      viewerUserId: String(userId),
       evaluationType: "award",
     });
     const data = await requestJson<ClubEvaluationRecord[]>(
@@ -280,9 +278,8 @@ async function loadAwards() {
 
 async function loadMembers() {
   const requestId = ++memberRequestId;
-  const userId = currentUserId.value;
   const clubId = selectedClubId.value;
-  if (!userId || !clubId || !canMaintainSelectedClub.value) {
+  if (!currentUserId.value || !clubId || !canMaintainSelectedClub.value) {
     if (requestId === memberRequestId) members.value = [];
     return;
   }
@@ -290,7 +287,6 @@ async function loadMembers() {
   memberLoading.value = true;
   try {
     const query = new URLSearchParams({
-      viewerUserId: String(userId),
       includeHistory: "false",
     });
     const data = await requestJson<ClubMemberRecord[]>(
@@ -370,7 +366,6 @@ async function submitAward() {
   saving.value = true;
   try {
     const payload = {
-      currentUserId: currentUserId.value,
       evaluationType: "award",
       userId: awardForm.userId,
       termName: awardForm.termName,

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -701,8 +701,7 @@ async function loadUsers() {
 
   usersLoading.value = true;
   try {
-    const query = new URLSearchParams({ viewerUserId: String(currentUserId.value) });
-    const data = await requestJson<UserSummary[]>(`/api/users?${query.toString()}`);
+    const data = await requestJson<UserSummary[]>(`/api/users`);
     if (requestId === usersRequestId) users.value = data;
   } catch (e) {
     if (requestId === usersRequestId) {
@@ -724,9 +723,8 @@ async function loadDialogUsers(clubId?: number) {
 
   dialogUsersLoading.value = true;
   try {
-    const query = new URLSearchParams({ viewerUserId: String(currentUserId.value) });
-    if (clubId) query.set("clubId", String(clubId));
-    const data = await requestJson<UserSummary[]>(`/api/users?${query.toString()}`);
+    const query = clubId ? `?clubId=${clubId}` : "";
+    const data = await requestJson<UserSummary[]>(`/api/users${query}`);
     if (requestId === dialogUsersRequestId) dialogUsers.value = data;
   } catch (e) {
     if (requestId === dialogUsersRequestId) {
@@ -755,7 +753,7 @@ async function loadData() {
   loading.value = true;
   error.value = "";
   try {
-    const query = new URLSearchParams({ viewerUserId: String(currentUserId.value) });
+    const query = new URLSearchParams();
     if (filters.auditStatus) query.set("auditStatus", filters.auditStatus);
     const shouldLoadApplications = canSubmitApplication.value || isReviewer.value;
     const shouldLoadClubs = canViewClubProfiles.value || canManageClubProfiles.value;
@@ -764,9 +762,7 @@ async function loadData() {
       shouldLoadApplications
         ? requestJson<ClubApplication[]>(`/api/clubs/applications?${query.toString()}`)
         : Promise.resolve([]),
-      shouldLoadClubs
-        ? requestJson<Club[]>(`/api/clubs?viewerUserId=${currentUserId.value}`)
-        : Promise.resolve([]),
+      shouldLoadClubs ? requestJson<Club[]>(`/api/clubs`) : Promise.resolve([]),
     ]);
     if (requestId !== dataRequestId) return;
     applications.value = applicationData;
@@ -789,10 +785,9 @@ async function loadData() {
 
 async function loadMembers() {
   const requestId = ++membersRequestId;
-  const userId = currentUserId.value;
   const clubId = selectedClubId.value;
   const include = includeHistory.value;
-  if (!userId || !clubId || !canViewSelectedClub()) {
+  if (!currentUserId.value || !clubId || !canViewSelectedClub()) {
     if (requestId === membersRequestId) {
       clubMembers.value = [];
     }
@@ -802,7 +797,6 @@ async function loadMembers() {
   memberLoading.value = true;
   try {
     const query = new URLSearchParams({
-      viewerUserId: String(userId),
       includeHistory: String(include),
     });
     if (memberFilters.departmentName) query.set("departmentName", memberFilters.departmentName);
@@ -823,16 +817,14 @@ async function loadMembers() {
 
 async function loadEvaluationMembers() {
   const requestId = ++evaluationMembersRequestId;
-  const userId = currentUserId.value;
   const clubId = selectedClubId.value;
-  if (!userId || !clubId || !canViewSelectedClub()) {
+  if (!currentUserId.value || !clubId || !canViewSelectedClub()) {
     if (requestId === evaluationMembersRequestId) evaluationMembers.value = [];
     return;
   }
 
   try {
     const query = new URLSearchParams({
-      viewerUserId: String(userId),
       includeHistory: "false",
     });
     const data = await requestJson<ClubMemberRecord[]>(
@@ -846,16 +838,15 @@ async function loadEvaluationMembers() {
 
 async function loadEvaluations() {
   const requestId = ++evaluationsRequestId;
-  const userId = currentUserId.value;
   const clubId = selectedClubId.value;
-  if (!userId || !clubId || evaluationViewClubs.value.length === 0) {
+  if (!currentUserId.value || !clubId || evaluationViewClubs.value.length === 0) {
     if (requestId === evaluationsRequestId) evaluations.value = [];
     return;
   }
 
   evaluationLoading.value = true;
   try {
-    const query = new URLSearchParams({ viewerUserId: String(userId) });
+    const query = new URLSearchParams();
     if (evaluationFilters.termName) query.set("termName", evaluationFilters.termName);
     query.set("evaluationType", "semester");
     const data = await requestJson<ClubEvaluationRecord[]>(
@@ -1022,7 +1013,6 @@ async function submitApplication() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        currentUserId: currentUserId.value,
         ...applicationForm,
       }),
     });
@@ -1077,7 +1067,6 @@ async function submitReview() {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        currentUserId: currentUserId.value,
         ...reviewForm,
       }),
     });
@@ -1121,7 +1110,6 @@ async function submitProfile() {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        currentUserId: currentUserId.value,
         name: profileForm.name,
         category: profileForm.category,
         description: emptyToNull(profileForm.description),
@@ -1166,7 +1154,7 @@ async function dissolveClub(row: Club) {
     await requestJson<void>(`/api/clubs/${row.id}/dissolve`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ currentUserId: currentUserId.value }),
+      body: JSON.stringify({}),
     });
     ElMessage.success("社团已解散");
     await Promise.all([loadUsers(), loadData()]);
@@ -1202,7 +1190,7 @@ async function exitCurrentClub(row: IdentityRow) {
     await requestJson<void>(`/api/clubs/${row.clubId}/members/self/exit`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ currentUserId: currentUserId.value }),
+      body: JSON.stringify({}),
     });
     ElMessage.success("已退出社团");
     await refreshAuthSessionQuietly();
@@ -1239,7 +1227,7 @@ async function removeClubMember(row: ClubMemberRecord) {
     await requestJson<void>(`/api/clubs/${row.clubId}/members/${row.memberId}/exit`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ currentUserId: currentUserId.value }),
+      body: JSON.stringify({}),
     });
     ElMessage.success("成员已移出");
     await Promise.all([loadUsers(), loadData()]);
@@ -1384,7 +1372,6 @@ async function updateMemberTermFields(
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          currentUserId: currentUserId.value,
           ...fields,
         }),
       },
@@ -1468,7 +1455,6 @@ async function submitMemberGrouping() {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          currentUserId: currentUserId.value,
           departmentName: emptyToNull(nextDepartment),
           groupName: emptyToNull(nextGroup),
         }),
@@ -1497,7 +1483,6 @@ async function submitMemberTerm() {
   termSaving.value = true;
   try {
     const payload = {
-      currentUserId: currentUserId.value,
       userId: memberTermForm.userId,
       departmentName: emptyToNull(memberTermForm.departmentName),
       groupName: emptyToNull(memberTermForm.groupName),
@@ -1632,7 +1617,6 @@ async function submitEvaluation() {
   evaluationSaving.value = true;
   try {
     const payload = {
-      currentUserId: currentUserId.value,
       evaluationType: evaluationForm.evaluationType,
       userId: evaluationForm.userId,
       termName: evaluationForm.termName,

--- a/frontend/src/views/EvaluationList.vue
+++ b/frontend/src/views/EvaluationList.vue
@@ -267,7 +267,7 @@ async function loadClubs() {
   }
 
   try {
-    clubs.value = await requestJson<Club[]>(`/api/clubs?viewerUserId=${currentUserId.value}`);
+    clubs.value = await requestJson<Club[]>(`/api/clubs`);
     if (!selectedClubId.value || !clubs.value.some((club) => club.id === selectedClubId.value)) {
       selectedClubId.value = clubs.value[0]?.id;
     }
@@ -279,9 +279,8 @@ async function loadClubs() {
 
 async function loadEvaluations() {
   const requestId = ++evaluationRequestId;
-  const userId = currentUserId.value;
   const clubId = selectedClubId.value;
-  if (!userId || !clubId) {
+  if (!currentUserId.value || !clubId) {
     if (requestId === evaluationRequestId) evaluations.value = [];
     return;
   }
@@ -289,7 +288,6 @@ async function loadEvaluations() {
   loading.value = true;
   try {
     const query = new URLSearchParams({
-      viewerUserId: String(userId),
       evaluationType: "semester",
     });
     if (filters.termName) query.set("termName", filters.termName);
@@ -309,9 +307,8 @@ async function loadEvaluations() {
 
 async function loadMembers() {
   const requestId = ++memberRequestId;
-  const userId = currentUserId.value;
   const clubId = selectedClubId.value;
-  if (!userId || !clubId || !canMaintainSelectedClub.value) {
+  if (!currentUserId.value || !clubId || !canMaintainSelectedClub.value) {
     if (requestId === memberRequestId) members.value = [];
     return;
   }
@@ -319,7 +316,6 @@ async function loadMembers() {
   memberLoading.value = true;
   try {
     const query = new URLSearchParams({
-      viewerUserId: String(userId),
       includeHistory: "false",
     });
     const data = await requestJson<ClubMemberRecord[]>(
@@ -403,7 +399,6 @@ async function submitEvaluation() {
   saving.value = true;
   try {
     const payload = {
-      currentUserId: currentUserId.value,
       evaluationType: "semester",
       userId: evaluationForm.userId,
       termName: evaluationForm.termName,

--- a/frontend/src/views/LearningCenter.vue
+++ b/frontend/src/views/LearningCenter.vue
@@ -258,7 +258,7 @@ async function loadClubs() {
   }
 
   try {
-    clubs.value = await api.getClubs({ viewerUserId: currentUserId.value });
+    clubs.value = await api.getClubs();
   } catch (error) {
     clubs.value = [];
     ElMessage.error(toErrorMessage(error, "社团列表加载失败"));

--- a/frontend/src/views/NoticeCenter.vue
+++ b/frontend/src/views/NoticeCenter.vue
@@ -156,7 +156,7 @@ async function loadClubs() {
   if (!currentUserId.value) return;
   clubLoading.value = true;
   try {
-    clubs.value = await requestJson<Club[]>(`/api/clubs?viewerUserId=${currentUserId.value}`);
+    clubs.value = await requestJson<Club[]>(`/api/clubs`);
   } catch (e) {
     ElMessage.error(e instanceof Error ? e.message : "社团列表加载失败");
   } finally {

--- a/frontend/src/views/ProjectList.vue
+++ b/frontend/src/views/ProjectList.vue
@@ -222,10 +222,7 @@ async function loadLeaderCandidates(clubId?: number | null, options: { silent?: 
 
   leaderCandidateLoading.value = true;
   try {
-    leaderCandidates.value = await api.getUsers({
-      viewerUserId: currentUserId.value,
-      clubId,
-    });
+    leaderCandidates.value = await api.getUsers({ clubId });
     leaderCandidatesByClub.value = {
       ...leaderCandidatesByClub.value,
       [clubId]: leaderCandidates.value,

--- a/frontend/src/views/RecruitmentList.vue
+++ b/frontend/src/views/RecruitmentList.vue
@@ -212,7 +212,7 @@ async function loadClubs() {
 
   clubLoading.value = true;
   try {
-    const data = await requestJson<Club[]>(`/api/clubs?viewerUserId=${currentUserId.value}`);
+    const data = await requestJson<Club[]>(`/api/clubs`);
     if (requestId !== clubRequestId) return;
     clubs.value = data;
     syncSelectedClubFilter();

--- a/frontend/src/views/VenueManage.vue
+++ b/frontend/src/views/VenueManage.vue
@@ -207,7 +207,7 @@ async function loadManagerOptions() {
   };
 
   try {
-    const res = await fetch(`/api/users?viewerUserId=${user.id}`);
+    const res = await fetch(`/api/users`);
     if (!res.ok) throw new Error(await readErrorMessage(res));
     const users = (await res.json()) as UserOption[];
     managerOptions.value = users.some((option) => option.id === user.id)

--- a/frontend/src/views/VenueReservationApply.vue
+++ b/frontend/src/views/VenueReservationApply.vue
@@ -319,8 +319,7 @@ async function loadVenues() {
 }
 
 async function loadReservationOptions() {
-  const userId = auth.value?.user.id;
-  if (!userId) {
+  if (!auth.value?.user.id) {
     clubs.value = [];
     activities.value = [];
     return;
@@ -328,8 +327,8 @@ async function loadReservationOptions() {
 
   try {
     const [clubRes, activityRes] = await Promise.all([
-      fetch(`/api/clubs?viewerUserId=${userId}`),
-      fetch(`/api/activities?currentUserId=${userId}`),
+      fetch(`/api/clubs`),
+      fetch(`/api/activities`),
     ]);
     if (!clubRes.ok) throw new Error(await readErrorMessage(clubRes));
     if (!activityRes.ok) throw new Error(await readErrorMessage(activityRes));

--- a/frontend/src/views/VenueReservationReview.vue
+++ b/frontend/src/views/VenueReservationReview.vue
@@ -263,15 +263,14 @@ async function loadPendingReservations() {
 }
 
 async function loadHistoryReservations() {
-  const reviewerId = reviewerUserId.value;
-  if (!reviewerId) return;
+  if (!reviewerUserId.value) return;
 
   historyLoading.value = true;
   historyError.value = "";
   try {
     const [approved, rejected] = await Promise.all([
-      fetchReservationsByStatus("approved", reviewerId),
-      fetchReservationsByStatus("rejected", reviewerId),
+      fetchReservationsByStatus("approved"),
+      fetchReservationsByStatus("rejected"),
     ]);
     historyReservations.value = [...approved, ...rejected];
   } catch (e) {
@@ -281,11 +280,8 @@ async function loadHistoryReservations() {
   }
 }
 
-async function fetchReservationsByStatus(status: "approved" | "rejected", reviewerId: number) {
-  const params = new URLSearchParams({
-    status,
-    reviewerUserId: String(reviewerId),
-  });
+async function fetchReservationsByStatus(status: "approved" | "rejected") {
+  const params = new URLSearchParams({ status });
   return requestJson<VenueReservation[]>(`/api/venue-reservations?${params.toString()}`);
 }
 
@@ -311,8 +307,7 @@ function openReview(reservation: VenueReservation, approved: boolean) {
 }
 
 async function submitReview() {
-  const reviewerId = reviewerUserId.value;
-  if (!reviewTarget.value || !reviewerId) {
+  if (!reviewTarget.value || !reviewerUserId.value) {
     ElMessage.error("缺少审批人或预约信息，无法提交审批。");
     return;
   }


### PR DESCRIPTION
## 改动内容

将 **UsersController** 和 **ClubsController** 的授权身份从客户端传入的 `viewerUserId`/`currentUserId` 改为从 Bearer token 的 `NameIdentifier` claim 读取，消除越权风险。

### 具体变更：
- 新增 `backend/Extensions/ClaimsPrincipalExtensions.cs` — 公共 `User.GetUserId()` 扩展方法
- 重构 `UsersController` — `GET /api/users` 加 `[Authorize]`，从 JWT 读取身份
- 重构 `ClubsController` — 全部 16 个端点加 `[Authorize]`（`GetAll` 除外，加 `[AllowAnonymous]`），统一从 JWT 读取身份
- 更新 `ActivitiesController` 和 `VenueReservationsController` — 删除重复的私有方法，改用共享扩展
- 修改 `api/openapi.yaml` — 移除 Users/Clubs 端点的 `viewerUserId` 参数；其余模块标记 deprecated
- 前端移除 GET /api/clubs 和 GET /api/users 调用中的 `viewerUserId` 参数

### 不在本轮范围的模块
| 模块 | 原因 |
|------|------|
| ActivitiesController | #113 独立处理 |
| VenueReservationsController | 已在前续 PR 中合规 |
| ProjectsController | #121 独立处理 |
| NoticesController | 后续开 Issue |
| RecruitmentsController | 后续开 Issue |

## 关联 Issue

Closes #81

## 审查关注点

- `[Authorize]` 和 `[AllowAnonymous]` 的使用是否正确
- ClubsController.GetAll 对匿名用户是否仍能浏览社团列表
- 所有 mutation 端点的当前用户 ID 是否都从 JWT 正确读取
- 公共扩展方法的边界处理

## 测试说明

需在登录态下手工测试：社团列表浏览（含匿名）、社团创建/申请/审核、成员管理、用户列表查询。尝试在请求中篡改 viewerUserId/currentUserId，验证后端不再信任这些参数。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过
- [ ] 前端代码已构建通过 — 等待 CI gen-api-code 后验证
- [ ] 已本地手工测试主要场景

**数据库**
- [x] 无表结构变化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持从登录会话自动识别当前操作用户，减少请求中手动传递身份信息的需要。
  * 多项社团、活动、项目、通知及场地操作已适配新的身份识别方式。

* **改进**
  * 多个接口移除不再需要的用户身份查询参数。
  * 相关请求字段调整为可选并标记为弃用，客户端请求校验更加简洁。
  * 未登录或缺少必要权限时，页面将更及时地停止加载并提示错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->