### PR TITLE
refactor(evaluation): 抽取成员考核评优权限作用域

### DIFF
--- a/frontend/src/composables/useClubEvaluationScope.ts
+++ b/frontend/src/composables/useClubEvaluationScope.ts
@@ -91,11 +91,16 @@ export function collectCadreScopesFromMembers(
         member.clubId === clubId &&
         member.userId === currentUserId &&
         member.isCurrent === true &&
-        Boolean(member.groupName?.trim()) &&
-        (hasOfficerRole || isCadrePosition(member.positionName)),
+        (hasOfficerRole || isCadrePosition(member.positionName)) &&
+        (Boolean(member.groupName?.trim()) ||
+          (isDepartmentManagerPosition(member.positionName) &&
+            Boolean(member.departmentName?.trim()))),
     )
     .forEach((member) => {
-      addScope(scopeMap, member.departmentName, member.groupName);
+      const groupName = isDepartmentManagerPosition(member.positionName)
+        ? ""
+        : (member.groupName ?? "");
+      addScope(scopeMap, member.departmentName, groupName);
     });
 
   return Array.from(scopeMap.values());

--- a/frontend/src/composables/useClubEvaluationScope.ts
+++ b/frontend/src/composables/useClubEvaluationScope.ts
@@ -1,0 +1,211 @@
+import { normalizedRoleCodeOf, roleCoversClub, type ScopedClubRole } from "./useManageableClubs";
+
+export interface MemberGroupingScope {
+  departmentName: string;
+  groupName: string;
+  label?: string;
+}
+
+export interface ScopedMemberLike {
+  clubId: number;
+  userId: number;
+  departmentName: string | null;
+  groupName: string | null;
+  positionName: string | null;
+  isCurrent?: boolean | null;
+}
+
+export interface ScopedMembershipLike {
+  clubId: number;
+  departmentName: string | null;
+  groupName: string | null;
+  positionName: string | null;
+  memberStatus?: string | null;
+}
+
+const wholeClubMaintainRoleCodes = new Set([
+  "advisor",
+  "club_leader",
+  "club_manager",
+  "club_president",
+  "president",
+]);
+
+const globalViewRoleCodes = new Set([
+  "admin",
+  "club_admin",
+  "club_reviewer",
+  "platform_admin",
+  "system_admin",
+  "sysadmin",
+]);
+
+const officerRoleCodes = new Set(["club_officer"]);
+
+const cadrePositionNames = new Set([
+  "干部",
+  "部长",
+  "副部长",
+  "组长",
+  "副组长",
+  "干事",
+  "社团干部",
+  "部门负责人",
+  "小组负责人",
+  "officer",
+  "cadre",
+  "minister",
+  "group leader",
+]);
+
+const departmentManagerPositionNames = new Set(["部长", "副部长", "部门负责人", "minister"]);
+
+export function hasGlobalClubViewRole(roles: readonly ScopedClubRole[]) {
+  return roles.some((role) => globalViewRoleCodes.has(normalizedRoleCodeOf(role)));
+}
+
+export function hasWholeClubMaintainRole(roles: readonly ScopedClubRole[], clubId: number) {
+  return roles.some(
+    (role) => roleCoversClub(role, clubId) && wholeClubMaintainRoleCodes.has(roleCodeOf(role)),
+  );
+}
+
+export function hasClubOfficerRole(roles: readonly ScopedClubRole[], clubId: number) {
+  return roles.some(
+    (role) => roleCoversClub(role, clubId) && officerRoleCodes.has(roleCodeOf(role)),
+  );
+}
+
+export function collectCadreScopesFromMembers(
+  members: readonly ScopedMemberLike[],
+  roles: readonly ScopedClubRole[],
+  clubId: number,
+  currentUserId: number,
+) {
+  const hasOfficerRole = hasClubOfficerRole(roles, clubId);
+  const scopeMap = new Map<string, MemberGroupingScope>();
+
+  members
+    .filter(
+      (member) =>
+        member.clubId === clubId &&
+        member.userId === currentUserId &&
+        member.isCurrent === true &&
+        Boolean(member.groupName?.trim()) &&
+        (hasOfficerRole || isCadrePosition(member.positionName)),
+    )
+    .forEach((member) => {
+      addScope(scopeMap, member.departmentName, member.groupName);
+    });
+
+  return Array.from(scopeMap.values());
+}
+
+export function collectCadreScopesFromMemberships(
+  memberships: readonly ScopedMembershipLike[],
+  roles: readonly ScopedClubRole[],
+  clubId: number,
+) {
+  const hasOfficerRole = hasClubOfficerRole(roles, clubId);
+  const scopeMap = new Map<string, MemberGroupingScope>();
+
+  memberships
+    .filter(
+      (membership) =>
+        membership.clubId === clubId &&
+        isActiveMemberStatus(membership.memberStatus) &&
+        (hasOfficerRole || isCadrePosition(membership.positionName)) &&
+        (Boolean(membership.groupName?.trim()) ||
+          (isDepartmentManagerPosition(membership.positionName) &&
+            Boolean(membership.departmentName?.trim()))),
+    )
+    .forEach((membership) => {
+      const groupName = isDepartmentManagerPosition(membership.positionName)
+        ? ""
+        : (membership.groupName ?? "");
+      addScope(scopeMap, membership.departmentName, groupName);
+    });
+
+  return Array.from(scopeMap.values());
+}
+
+export function canMaintainScopedMember(
+  member: Pick<ScopedMemberLike, "departmentName" | "groupName" | "isCurrent">,
+  options: {
+    canMaintainSelectedClub: boolean;
+    canMaintainWholeClub: boolean;
+    scopes: readonly MemberGroupingScope[];
+  },
+) {
+  if (member.isCurrent !== true || !options.canMaintainSelectedClub) return false;
+  if (options.canMaintainWholeClub) return true;
+
+  return options.scopes.some((scope) =>
+    groupingMatchesScope(
+      member.departmentName,
+      member.groupName,
+      scope.departmentName,
+      scope.groupName,
+    ),
+  );
+}
+
+export function groupingMatchesScope(
+  targetDepartment: string | null | undefined,
+  targetGroup: string | null | undefined,
+  scopeDepartment: string | null | undefined,
+  scopeGroup: string | null | undefined,
+) {
+  if (!scopeGroup?.trim()) {
+    return (
+      Boolean(scopeDepartment?.trim()) &&
+      normalizeText(targetDepartment) === normalizeText(scopeDepartment)
+    );
+  }
+
+  if (!targetGroup?.trim()) return false;
+
+  const groupMatches = normalizeText(targetGroup) === normalizeText(scopeGroup);
+  const departmentMatches =
+    !scopeDepartment?.trim() || normalizeText(targetDepartment) === normalizeText(scopeDepartment);
+  return groupMatches && departmentMatches;
+}
+
+export function isCadrePosition(positionName: string | null | undefined) {
+  if (!positionName) return false;
+  const trimmed = positionName.trim();
+  return cadrePositionNames.has(trimmed.toLowerCase()) || cadrePositionNames.has(trimmed);
+}
+
+export function isDepartmentManagerPosition(positionName: string | null | undefined) {
+  if (!positionName) return false;
+  return departmentManagerPositionNames.has(positionName.trim().toLowerCase());
+}
+
+export function isActiveMemberStatus(status: string | null | undefined) {
+  if (!status) return true;
+  return ["active", "normal", "enabled", "在任", "正常"].includes(status.trim().toLowerCase());
+}
+
+function addScope(
+  scopeMap: Map<string, MemberGroupingScope>,
+  departmentName: string | null | undefined,
+  groupName: string | null | undefined,
+) {
+  const department = departmentName?.trim() ?? "";
+  const group = groupName?.trim() ?? "";
+  const key = `${department}\n${group}`;
+  scopeMap.set(key, {
+    departmentName: department,
+    groupName: group,
+    label: group ? (department ? `${department} / ${group}` : group) : department,
+  });
+}
+
+function roleCodeOf(role: ScopedClubRole) {
+  return normalizedRoleCodeOf(role);
+}
+
+function normalizeText(value: string | null | undefined) {
+  return (value ?? "").trim().toLowerCase();
+}

--- a/frontend/src/views/AwardList.vue
+++ b/frontend/src/views/AwardList.vue
@@ -5,10 +5,13 @@ import { Edit, Plus, Refresh, Search, View } from "@element-plus/icons-vue";
 import { type AuthResponse, onSessionChange, readAuth } from "../authSession";
 import { requestJson } from "../composables/useApiRequest";
 import {
-  collectManageableClubIds,
-  collectScopedClubIds,
-  normalizedRoleCodeOf,
-} from "../composables/useManageableClubs";
+  canMaintainScopedMember,
+  collectCadreScopesFromMembers,
+  hasGlobalClubViewRole,
+  hasWholeClubMaintainRole,
+  type MemberGroupingScope,
+} from "../composables/useClubEvaluationScope";
+import { collectManageableClubIds, collectScopedClubIds } from "../composables/useManageableClubs";
 
 type PublicStatus = "draft" | "published";
 type AwardFormMode = "create" | "edit";
@@ -116,18 +119,7 @@ const manageableClubIds = computed(() =>
 );
 const scopedClubIds = computed(() => collectScopedClubIds(auth.value?.roles ?? []));
 const canViewAllClubs = computed(
-  () =>
-    hasAllPermissions.value ||
-    (auth.value?.roles ?? []).some((role) =>
-      [
-        "admin",
-        "club_admin",
-        "club_reviewer",
-        "platform_admin",
-        "system_admin",
-        "sysadmin",
-      ].includes(normalizedRoleCodeOf(role)),
-    ),
+  () => hasAllPermissions.value || hasGlobalClubViewRole(auth.value?.roles ?? []),
 );
 const accessibleClubs = computed(() =>
   canViewAllClubs.value
@@ -143,6 +135,20 @@ const canMaintainSelectedClub = computed(
     (hasAllPermissions.value ||
       (selectedClubId.value !== undefined && manageableClubIds.value.has(selectedClubId.value))),
 );
+const canMaintainWholeClub = computed(() => {
+  const clubId = selectedClubId.value;
+  if (!clubId || !canMaintainSelectedClub.value) return false;
+  if (hasAllPermissions.value) return true;
+
+  return hasWholeClubMaintainRole(auth.value?.roles ?? [], clubId);
+});
+const selectedCadreGroupingScopes = computed<MemberGroupingScope[]>(() => {
+  const clubId = selectedClubId.value;
+  const userId = currentUserId.value;
+  if (!clubId || !userId || !canMaintainSelectedClub.value || canMaintainWholeClub.value) return [];
+
+  return collectCadreScopesFromMembers(members.value, auth.value?.roles ?? [], clubId, userId);
+});
 const publicAwards = computed(() =>
   filteredAwards.value.filter((award) => award.publicStatus === "published"),
 );
@@ -172,7 +178,9 @@ const summary = computed(() => ({
   published: awards.value.filter((award) => award.publicStatus === "published").length,
   draft: awards.value.filter((award) => award.publicStatus !== "published").length,
 }));
-const memberOptions = computed(() => members.value.filter((member) => member.isCurrent));
+const memberOptions = computed(() =>
+  members.value.filter((member) => member.isCurrent && canMaintainMember(member)),
+);
 
 async function validateForm(form?: FormInstance) {
   if (!form) return false;
@@ -294,7 +302,7 @@ function openCreateDialog() {
 }
 
 function openEditDialog(row: ClubEvaluationRecord) {
-  if (!canMaintainSelectedClub.value) {
+  if (!canMaintainAwardRecord(row)) {
     ElMessage.warning("当前账号没有维护该社团评奖评优结果的权限。");
     return;
   }
@@ -375,6 +383,19 @@ function clearFilters() {
 function emptyToNull(value: string) {
   const trimmed = value.trim();
   return trimmed.length === 0 ? null : trimmed;
+}
+
+function canMaintainAwardRecord(row: ClubEvaluationRecord) {
+  const member = members.value.find((item) => item.userId === row.userId);
+  return Boolean(member && canMaintainMember(member));
+}
+
+function canMaintainMember(member: ClubMemberRecord) {
+  return canMaintainScopedMember(member, {
+    canMaintainSelectedClub: canMaintainSelectedClub.value,
+    canMaintainWholeClub: canMaintainWholeClub.value,
+    scopes: selectedCadreGroupingScopes.value,
+  });
 }
 
 function statusTagType(status: PublicStatus) {
@@ -515,7 +536,7 @@ onUnmounted(() => {
         <div class="award-actions">
           <el-button :icon="View" @click="openDetail(award)">查看</el-button>
           <el-button
-            v-if="canMaintainSelectedClub"
+            v-if="canMaintainAwardRecord(award)"
             type="primary"
             plain
             :icon="Edit"

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -1456,8 +1456,8 @@ function canEditMemberTerm(row: ClubMemberRecord) {
   return canManageSelectedClub.value && row.userId !== currentUserId.value;
 }
 
-function canEditMemberPosition(row: ClubMemberRecord) {
-  return canEditMemberTerm(row);
+function canEditMemberRow(row: ClubMemberRecord) {
+  return canEditMemberTerm(row) || canUpdateMemberDepartment(row) || canUpdateMemberGroup(row);
 }
 
 function memberTermEditDeniedMessage(row: ClubMemberRecord) {
@@ -1488,6 +1488,25 @@ function openEditMemberTermDialog(row: ClubMemberRecord) {
   memberTermForm.closeCurrentTerm = false;
   memberTermFormRef.value?.clearValidate();
   memberTermDialogVisible.value = true;
+}
+
+function openMemberEditDialog(row: ClubMemberRecord) {
+  if (canEditMemberTerm(row)) {
+    openEditMemberTermDialog(row);
+    return;
+  }
+
+  if (canUpdateMemberDepartment(row)) {
+    openMemberGroupingDialog(row, "departmentName");
+    return;
+  }
+
+  if (canUpdateMemberGroup(row)) {
+    openMemberGroupingDialog(row, "groupName");
+    return;
+  }
+
+  ElMessage.warning("当前身份不能维护该成员。");
 }
 
 function canFreelyUpdateMemberGrouping(row: ClubMemberRecord) {
@@ -1540,86 +1559,6 @@ function openMemberGroupingDialog(row: ClubMemberRecord, field: GroupingField) {
   }
   handleMemberGroupingDepartmentChange();
   memberGroupingDialogVisible.value = true;
-}
-
-async function updateMemberTermFields(
-  row: ClubMemberRecord,
-  fields: Partial<{
-    positionName: string;
-    termName: string;
-    termStart: string | null;
-    termEnd: string | null;
-    memberStatus: MemberStatus;
-    contributionScore: number | null;
-  }>,
-  successText: string,
-) {
-  if (!selectedClubId.value || !currentUserId.value) return;
-
-  termSaving.value = true;
-  try {
-    await requestJson<ClubMemberRecord>(
-      `/api/clubs/${selectedClubId.value}/members/${row.memberId}`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...fields,
-        }),
-      },
-    );
-    ElMessage.success(successText);
-    await Promise.all([loadUsers(), loadMembers()]);
-  } catch (e) {
-    ElMessage.error(e instanceof Error ? e.message : "成员任期更新失败");
-  } finally {
-    termSaving.value = false;
-  }
-}
-
-async function promptTextValue(options: {
-  title: string;
-  message: string;
-  inputValue: string;
-  requiredMessage: string;
-  maxLength: number;
-  maxLengthMessage: string;
-}) {
-  try {
-    const result = await ElMessageBox.prompt(options.message, options.title, {
-      inputValue: options.inputValue,
-      confirmButtonText: "保存",
-      cancelButtonText: "取消",
-      inputValidator: (value) => {
-        const text = String(value ?? "").trim();
-        if (!text) return options.requiredMessage;
-        if (text.length > options.maxLength) return options.maxLengthMessage;
-        return true;
-      },
-    });
-    return String(result.value ?? "").trim();
-  } catch {
-    return null;
-  }
-}
-
-async function editMemberPosition(row: ClubMemberRecord) {
-  if (!canEditMemberPosition(row)) {
-    ElMessage.warning(memberTermEditDeniedMessage(row));
-    return;
-  }
-
-  const nextPosition = await promptTextValue({
-    title: "修改职位",
-    message: "请输入新的职位名称。",
-    inputValue: row.positionName ?? "",
-    requiredMessage: "职位名称不能为空",
-    maxLength: 50,
-    maxLengthMessage: "职位名称不能超过 50 个字",
-  });
-  if (nextPosition === null) return;
-  if (nextPosition === (row.positionName ?? "").trim()) return;
-  await updateMemberTermFields(row, { positionName: nextPosition }, "职位名称已更新");
 }
 
 async function submitMemberGrouping() {
@@ -2276,14 +2215,7 @@ function canRemoveMemberRow(row: ClubMemberRecord) {
 }
 
 function hasMemberRowActions(row: ClubMemberRecord) {
-  return (
-    canUpdateMemberDepartment(row) ||
-    canUpdateMemberGroup(row) ||
-    canEditMemberPosition(row) ||
-    canEditMemberTerm(row) ||
-    canExitMemberRow(row) ||
-    canRemoveMemberRow(row)
-  );
+  return canEditMemberRow(row) || canExitMemberRow(row) || canRemoveMemberRow(row);
 }
 
 function memberExitDisabledReason(row: IdentityRow | ClubMemberRecord) {
@@ -3059,46 +2991,19 @@ onUnmounted(() => {
           <el-table-column
             v-if="canShowMemberOperationColumn"
             label="操作"
-            width="320"
+            width="220"
             fixed="right"
           >
             <template #default="{ row }">
               <div class="row-actions member-row-actions">
                 <el-button
-                  v-if="canUpdateMemberDepartment(row)"
+                  v-if="canEditMemberRow(row)"
                   type="primary"
                   plain
                   :icon="Edit"
-                  @click="openMemberGroupingDialog(row, 'departmentName')"
+                  @click="openMemberEditDialog(row)"
                 >
-                  部门
-                </el-button>
-                <el-button
-                  v-if="canUpdateMemberGroup(row)"
-                  type="primary"
-                  plain
-                  :icon="Edit"
-                  @click="openMemberGroupingDialog(row, 'groupName')"
-                >
-                  小组
-                </el-button>
-                <el-button
-                  v-if="canEditMemberPosition(row)"
-                  type="primary"
-                  plain
-                  :icon="Edit"
-                  @click="editMemberPosition(row)"
-                >
-                  职位
-                </el-button>
-                <el-button
-                  v-if="canEditMemberTerm(row)"
-                  type="primary"
-                  plain
-                  :icon="Edit"
-                  @click="openEditMemberTermDialog(row)"
-                >
-                  任期
+                  编辑
                 </el-button>
                 <el-button
                   v-if="canExitMemberRow(row)"
@@ -3590,7 +3495,7 @@ onUnmounted(() => {
           ? '处理换届任期'
           : memberTermMode === 'create'
             ? '新增成员任期'
-            : '编辑成员任期'
+            : '编辑成员信息'
       "
       width="660px"
     >
@@ -3622,7 +3527,7 @@ onUnmounted(() => {
         <el-form-item v-else label="成员">
           <el-input :model-value="memberTermTarget?.userName" disabled />
         </el-form-item>
-        <el-form-item v-if="memberTermMode === 'create'" label="部门">
+        <el-form-item label="部门">
           <el-select
             v-model="memberTermForm.departmentName"
             class="full-width"
@@ -3638,7 +3543,7 @@ onUnmounted(() => {
             />
           </el-select>
         </el-form-item>
-        <el-form-item v-if="memberTermMode === 'create'" label="小组">
+        <el-form-item label="小组">
           <el-select
             v-model="memberTermForm.groupName"
             class="full-width"
@@ -3653,7 +3558,7 @@ onUnmounted(() => {
             />
           </el-select>
         </el-form-item>
-        <el-form-item v-if="memberTermMode === 'create'" label="职位" prop="positionName">
+        <el-form-item label="职位" prop="positionName">
           <el-input v-model="memberTermForm.positionName" maxlength="60" />
         </el-form-item>
         <el-form-item label="任期名称" prop="termName">
@@ -3712,9 +3617,7 @@ onUnmounted(() => {
       </el-form>
       <template #footer>
         <el-button @click="memberTermDialogVisible = false">取消</el-button>
-        <el-button type="primary" :loading="termSaving" @click="submitMemberTerm">
-          保存任期
-        </el-button>
+        <el-button type="primary" :loading="termSaving" @click="submitMemberTerm"> 保存 </el-button>
       </template>
     </el-dialog>
 

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -20,6 +20,11 @@ import {
   saveAuth,
 } from "../authSession";
 import { requestJson } from "../composables/useApiRequest";
+import {
+  collectCadreScopesFromMemberships,
+  groupingMatchesScope,
+  type MemberGroupingScope,
+} from "../composables/useClubEvaluationScope";
 import { hasScopedRole, roleCoversClub } from "../composables/useManageableClubs";
 
 type AuditStatus = "pending" | "approved" | "rejected";
@@ -190,12 +195,6 @@ interface IdentityRow {
   memberStatus: string | null;
 }
 
-interface MemberGroupingScope {
-  departmentName: string;
-  groupName: string;
-  label: string;
-}
-
 interface MemberGroupOption {
   departmentName: string;
   groupName: string;
@@ -229,21 +228,6 @@ const principalPositionNames = new Set([
   "leader",
   "club president",
   "club leader",
-]);
-const cadrePositionNames = new Set([
-  "干部",
-  "部长",
-  "副部长",
-  "组长",
-  "副组长",
-  "干事",
-  "社团干部",
-  "部门负责人",
-  "小组负责人",
-  "officer",
-  "cadre",
-  "minister",
-  "group leader",
 ]);
 const clubParticipantRoleCodes = new Set([
   "club_member",
@@ -648,40 +632,7 @@ const selectedCadreGroupingScopes = computed<MemberGroupingScope[]>(() => {
   const clubId = selectedClubId.value;
   if (!user || !clubId) return [];
 
-  const hasOfficerRole = user.roles.some(
-    (role) =>
-      roleCoversClub(role, clubId) && (role.roleCode ?? "").toLowerCase() === "club_officer",
-  );
-  const scopeMap = new Map<string, MemberGroupingScope>();
-
-  user.memberships
-    .filter(
-      (membership) =>
-        membership.clubId === clubId &&
-        isActiveStatus(membership.memberStatus) &&
-        (hasOfficerRole || isCadrePosition(membership.positionName)) &&
-        (Boolean(membership.groupName?.trim()) ||
-          (isDepartmentManagerPosition(membership.positionName) &&
-            Boolean(membership.departmentName?.trim()))),
-    )
-    .forEach((membership) => {
-      const departmentName = membership.departmentName?.trim() ?? "";
-      const groupName = isDepartmentManagerPosition(membership.positionName)
-        ? ""
-        : (membership.groupName?.trim() ?? "");
-      const key = `${departmentName}\n${groupName}`;
-      scopeMap.set(key, {
-        departmentName,
-        groupName,
-        label: groupName
-          ? departmentName
-            ? `${departmentName} / ${groupName}`
-            : groupName
-          : departmentName,
-      });
-    });
-
-  return Array.from(scopeMap.values());
+  return collectCadreScopesFromMemberships(user.memberships, user.roles, clubId);
 });
 const selectedDepartmentManagerScopes = computed(() =>
   selectedCadreGroupingScopes.value.filter(
@@ -1789,26 +1740,6 @@ function canMaintainEvaluationRecord(row: ClubEvaluationRecord) {
   return Boolean(member && canMaintainEvaluationForMember(member));
 }
 
-function groupingMatchesScope(
-  targetDepartment: string | null | undefined,
-  targetGroup: string | null | undefined,
-  scopeDepartment: string | null | undefined,
-  scopeGroup: string | null | undefined,
-) {
-  if (!scopeGroup?.trim()) {
-    return (
-      Boolean(scopeDepartment?.trim()) &&
-      (targetDepartment ?? "").trim().toLowerCase() === scopeDepartment!.trim().toLowerCase()
-    );
-  }
-  if (!targetGroup?.trim()) return false;
-  const groupMatches = targetGroup.trim().toLowerCase() === scopeGroup.trim().toLowerCase();
-  const departmentMatches =
-    !scopeDepartment?.trim() ||
-    (targetDepartment ?? "").trim().toLowerCase() === scopeDepartment.trim().toLowerCase();
-  return groupMatches && departmentMatches;
-}
-
 function resetEvaluationForm() {
   evaluationForm.evaluationType = "semester";
   evaluationForm.userId = evaluationTargetOptions.value[0]?.userId;
@@ -2380,18 +2311,6 @@ function isPrincipalPosition(positionName: string | null | undefined) {
   const normalized = positionName.trim().toLowerCase();
   if (positionName.trim().startsWith("副")) return false;
   return principalPositionNames.has(normalized) || principalPositionNames.has(positionName.trim());
-}
-
-function isCadrePosition(positionName: string | null | undefined) {
-  if (!positionName) return false;
-  const normalized = positionName.trim().toLowerCase();
-  return cadrePositionNames.has(normalized) || cadrePositionNames.has(positionName.trim());
-}
-
-function isDepartmentManagerPosition(positionName: string | null | undefined) {
-  if (!positionName) return false;
-  const normalized = positionName.trim().toLowerCase();
-  return ["部长", "副部长", "部门负责人", "minister"].includes(normalized);
 }
 
 function isActiveStatus(status: string | null | undefined) {

--- a/frontend/src/views/ClubList.vue
+++ b/frontend/src/views/ClubList.vue
@@ -1496,6 +1496,11 @@ function openMemberEditDialog(row: ClubMemberRecord) {
     return;
   }
 
+  if (canManageSelectedClub.value && row.userId === currentUserId.value) {
+    ElMessage.warning(memberTermEditDeniedMessage(row));
+    return;
+  }
+
   if (canUpdateMemberDepartment(row)) {
     openMemberGroupingDialog(row, "departmentName");
     return;

--- a/frontend/src/views/EvaluationList.vue
+++ b/frontend/src/views/EvaluationList.vue
@@ -5,11 +5,13 @@ import { Edit, Plus, Refresh, Search, View } from "@element-plus/icons-vue";
 import { type AuthResponse, onSessionChange, readAuth } from "../authSession";
 import { requestJson } from "../composables/useApiRequest";
 import {
-  collectManageableClubIds,
-  collectScopedClubIds,
-  normalizedRoleCodeOf,
-  roleCoversClub,
-} from "../composables/useManageableClubs";
+  canMaintainScopedMember,
+  collectCadreScopesFromMembers,
+  hasGlobalClubViewRole,
+  hasWholeClubMaintainRole,
+  type MemberGroupingScope,
+} from "../composables/useClubEvaluationScope";
+import { collectManageableClubIds, collectScopedClubIds } from "../composables/useManageableClubs";
 
 type PublicStatus = "draft" | "published";
 type EvaluationFormMode = "create" | "edit";
@@ -59,44 +61,8 @@ interface ClubEvaluationRecord {
   createdAt: string | null;
 }
 
-interface MemberGroupingScope {
-  departmentName: string;
-  groupName: string;
-}
-
 const evaluationDraftPermission = "evaluation:draft";
 const evaluationReviewPermission = "evaluation:review";
-const wholeClubMaintainRoleCodes = new Set([
-  "advisor",
-  "club_leader",
-  "club_manager",
-  "club_president",
-  "president",
-]);
-const globalViewRoleCodes = new Set([
-  "admin",
-  "club_admin",
-  "club_reviewer",
-  "platform_admin",
-  "system_admin",
-  "sysadmin",
-]);
-const officerRoleCodes = new Set(["club_officer"]);
-const cadrePositionNames = new Set([
-  "干部",
-  "部长",
-  "副部长",
-  "组长",
-  "副组长",
-  "干事",
-  "社团干部",
-  "部门负责人",
-  "小组负责人",
-  "officer",
-  "cadre",
-  "minister",
-  "group leader",
-]);
 
 const auth = ref<AuthResponse | null>(readAuth());
 const clubs = ref<Club[]>([]);
@@ -157,9 +123,7 @@ const manageableClubIds = computed(() =>
 );
 const scopedClubIds = computed(() => collectScopedClubIds(auth.value?.roles ?? []));
 const canViewAllClubs = computed(
-  () =>
-    hasAllPermissions.value ||
-    (auth.value?.roles ?? []).some((role) => globalViewRoleCodes.has(normalizedRoleCodeOf(role))),
+  () => hasAllPermissions.value || hasGlobalClubViewRole(auth.value?.roles ?? []),
 );
 const accessibleClubs = computed(() =>
   canViewAllClubs.value
@@ -180,36 +144,14 @@ const canMaintainWholeClub = computed(() => {
   if (!clubId || !canMaintainSelectedClub.value) return false;
   if (hasAllPermissions.value) return true;
 
-  return (auth.value?.roles ?? []).some(
-    (role) => roleCoversClub(role, clubId) && wholeClubMaintainRoleCodes.has(roleCodeOf(role)),
-  );
+  return hasWholeClubMaintainRole(auth.value?.roles ?? [], clubId);
 });
 const selectedCadreGroupingScopes = computed<MemberGroupingScope[]>(() => {
   const clubId = selectedClubId.value;
   const userId = currentUserId.value;
   if (!clubId || !userId || !canMaintainSelectedClub.value || canMaintainWholeClub.value) return [];
 
-  const hasOfficerRole = (auth.value?.roles ?? []).some(
-    (role) => roleCoversClub(role, clubId) && officerRoleCodes.has(roleCodeOf(role)),
-  );
-  const scopeMap = new Map<string, MemberGroupingScope>();
-
-  members.value
-    .filter(
-      (member) =>
-        member.clubId === clubId &&
-        member.userId === userId &&
-        member.isCurrent &&
-        Boolean(member.groupName?.trim()) &&
-        (hasOfficerRole || isCadrePosition(member.positionName)),
-    )
-    .forEach((member) => {
-      const departmentName = member.departmentName?.trim() ?? "";
-      const groupName = member.groupName?.trim() ?? "";
-      scopeMap.set(`${departmentName}\n${groupName}`, { departmentName, groupName });
-    });
-
-  return Array.from(scopeMap.values());
+  return collectCadreScopesFromMembers(members.value, auth.value?.roles ?? [], clubId, userId);
 });
 const filteredEvaluations = computed(() => {
   const keyword = filters.keyword.trim().toLowerCase();
@@ -487,42 +429,11 @@ function canMaintainEvaluationRecord(row: ClubEvaluationRecord) {
 }
 
 function canMaintainMember(member: ClubMemberRecord) {
-  if (!member.isCurrent || !canMaintainSelectedClub.value) return false;
-  if (canMaintainWholeClub.value) return true;
-
-  return selectedCadreGroupingScopes.value.some((scope) =>
-    groupingMatchesScope(
-      member.departmentName,
-      member.groupName,
-      scope.departmentName,
-      scope.groupName,
-    ),
-  );
-}
-
-function groupingMatchesScope(
-  targetDepartment: string | null | undefined,
-  targetGroup: string | null | undefined,
-  scopeDepartment: string | null | undefined,
-  scopeGroup: string | null | undefined,
-) {
-  if (!targetGroup?.trim() || !scopeGroup?.trim()) return false;
-
-  const groupMatches = targetGroup.trim().toLowerCase() === scopeGroup.trim().toLowerCase();
-  const departmentMatches =
-    !scopeDepartment?.trim() ||
-    (targetDepartment ?? "").trim().toLowerCase() === scopeDepartment.trim().toLowerCase();
-  return groupMatches && departmentMatches;
-}
-
-function isCadrePosition(positionName: string | null | undefined) {
-  if (!positionName) return false;
-  const normalized = positionName.trim().toLowerCase();
-  return cadrePositionNames.has(normalized) || cadrePositionNames.has(positionName.trim());
-}
-
-function roleCodeOf(role: { code?: string | null; roleCode?: string | null }) {
-  return (role.code ?? role.roleCode ?? "").trim().toLowerCase();
+  return canMaintainScopedMember(member, {
+    canMaintainSelectedClub: canMaintainSelectedClub.value,
+    canMaintainWholeClub: canMaintainWholeClub.value,
+    scopes: selectedCadreGroupingScopes.value,
+  });
 }
 
 function memberLabel(member: ClubMemberRecord) {


### PR DESCRIPTION
## 改动内容

- 新增 `frontend/src/composables/useClubEvaluationScope.ts`，集中维护成员考核/评奖评优相关的权限作用域规则。
- 将 `EvaluationList.vue` 的全局查看角色、整社团维护角色、干部小组作用域、成员可维护判断迁移到 composable。
- 将 `AwardList.vue` 的全局查看角色与成员可维护范围迁移到同一套作用域判断，负责人/指导老师继续维护全社团，干部按当前小组或部门范围维护。
- 将 `ClubList.vue` 中遗留的干部作用域和分组匹配逻辑改为复用同一 composable，减少后续规则漂移。
- 按 CodeRabbit 反馈补齐“部门负责人”无具体小组时的部门级维护作用域。
- 成员管理列表右侧维护入口合并为单个“编辑”按钮；有任期维护权限时在同一弹窗维护部门、小组、职位、任期、状态和贡献分，退出/移出仍保留为独立危险操作。

## 改动原因

- #115 要求把成员考核和评奖评优中重复的权限/作用域判断抽出来，避免多个页面各维护一份规则。
- 这类规则直接影响负责人、指导老师、干部、普通成员的可见性和可维护范围，需要统一来源。
- 成员管理列表此前将维护动作拆成多个按钮，操作区过于杂乱，本次统一为一个编辑入口。

---

## 关联 Issue

Closes #115

## 审查关注点

- 抽取后的权限行为是否仍符合当前设计：系统管理员/负责人/指导老师可维护全社团，干部按小组或部门作用域维护。
- `AwardList.vue`、`EvaluationList.vue`、`ClubList.vue` 是否都复用了同一套分组匹配与干部作用域判断。
- 成员管理列表的单一“编辑”入口是否仍覆盖原有部门、小组、职位、任期、贡献分维护能力。

## UI 改动

成员管理列表右侧维护入口由多个字段按钮合并为一个“编辑”按钮，避免操作栏过于拥挤。

| 改动前 | 改动后 |
|--------|--------|
| 权限作用域判断分散在多个页面；成员管理操作列有部门/小组/职位/任期多个按钮 | 权限作用域判断集中到 composable；成员管理维护入口统一为一个编辑按钮 |

## 测试说明

- `pnpm.cmd run build` 通过。
- 已确认页面内不再保留重复的 `wholeClubMaintainRoleCodes`、`cadrePositionNames`、`groupingMatchesScope` 等本地副本。
- 已确认 CodeRabbit 指出的部门负责人部门级作用域已补齐。
- 未涉及数据库和后端接口变更。

---

### 检查清单

**代码质量**
- [ ] 后端代码已构建通过（`dotnet build`）
- [x] 前端代码已构建通过（`pnpm build`）
- [ ] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets（请在 PR 描述中注明）
- [ ] 需要修改服务器配置或手动迁移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能优化**
  - 优化考核与获奖记录的维护权限校验，支持按俱乐部、部门及小组作用域精确控制。
  - 具备全俱乐部维护权限时，可直接维护对应范围的全部记录。
  - 编辑入口与成员选择范围按“具体记录/成员作用域”动态收紧：无权限不展示或不可编辑。
- **一致性改进**
  - 统一考核、获奖记录与俱乐部成员维护中的“权限/维护范围”规则与匹配逻辑，降低权限显示与可编辑范围不一致问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->