### PR TITLE
feat(learning): 新增学习资源在线预览

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4411,7 +4411,7 @@ paths:
   /api/learning/items/{itemId}/preview-session:
     post:
       summary: 准备学习资源在线预览会话
-      description: 重新校验登录状态、发布状态、资源可见范围和管理权限；Office 文件首次访问时在受限服务端进程中转换并缓存为私有 OSS PDF。成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。
+      description: 重新校验登录状态、发布状态、资源可见范围和管理权限；成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。Office 在线转换在独立低权限 worker 完成前保持禁用。
       operationId: createLearningPreviewSession
       security:
         - bearerAuth: []
@@ -4442,7 +4442,7 @@ paths:
         "404":
           description: 用户、资源或文件不存在。
         "415":
-          description: 文件格式不受支持，或文件签名与扩展名不一致。
+          description: 文件格式不受支持、文件签名与扩展名不一致，或 Office 在线转换尚未启用。
         "422":
           description: Office 文件转换失败、超时、超出大小或内存限制。
         "503":
@@ -4451,7 +4451,7 @@ paths:
   /api/learning/items/{itemId}/preview:
     get:
       summary: 获取受保护的学习资源在线预览内容
-      description: 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF，DOC、DOCX、PPT、PPTX 返回缓存的 PDF 副本。该操作不会写入下载时间或下载 IP。
+      description: 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF；Office 在线转换在独立低权限 worker 完成前保持禁用。该操作不会写入下载时间或下载 IP。
       operationId: getLearningPreview
       security:
         - previewSessionCookie: []
@@ -4512,7 +4512,31 @@ paths:
         "206":
           description: 符合请求范围的部分预览内容。
           content:
-            application/octet-stream:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/gif:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+            video/mp4:
+              schema:
+                type: string
+                format: binary
+            video/webm:
               schema:
                 type: string
                 format: binary

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4408,6 +4408,129 @@ paths:
         "503":
           description: OSS、ECS RAM 角色临时凭据或对象读取暂不可用。
 
+  /api/learning/items/{itemId}/preview-session:
+    post:
+      summary: 准备学习资源在线预览会话
+      description: 重新校验登录状态、发布状态、资源可见范围和管理权限；Office 文件首次访问时在受限服务端进程中转换并缓存为私有 OSS PDF。成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。
+      operationId: createLearningPreviewSession
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        "204":
+          description: 预览已准备完成，响应设置短时预览 Cookie。
+          headers:
+            X-ClubHub-Preview-Kind:
+              description: 前端展示类型。
+              schema:
+                type: string
+                enum: [image, video, pdf]
+            X-ClubHub-Preview-Converted:
+              description: 是否使用 Office 转换后的 PDF 副本。
+              schema:
+                type: boolean
+        "400":
+          description: 资源 ID 无效或课程没有可预览文件。
+        "403":
+          description: 当前用户不在可见范围内，或没有预览非公开资源的管理权限。
+        "404":
+          description: 用户、资源或文件不存在。
+        "415":
+          description: 文件格式不受支持，或文件签名与扩展名不一致。
+        "422":
+          description: Office 文件转换失败、超时、超出大小或内存限制。
+        "503":
+          description: 私有 OSS 或预览缓存暂不可用。
+
+  /api/learning/items/{itemId}/preview:
+    get:
+      summary: 获取受保护的学习资源在线预览内容
+      description: 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF，DOC、DOCX、PPT、PPTX 返回缓存的 PDF 副本。该操作不会写入下载时间或下载 IP。
+      operationId: getLearningPreview
+      security:
+        - previewSessionCookie: []
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+        - name: Range
+          in: header
+          required: false
+          description: 单段字节范围，例如 bytes=0-1048575。
+          schema:
+            type: string
+      responses:
+        "200":
+          description: 完整预览内容。
+          headers:
+            Accept-Ranges:
+              schema:
+                type: string
+                example: bytes
+            X-Content-Type-Options:
+              schema:
+                type: string
+                example: nosniff
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/gif:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+            video/mp4:
+              schema:
+                type: string
+                format: binary
+            video/webm:
+              schema:
+                type: string
+                format: binary
+        "206":
+          description: 符合请求范围的部分预览内容。
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "401":
+          description: 预览会话缺失或已过期。
+        "403":
+          description: 当前用户不再具备资源预览权限。
+        "404":
+          description: 资源、原文件或预览副本不存在。
+        "415":
+          description: 文件格式不受支持，或文件签名与扩展名不一致。
+        "416":
+          description: Range 请求无效或包含多个范围。
+        "422":
+          description: Office 文件转换失败。
+        "503":
+          description: 私有 OSS 或预览缓存暂不可用。
+
   /api/learning/items/{itemId}:
     put:
       summary: 更新课程或学习资源
@@ -5074,6 +5197,11 @@ components:
       scheme: bearer
       bearerFormat: ClubHub-HMAC
       description: 登录或注册成功后返回的 ClubHub Bearer 令牌。
+    previewSessionCookie:
+      type: apiKey
+      in: cookie
+      name: clubhub-preview
+      description: 由预览会话接口设置、仅对指定资源预览路径有效的短时 HttpOnly Cookie。
 
   schemas:
     ApiError:

--- a/backend.Tests/LearningPreviewTests.cs
+++ b/backend.Tests/LearningPreviewTests.cs
@@ -1,0 +1,172 @@
+using ClubHub.Api.Data.Entities;
+using ClubHub.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace ClubHub.Api.Tests;
+
+public class LearningPreviewTests
+{
+    [Theory]
+    [InlineData(".pdf", "%PDF-1.7", LearningPreviewKind.Pdf, "application/pdf")]
+    [InlineData(".gif", "GIF89a", LearningPreviewKind.Image, "image/gif")]
+    public void Detect_recognizes_safe_native_formats(
+        string extension,
+        string signature,
+        LearningPreviewKind expectedKind,
+        string expectedContentType)
+    {
+        var format = LearningPreviewFormatDetector.Detect(
+            extension,
+            System.Text.Encoding.ASCII.GetBytes(signature));
+
+        Assert.Equal(expectedKind, format.Kind);
+        Assert.Equal(expectedContentType, format.ContentType);
+        Assert.False(format.RequiresOfficeConversion);
+    }
+
+    [Fact]
+    public void Detect_requires_office_conversion_for_docx_zip_signature()
+    {
+        var format = LearningPreviewFormatDetector.Detect(
+            ".docx",
+            new byte[] { 0x50, 0x4b, 0x03, 0x04 });
+
+        Assert.Equal(LearningPreviewKind.Pdf, format.Kind);
+        Assert.True(format.RequiresOfficeConversion);
+    }
+
+    [Fact]
+    public void Detect_rejects_extension_and_content_mismatch()
+    {
+        var exception = Assert.Throws<LearningPreviewException>(() =>
+            LearningPreviewFormatDetector.Detect(".pdf", "not a pdf"u8));
+
+        Assert.Equal(LearningPreviewFailure.Unsupported, exception.Failure);
+        Assert.Contains("扩展名不一致", exception.Message);
+    }
+
+    [Fact]
+    public async Task Converter_rejects_invalid_openxml_before_starting_office_process()
+    {
+        var converter = new OfficePreviewConverter(Options.Create(new LearningPreviewOptions
+        {
+            OfficeExecutablePath = "missing-soffice"
+        }));
+        await using var source = new MemoryStream(new byte[] { 0x50, 0x4b, 0x03, 0x04, 0x00 });
+
+        var exception = await Assert.ThrowsAsync<LearningPreviewException>(() =>
+            converter.ConvertAsync(source, source.Length, ".docx", CancellationToken.None));
+
+        Assert.Equal(LearningPreviewFailure.Unsupported, exception.Failure);
+        Assert.Contains("有效的 Word", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("bytes=0-99", 1000, 0, 99)]
+    [InlineData("bytes=900-", 1000, 900, 999)]
+    [InlineData("bytes=-100", 1000, 900, 999)]
+    [InlineData("bytes=900-2000", 1000, 900, 999)]
+    public void ParseRange_supports_single_http_byte_ranges(
+        string value,
+        long length,
+        long expectedStart,
+        long expectedEnd)
+    {
+        var range = LearningPreviewService.ParseRange(value, length);
+
+        Assert.NotNull(range);
+        Assert.Equal(expectedStart, range.Start);
+        Assert.Equal(expectedEnd, range.End);
+    }
+
+    [Theory]
+    [InlineData("bytes=1000-")]
+    [InlineData("bytes=100-50")]
+    [InlineData("bytes=0-10,20-30")]
+    public void ParseRange_rejects_invalid_or_multiple_ranges(string value)
+    {
+        var exception = Assert.Throws<LearningPreviewException>(() =>
+            LearningPreviewService.ParseRange(value, 1000));
+
+        Assert.Equal(LearningPreviewFailure.InvalidRange, exception.Failure);
+    }
+
+    [Theory]
+    [InlineData(true, true, false, false, false, true)]
+    [InlineData(true, false, true, false, false, true)]
+    [InlineData(true, false, false, true, false, true)]
+    [InlineData(true, false, false, false, false, false)]
+    [InlineData(false, true, true, true, true, false)]
+    public void AccessPolicy_requires_visibility_and_non_public_management(
+        bool visible,
+        bool published,
+        bool manage,
+        bool review,
+        bool delete,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            LearningPreviewAccessPolicy.CanPreview(visible, published, manage, review, delete));
+    }
+
+    [Fact]
+    public void HttpPolicy_sets_inline_and_anti_sniffing_headers()
+    {
+        var context = new DefaultHttpContext();
+
+        LearningPreviewHttpPolicy.Apply(context.Response, "application/pdf", "培训资料.pdf");
+
+        Assert.StartsWith("inline;", context.Response.Headers.ContentDisposition.ToString());
+        Assert.Equal("nosniff", context.Response.Headers["X-Content-Type-Options"]);
+        Assert.Equal("bytes", context.Response.Headers.AcceptRanges);
+        Assert.Contains("no-store", context.Response.Headers.CacheControl.ToString());
+        Assert.Equal("same-origin", context.Response.Headers["Cross-Origin-Resource-Policy"]);
+    }
+
+    [Fact]
+    public void Preview_token_is_item_scoped_and_cannot_be_used_as_login_token()
+    {
+        var service = CreateTokenService();
+        var token = service.CreatePreviewToken(21, 144);
+
+        Assert.Equal(TimeSpan.FromMinutes(30), service.PreviewSessionLifetime);
+        Assert.True(service.TryValidatePreviewToken(token, 144, out var principal));
+        Assert.Equal(21, principal.UserId);
+        Assert.False(service.TryValidatePreviewToken(token, 145, out _));
+        Assert.False(service.TryValidateToken(token, out _));
+    }
+
+    [Fact]
+    public void Login_token_cannot_be_used_as_preview_token()
+    {
+        var service = CreateTokenService();
+        var token = service.CreateToken(new User { UserId = 21, Username = "student" });
+
+        Assert.False(service.TryValidatePreviewToken(token, 144, out _));
+    }
+
+    private static AuthTokenService CreateTokenService()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:TokenSigningKey"] = "test-signing-key-with-sufficient-entropy",
+                ["LearningPreview:SessionLifetimeMinutes"] = "30"
+            })
+            .Build();
+        return new AuthTokenService(configuration, new TestHostEnvironment());
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "ClubHub.Api.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/backend.Tests/LearningPreviewTests.cs
+++ b/backend.Tests/LearningPreviewTests.cs
@@ -150,6 +150,69 @@ public class LearningPreviewTests
         Assert.False(service.TryValidatePreviewToken(token, 144, out _));
     }
 
+    [Fact]
+    public void Preview_session_store_reuses_metadata_only_for_matching_token_user_and_item()
+    {
+        using var store = new LearningPreviewSessionStore();
+        var preview = new PreparedLearningPreview(
+            LearningPreviewKind.Pdf,
+            "application/pdf",
+            1024,
+            "clubs/7/learning/144/preview.pdf",
+            null,
+            false);
+
+        store.Store("signed-preview-token", 21, 144, preview, TimeSpan.FromMinutes(30));
+
+        Assert.True(store.TryGet("signed-preview-token", 21, 144, out var stored));
+        Assert.Same(preview, stored);
+        Assert.False(store.TryGet("different-token", 21, 144, out _));
+        Assert.False(store.TryGet("signed-preview-token", 22, 144, out _));
+        Assert.False(store.TryGet("signed-preview-token", 21, 145, out _));
+    }
+
+    [Fact]
+    public async Task Conversion_limiter_never_exceeds_configured_concurrency()
+    {
+        using var limiter = new OfficeConversionLimiter(2);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstWaveStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sync = new object();
+        var active = 0;
+        var maximumActive = 0;
+        var started = 0;
+
+        var operations = Enumerable.Range(0, 6).Select(_ => limiter.RunAsync(
+            async cancellationToken =>
+            {
+                lock (sync)
+                {
+                    active += 1;
+                    maximumActive = Math.Max(maximumActive, active);
+                    started += 1;
+                    if (started == limiter.MaxConcurrency) firstWaveStarted.TrySetResult();
+                }
+
+                await release.Task.WaitAsync(cancellationToken);
+                lock (sync)
+                {
+                    active -= 1;
+                }
+                return true;
+            },
+            CancellationToken.None)).ToArray();
+
+        await firstWaveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        lock (sync)
+        {
+            Assert.Equal(limiter.MaxConcurrency, active);
+        }
+
+        release.TrySetResult();
+        await Task.WhenAll(operations);
+        Assert.Equal(limiter.MaxConcurrency, maximumActive);
+    }
+
     private static AuthTokenService CreateTokenService()
     {
         var configuration = new ConfigurationBuilder()

--- a/backend/Controllers/LearningController.cs
+++ b/backend/Controllers/LearningController.cs
@@ -48,6 +48,7 @@ public class LearningController : ControllerBase
     private readonly IWebHostEnvironment _environment;
     private readonly ILearningObjectStorage _objectStorage;
     private readonly LearningPreviewService _previewService;
+    private readonly LearningPreviewSessionStore _previewSessionStore;
     private readonly AuthTokenService _authTokenService;
     private readonly ILogger<LearningController> _logger;
 
@@ -57,6 +58,7 @@ public class LearningController : ControllerBase
         IWebHostEnvironment environment,
         ILearningObjectStorage objectStorage,
         LearningPreviewService previewService,
+        LearningPreviewSessionStore previewSessionStore,
         AuthTokenService authTokenService,
         ILogger<LearningController> logger)
     {
@@ -65,6 +67,7 @@ public class LearningController : ControllerBase
         _environment = environment;
         _objectStorage = objectStorage;
         _previewService = previewService;
+        _previewSessionStore = previewSessionStore;
         _authTokenService = authTokenService;
         _logger = logger;
     }
@@ -478,13 +481,19 @@ public class LearningController : ControllerBase
                 access.Item.FileUrl,
                 HttpContext.RequestAborted);
             var previewToken = _authTokenService.CreatePreviewToken(access.UserId, itemId);
+            _previewSessionStore.Store(
+                previewToken,
+                access.UserId,
+                itemId,
+                preview,
+                _authTokenService.PreviewSessionLifetime);
             Response.Cookies.Append(
                 AuthTokenService.PreviewCookieName,
                 previewToken,
                 new CookieOptions
                 {
                     HttpOnly = true,
-                    Secure = Request.IsHttps,
+                    Secure = !_environment.IsDevelopment() || Request.IsHttps,
                     SameSite = SameSiteMode.Strict,
                     Path = $"/api/learning/items/{itemId}/preview",
                     MaxAge = _authTokenService.PreviewSessionLifetime,
@@ -522,23 +531,28 @@ public class LearningController : ControllerBase
         PreparedLearningPreview? preview = null;
         try
         {
-            preview = await _previewService.PrepareAsync(
-                access.Item!.ItemId,
-                access.Item.ClubId,
-                access.Item.FileUrl,
-                HttpContext.RequestAborted);
+            if (!Request.Cookies.TryGetValue(AuthTokenService.PreviewCookieName, out var previewToken) ||
+                !_previewSessionStore.TryGet(
+                    previewToken,
+                    access.UserId,
+                    itemId,
+                    out preview) || preview is null)
+            {
+                return Unauthorized("在线预览会话已失效，请重新打开预览。");
+            }
+            var preparedPreview = preview!;
             LearningPreviewHttpPolicy.Apply(
                 Response,
-                preview.ContentType,
-                BuildPreviewFileName(access.Item.Title, preview));
+                preparedPreview.ContentType,
+                BuildPreviewFileName(access.Item.Title, preparedPreview));
 
             var content = await _previewService.OpenAsync(
-                preview,
+                preparedPreview,
                 Request.Headers.Range.ToString(),
                 HttpContext.RequestAborted);
             if (content.PhysicalPath is not null)
             {
-                return new PhysicalFileResult(content.PhysicalPath, preview.ContentType)
+                return new PhysicalFileResult(content.PhysicalPath, preparedPreview.ContentType)
                 {
                     EnableRangeProcessing = true
                 };
@@ -551,7 +565,7 @@ public class LearningController : ControllerBase
                     $"bytes {content.Range.Start}-{content.Range.End}/{content.Range.TotalLength}";
             }
             Response.ContentLength = content.ContentLength;
-            return File(content.Content!, preview.ContentType);
+            return File(content.Content!, preparedPreview.ContentType);
         }
         catch (LearningPreviewException exception)
         {

--- a/backend/Controllers/LearningController.cs
+++ b/backend/Controllers/LearningController.cs
@@ -47,6 +47,8 @@ public class LearningController : ControllerBase
     private readonly AuthService _authService;
     private readonly IWebHostEnvironment _environment;
     private readonly ILearningObjectStorage _objectStorage;
+    private readonly LearningPreviewService _previewService;
+    private readonly AuthTokenService _authTokenService;
     private readonly ILogger<LearningController> _logger;
 
     public LearningController(
@@ -54,12 +56,16 @@ public class LearningController : ControllerBase
         AuthService authService,
         IWebHostEnvironment environment,
         ILearningObjectStorage objectStorage,
+        LearningPreviewService previewService,
+        AuthTokenService authTokenService,
         ILogger<LearningController> logger)
     {
         _db = db;
         _authService = authService;
         _environment = environment;
         _objectStorage = objectStorage;
+        _previewService = previewService;
+        _authTokenService = authTokenService;
         _logger = logger;
     }
 
@@ -456,6 +462,116 @@ public class LearningController : ControllerBase
     }
 
     /// <summary>
+    /// 校验资源可见范围、准备 Office 转换副本，并建立短时在线预览会话。
+    /// </summary>
+    [HttpPost("items/{itemId:int}/preview-session")]
+    public async Task<IActionResult> CreatePreviewSession(int itemId)
+    {
+        var access = await GetPreviewAccessAsync(itemId);
+        if (access.Error is not null) return access.Error;
+
+        try
+        {
+            var preview = await _previewService.PrepareAsync(
+                access.Item!.ItemId,
+                access.Item.ClubId,
+                access.Item.FileUrl,
+                HttpContext.RequestAborted);
+            var previewToken = _authTokenService.CreatePreviewToken(access.UserId, itemId);
+            Response.Cookies.Append(
+                AuthTokenService.PreviewCookieName,
+                previewToken,
+                new CookieOptions
+                {
+                    HttpOnly = true,
+                    Secure = Request.IsHttps,
+                    SameSite = SameSiteMode.Strict,
+                    Path = $"/api/learning/items/{itemId}/preview",
+                    MaxAge = _authTokenService.PreviewSessionLifetime,
+                    IsEssential = true
+                });
+            Response.Headers["X-ClubHub-Preview-Kind"] = PreviewKindValue(preview.Kind);
+            Response.Headers["X-ClubHub-Preview-Converted"] =
+                preview.IsConverted ? "true" : "false";
+            Response.Headers.CacheControl = "no-store";
+            return NoContent();
+        }
+        catch (LearningPreviewException exception)
+        {
+            return PreviewFailure(exception);
+        }
+        catch (Exception exception) when (IsObjectStorageFailure(exception))
+        {
+            _logger.LogError(exception, "资源 {ItemId} 无法准备在线预览。", itemId);
+            return Problem(
+                statusCode: StatusCodes.Status503ServiceUnavailable,
+                title: "资源预览暂不可用",
+                detail: "无法从私有 OSS 读取或保存预览副本，请稍后重试。");
+        }
+    }
+
+    /// <summary>
+    /// 使用短时预览会话重新校验权限后，以 inline 和 Range 语义返回预览内容。
+    /// </summary>
+    [HttpGet("items/{itemId:int}/preview")]
+    public async Task<IActionResult> GetPreview(int itemId)
+    {
+        var access = await GetPreviewAccessAsync(itemId);
+        if (access.Error is not null) return access.Error;
+
+        PreparedLearningPreview? preview = null;
+        try
+        {
+            preview = await _previewService.PrepareAsync(
+                access.Item!.ItemId,
+                access.Item.ClubId,
+                access.Item.FileUrl,
+                HttpContext.RequestAborted);
+            LearningPreviewHttpPolicy.Apply(
+                Response,
+                preview.ContentType,
+                BuildPreviewFileName(access.Item.Title, preview));
+
+            var content = await _previewService.OpenAsync(
+                preview,
+                Request.Headers.Range.ToString(),
+                HttpContext.RequestAborted);
+            if (content.PhysicalPath is not null)
+            {
+                return new PhysicalFileResult(content.PhysicalPath, preview.ContentType)
+                {
+                    EnableRangeProcessing = true
+                };
+            }
+
+            if (content.Range is not null)
+            {
+                Response.StatusCode = StatusCodes.Status206PartialContent;
+                Response.Headers.ContentRange =
+                    $"bytes {content.Range.Start}-{content.Range.End}/{content.Range.TotalLength}";
+            }
+            Response.ContentLength = content.ContentLength;
+            return File(content.Content!, preview.ContentType);
+        }
+        catch (LearningPreviewException exception)
+        {
+            if (exception.Failure == LearningPreviewFailure.InvalidRange && preview is not null)
+            {
+                Response.Headers.ContentRange = $"bytes */{preview.Length}";
+            }
+            return PreviewFailure(exception);
+        }
+        catch (Exception exception) when (IsObjectStorageFailure(exception))
+        {
+            _logger.LogError(exception, "资源 {ItemId} 无法返回在线预览内容。", itemId);
+            return Problem(
+                statusCode: StatusCodes.Status503ServiceUnavailable,
+                title: "资源预览暂不可用",
+                detail: "无法从私有 OSS 读取预览内容，请稍后重试。");
+        }
+    }
+
+    /// <summary>
     /// 校验资源访问权限后返回历史本地文件，或从私有 OSS 读取对象并流式传输。
     /// </summary>
     [HttpGet("items/{itemId:int}/file")]
@@ -498,6 +614,7 @@ public class LearningController : ControllerBase
                     HttpContext.RequestAborted);
                 var storedObject = await _objectStorage.OpenReadAsync(
                     item.FileUrl!,
+                    null,
                     HttpContext.RequestAborted);
                 if (metadata.ContentLength is > 0)
                 {
@@ -583,6 +700,24 @@ public class LearningController : ControllerBase
         _db.LearningRecords.RemoveRange(records);
         _db.LearningItems.Remove(item);
         await _db.SaveChangesAsync();
+
+        try
+        {
+            await _previewService.RemovePreviewAsync(
+                itemId,
+                clubId,
+                item.FileUrl,
+                HttpContext.RequestAborted);
+        }
+        catch (Exception exception) when (IsObjectStorageFailure(exception))
+        {
+            await transaction.RollbackAsync();
+            _logger.LogError(exception, "资源 {ItemId} 的预览副本无法从对象存储删除。", itemId);
+            return Problem(
+                statusCode: StatusCodes.Status503ServiceUnavailable,
+                title: "资源存储暂不可用",
+                detail: "无法清理资源预览副本，数据库记录已保留，请稍后重试。");
+        }
 
         if (storageReference is not null)
         {
@@ -1535,6 +1670,120 @@ public class LearningController : ControllerBase
     }
 
     /// <summary>
+    /// 在线预览始终重新校验登录用户、资源可见范围和非公开状态的管理权限。
+    /// </summary>
+    private async Task<PreviewAccessResult> GetPreviewAccessAsync(int itemId)
+    {
+        if (itemId <= 0)
+        {
+            return new PreviewAccessResult(
+                null,
+                0,
+                BadRequest("资源 ID 必须大于 0。"));
+        }
+
+        var currentUserId = User.GetUserId();
+        if (currentUserId is null)
+        {
+            return new PreviewAccessResult(
+                null,
+                0,
+                Unauthorized("在线预览会话已失效，请重新打开预览。"));
+        }
+
+        var item = await LoadLearningItemForAccessAsync(itemId);
+        if (item is null)
+        {
+            return new PreviewAccessResult(null, currentUserId.Value, NotFound("学习资源不存在。"));
+        }
+        if (!LearningWorkflow.IsSupportedResourceType(item.ItemType))
+        {
+            return new PreviewAccessResult(
+                null,
+                currentUserId.Value,
+                BadRequest("培训课程没有可在线预览的资源文件。"));
+        }
+
+        var user = await LoadUserAsync(currentUserId.Value);
+        if (user is null)
+        {
+            return new PreviewAccessResult(null, currentUserId.Value, NotFound("当前用户不存在。"));
+        }
+        if (!UsersController.IsActive(user.AccountStatus))
+        {
+            return new PreviewAccessResult(
+                null,
+                currentUserId.Value,
+                StatusCode(StatusCodes.Status403Forbidden, "当前用户账号已停用。"));
+        }
+
+        var permissionRoles = await _authService.GetPermissionRolesAsync(currentUserId.Value);
+        var record = await GetLatestLearningRecordAsync(itemId, currentUserId.Value);
+        var canManage = CanManageLearningItem(permissionRoles, item, currentUserId.Value);
+        var canReview = HasPermission(permissionRoles, ResourceReviewPermission, item.ClubId);
+        var canDelete = HasPermission(permissionRoles, ResourceDeletePermission, item.ClubId);
+        var isVisible = CanViewLearningItem(user, permissionRoles, item, record, canManage);
+        if (!LearningPreviewAccessPolicy.CanPreview(
+                isVisible,
+                LearningWorkflow.IsPublished(item),
+                canManage,
+                canReview,
+                canDelete))
+        {
+            return new PreviewAccessResult(
+                null,
+                currentUserId.Value,
+                StatusCode(
+                    StatusCodes.Status403Forbidden,
+                    "当前用户不在该资源的可见范围内，或没有预览非公开资源的管理权限。"));
+        }
+
+        return new PreviewAccessResult(item, currentUserId.Value, null);
+    }
+
+    private IActionResult PreviewFailure(LearningPreviewException exception)
+    {
+        var statusCode = exception.Failure switch
+        {
+            LearningPreviewFailure.Unsupported => StatusCodes.Status415UnsupportedMediaType,
+            LearningPreviewFailure.InvalidRange => StatusCodes.Status416RangeNotSatisfiable,
+            LearningPreviewFailure.ConversionFailed => StatusCodes.Status422UnprocessableEntity,
+            _ => StatusCodes.Status404NotFound
+        };
+        _logger.LogWarning(
+            exception,
+            "学习资源在线预览失败，类型 {Failure}。",
+            exception.Failure);
+        return StatusCode(statusCode, exception.Message);
+    }
+
+    private static string PreviewKindValue(LearningPreviewKind kind) => kind switch
+    {
+        LearningPreviewKind.Image => "image",
+        LearningPreviewKind.Video => "video",
+        _ => "pdf"
+    };
+
+    private static string BuildPreviewFileName(
+        string title,
+        PreparedLearningPreview preview)
+    {
+        var extension = preview.ContentType switch
+        {
+            "image/jpeg" => ".jpg",
+            "image/png" => ".png",
+            "image/gif" => ".gif",
+            "image/webp" => ".webp",
+            "video/mp4" => ".mp4",
+            "video/webm" => ".webm",
+            _ => ".pdf"
+        };
+        return title.EndsWith(extension, StringComparison.OrdinalIgnoreCase)
+            ? title
+            : $"{title}{extension}";
+    }
+
+    /// <summary>
     /// 返回当前用户不能学习或下载资源的原因；允许访问时返回空。
     /// </summary>
     private static EnrollmentDecision? GetLearningAccessDecision(
@@ -2196,4 +2445,9 @@ public class LearningController : ControllerBase
         (value ?? string.Empty).Trim().ToLowerInvariant();
 
     private sealed record EnrollmentDecision(int StatusCode, string Message);
+
+    private sealed record PreviewAccessResult(
+        DbLearningItem? Item,
+        int UserId,
+        IActionResult? Error);
 }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,9 @@ RUN dotnet publish backend/ClubHub.Api.csproj -c Release -o /app --no-restore
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libreoffice-writer libreoffice-impress fonts-noto-cjk \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /app .
 EXPOSE 5000

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,9 +8,6 @@ RUN dotnet publish backend/ClubHub.Api.csproj -c Release -o /app --no-restore
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends libreoffice-writer libreoffice-impress fonts-noto-cjk \
-    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /app .
 EXPOSE 5000

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -25,7 +25,9 @@ builder.Services.Configure<LearningPreviewOptions>(
 builder.Services.AddSingleton<ILearningObjectStorage, OssLearningObjectStorage>();
 builder.Services.AddSingleton<IAwardObjectStorage, OssAwardObjectStorage>();
 builder.Services.AddSingleton<OfficePreviewConverter>();
+builder.Services.AddSingleton<OfficeConversionLimiter>();
 builder.Services.AddSingleton<LearningPreviewService>();
+builder.Services.AddSingleton<LearningPreviewSessionStore>();
 builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<RecruitmentApplicationService>();
 builder.Services.AddScoped<ProjectMembershipService>();

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -20,8 +20,12 @@ builder.Services.AddControllers()
 builder.Services.AddSingleton<AuthTokenService>();
 builder.Services.Configure<OssStorageOptions>(
     builder.Configuration.GetSection(OssStorageOptions.SectionName));
+builder.Services.Configure<LearningPreviewOptions>(
+    builder.Configuration.GetSection(LearningPreviewOptions.SectionName));
 builder.Services.AddSingleton<ILearningObjectStorage, OssLearningObjectStorage>();
 builder.Services.AddSingleton<IAwardObjectStorage, OssAwardObjectStorage>();
+builder.Services.AddSingleton<OfficePreviewConverter>();
+builder.Services.AddSingleton<LearningPreviewService>();
 builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<RecruitmentApplicationService>();
 builder.Services.AddScoped<ProjectMembershipService>();

--- a/backend/Services/AuthTokenAuthenticationHandler.cs
+++ b/backend/Services/AuthTokenAuthenticationHandler.cs
@@ -27,7 +27,7 @@ public sealed class AuthTokenAuthenticationHandler : AuthenticationHandler<Authe
         var authorization = Request.Headers.Authorization.ToString();
         if (string.IsNullOrWhiteSpace(authorization))
         {
-            return Task.FromResult(AuthenticateResult.NoResult());
+            return Task.FromResult(TryAuthenticatePreviewCookie());
         }
 
         const string bearerPrefix = "Bearer ";
@@ -42,6 +42,26 @@ public sealed class AuthTokenAuthenticationHandler : AuthenticationHandler<Authe
             return Task.FromResult(AuthenticateResult.Fail("Invalid ClubHub token."));
         }
 
+        return Task.FromResult(CreateSuccessResult(principal));
+    }
+
+    private AuthenticateResult TryAuthenticatePreviewCookie()
+    {
+        if (!HttpMethods.IsGet(Request.Method) ||
+            Request.Path.Value?.EndsWith("/preview", StringComparison.OrdinalIgnoreCase) != true ||
+            !int.TryParse(Request.RouteValues["itemId"]?.ToString(), out var itemId) ||
+            itemId <= 0 ||
+            !Request.Cookies.TryGetValue(AuthTokenService.PreviewCookieName, out var token) ||
+            !_authTokenService.TryValidatePreviewToken(token, itemId, out var principal))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        return CreateSuccessResult(principal);
+    }
+
+    private static AuthenticateResult CreateSuccessResult(AuthTokenPrincipal principal)
+    {
         var claims = new List<Claim>
         {
             new(ClaimTypes.NameIdentifier, principal.UserId.ToString())
@@ -54,7 +74,7 @@ public sealed class AuthTokenAuthenticationHandler : AuthenticationHandler<Authe
 
         var identity = new ClaimsIdentity(claims, SchemeName);
         var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
-        return Task.FromResult(AuthenticateResult.Success(ticket));
+        return AuthenticateResult.Success(ticket);
     }
 
     protected override async Task HandleChallengeAsync(AuthenticationProperties properties)

--- a/backend/Services/AuthTokenService.cs
+++ b/backend/Services/AuthTokenService.cs
@@ -8,8 +8,14 @@ namespace ClubHub.Api.Services;
 public sealed class AuthTokenService
 {
     private const int TokenLifetimeHours = 12;
+    private const string PreviewTokenPrefix = "preview";
     private const string LocalDevelopmentSigningKey = "ClubHub.LocalDevelopment.TokenSigningKey.ChangeForProduction";
     private readonly byte[] _signingKey;
+    private readonly int _previewSessionLifetimeMinutes;
+
+    public const string PreviewCookieName = "clubhub-preview";
+
+    public TimeSpan PreviewSessionLifetime => TimeSpan.FromMinutes(_previewSessionLifetimeMinutes);
 
     public AuthTokenService(IConfiguration configuration, IHostEnvironment environment)
     {
@@ -27,6 +33,10 @@ public sealed class AuthTokenService
         }
 
         _signingKey = Encoding.UTF8.GetBytes(signingKey);
+        _previewSessionLifetimeMinutes = Math.Clamp(
+            configuration.GetValue<int?>("LearningPreview:SessionLifetimeMinutes") ?? 30,
+            1,
+            120);
     }
 
     public string CreateToken(User user)
@@ -87,6 +97,59 @@ public sealed class AuthTokenService
         return true;
     }
 
+    public string CreatePreviewToken(int userId, int itemId)
+    {
+        var payload = new PreviewTokenPayload(
+            userId,
+            itemId,
+            DateTimeOffset.UtcNow.AddMinutes(_previewSessionLifetimeMinutes).ToUnixTimeSeconds());
+        var payloadJson = JsonSerializer.Serialize(payload);
+        var payloadPart = Base64UrlEncode(Encoding.UTF8.GetBytes(payloadJson));
+        var signedPart = $"{PreviewTokenPrefix}.{payloadPart}";
+        return $"{signedPart}.{Sign(signedPart)}";
+    }
+
+    public bool TryValidatePreviewToken(
+        string token,
+        int expectedItemId,
+        out AuthTokenPrincipal principal)
+    {
+        principal = default;
+        var parts = token.Split('.', 3);
+        if (parts.Length != 3 || parts[0] != PreviewTokenPrefix ||
+            string.IsNullOrWhiteSpace(parts[1]) || string.IsNullOrWhiteSpace(parts[2]))
+        {
+            return false;
+        }
+
+        var signedPart = $"{parts[0]}.{parts[1]}";
+        if (!FixedTimeEquals(parts[2], Sign(signedPart))) return false;
+
+        PreviewTokenPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<PreviewTokenPayload>(
+                Encoding.UTF8.GetString(Base64UrlDecode(parts[1])));
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        if (payload is null || payload.UserId <= 0 || payload.ItemId != expectedItemId ||
+            payload.ExpiresAtUnix <= DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+        {
+            return false;
+        }
+
+        principal = new AuthTokenPrincipal(payload.UserId, null);
+        return true;
+    }
+
     private string Sign(string payloadPart)
     {
         using var hmac = new HMACSHA256(_signingKey);
@@ -115,6 +178,8 @@ public sealed class AuthTokenService
     }
 
     private sealed record AuthTokenPayload(int UserId, string? Username, long ExpiresAtUnix);
+
+    private sealed record PreviewTokenPayload(int UserId, int ItemId, long ExpiresAtUnix);
 }
 
 public readonly record struct AuthTokenPrincipal(int UserId, string? Username);

--- a/backend/Services/ILearningObjectStorage.cs
+++ b/backend/Services/ILearningObjectStorage.cs
@@ -21,8 +21,21 @@ public interface ILearningObjectStorage
         string storageReference,
         CancellationToken cancellationToken);
 
+    Task<bool> ExistsAsync(
+        string storageReference,
+        CancellationToken cancellationToken);
+
     Task<StoredObjectDownload> OpenReadAsync(
         string storageReference,
+        StoredObjectRange? range,
+        CancellationToken cancellationToken);
+
+    Task SaveAsync(
+        string storageReference,
+        Stream content,
+        long contentLength,
+        string contentType,
+        string contentDisposition,
         CancellationToken cancellationToken);
 
     Task RemoveAsync(string storageReference, CancellationToken cancellationToken);
@@ -36,6 +49,8 @@ public sealed record StoredObjectMetadata(
     DateTimeOffset? LastModified);
 
 public sealed record StoredObjectDownload(Stream Content);
+
+public sealed record StoredObjectRange(long Start, long End);
 
 public sealed class LearningObjectStorageException : Exception
 {

--- a/backend/Services/LearningObjectStorage.cs
+++ b/backend/Services/LearningObjectStorage.cs
@@ -125,8 +125,35 @@ public sealed class OssLearningObjectStorage : ILearningObjectStorage, IDisposab
         }
     }
 
+    public async Task<bool> ExistsAsync(
+        string storageReference,
+        CancellationToken cancellationToken)
+    {
+        var client = GetClient();
+        var objectName = ParseOwnedReference(storageReference);
+        try
+        {
+            return await client.IsObjectExistAsync(
+                _options.Bucket,
+                objectName,
+                null,
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            throw new LearningObjectStorageException(
+                "Failed to check the learning preview in object storage.",
+                exception);
+        }
+    }
+
     public async Task<StoredObjectDownload> OpenReadAsync(
         string storageReference,
+        StoredObjectRange? range,
         CancellationToken cancellationToken)
     {
         var client = GetClient();
@@ -137,7 +164,8 @@ public sealed class OssLearningObjectStorage : ILearningObjectStorage, IDisposab
                 new OSS.Models.GetObjectRequest
                 {
                     Bucket = _options.Bucket,
-                    Key = objectName
+                    Key = objectName,
+                    Range = range is null ? null : $"bytes={range.Start}-{range.End}"
                 },
                 HttpCompletionOption.ResponseHeadersRead,
                 cancellationToken: cancellationToken);
@@ -159,6 +187,42 @@ public sealed class OssLearningObjectStorage : ILearningObjectStorage, IDisposab
         catch (Exception exception)
         {
             throw new LearningObjectStorageException("Failed to read the learning resource from OSS.", exception);
+        }
+    }
+
+    public async Task SaveAsync(
+        string storageReference,
+        Stream content,
+        long contentLength,
+        string contentType,
+        string contentDisposition,
+        CancellationToken cancellationToken)
+    {
+        _ = contentLength;
+        var client = GetClient();
+        var objectName = ParseOwnedReference(storageReference);
+        try
+        {
+            await client.PutObjectAsync(
+                new OSS.Models.PutObjectRequest
+                {
+                    Bucket = _options.Bucket,
+                    Key = objectName,
+                    Body = content,
+                    ContentType = contentType,
+                    ContentDisposition = contentDisposition
+                },
+                cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            throw new LearningObjectStorageException(
+                "Failed to save the generated learning preview to OSS.",
+                exception);
         }
     }
 

--- a/backend/Services/LearningPreviewOptions.cs
+++ b/backend/Services/LearningPreviewOptions.cs
@@ -6,6 +6,11 @@ public sealed class LearningPreviewOptions
 
     public string OfficeExecutablePath { get; init; } = "soffice";
 
+    /// <summary>
+    /// 是否允许在本地开发环境中运行 Office 转换；生产环境始终禁用。
+    /// </summary>
+    public bool EnableOfficeConversion { get; init; }
+
     public int ConversionTimeoutSeconds { get; init; } = 60;
 
     public long MaxInputBytes { get; init; } = 50L * 1024 * 1024;
@@ -13,6 +18,11 @@ public sealed class LearningPreviewOptions
     public long MaxOutputBytes { get; init; } = 100L * 1024 * 1024;
 
     public long MaxWorkingSetBytes { get; init; } = 512L * 1024 * 1024;
+
+    /// <summary>
+    /// 单个 API 进程允许同时运行的 Office 转换数量。
+    /// </summary>
+    public int MaxConcurrentConversions { get; init; } = 2;
 
     public int SessionLifetimeMinutes { get; init; } = 30;
 }

--- a/backend/Services/LearningPreviewOptions.cs
+++ b/backend/Services/LearningPreviewOptions.cs
@@ -1,0 +1,18 @@
+namespace ClubHub.Api.Services;
+
+public sealed class LearningPreviewOptions
+{
+    public const string SectionName = "LearningPreview";
+
+    public string OfficeExecutablePath { get; init; } = "soffice";
+
+    public int ConversionTimeoutSeconds { get; init; } = 60;
+
+    public long MaxInputBytes { get; init; } = 50L * 1024 * 1024;
+
+    public long MaxOutputBytes { get; init; } = 100L * 1024 * 1024;
+
+    public long MaxWorkingSetBytes { get; init; } = 512L * 1024 * 1024;
+
+    public int SessionLifetimeMinutes { get; init; } = 30;
+}

--- a/backend/Services/LearningPreviewService.cs
+++ b/backend/Services/LearningPreviewService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO.Compression;
@@ -7,24 +6,33 @@ using Microsoft.Extensions.Options;
 
 namespace ClubHub.Api.Services;
 
-public sealed class LearningPreviewService
+public sealed class LearningPreviewService : IDisposable
 {
     private const string LocalFileUrlPrefix = "/api/learning/items/";
     private const int SignatureBytes = 512;
-    private static readonly ConcurrentDictionary<string, SemaphoreSlim> ConversionLocks = new();
+    private const int ConversionLockStripeCount = 64;
 
     private readonly ILearningObjectStorage _objectStorage;
     private readonly IWebHostEnvironment _environment;
     private readonly OfficePreviewConverter _converter;
+    private readonly OfficeConversionLimiter _conversionLimiter;
+    private readonly bool _officeConversionEnabled;
+    private readonly SemaphoreSlim[] _conversionLocks = Enumerable.Range(0, ConversionLockStripeCount)
+        .Select(_ => new SemaphoreSlim(1, 1))
+        .ToArray();
 
     public LearningPreviewService(
         ILearningObjectStorage objectStorage,
         IWebHostEnvironment environment,
-        OfficePreviewConverter converter)
+        OfficePreviewConverter converter,
+        OfficeConversionLimiter conversionLimiter,
+        IOptions<LearningPreviewOptions> options)
     {
         _objectStorage = objectStorage;
         _environment = environment;
         _converter = converter;
+        _conversionLimiter = conversionLimiter;
+        _officeConversionEnabled = environment.IsDevelopment() && options.Value.EnableOfficeConversion;
     }
 
     public async Task<PreparedLearningPreview> PrepareAsync(
@@ -43,6 +51,13 @@ public sealed class LearningPreviewService
                 source.StorageReference,
                 source.PhysicalPath,
                 false);
+        }
+
+        if (!_officeConversionEnabled)
+        {
+            throw new LearningPreviewException(
+                LearningPreviewFailure.Unsupported,
+                "Office 在线转换在独立隔离服务完成前暂不可用，请在获得权限后下载查看。");
         }
 
         return source.StorageReference is not null
@@ -198,7 +213,7 @@ public sealed class LearningPreviewService
         CancellationToken cancellationToken)
     {
         var previewReference = BuildPreviewReference(clubId, itemId);
-        var gate = ConversionLocks.GetOrAdd(previewReference, _ => new SemaphoreSlim(1, 1));
+        var gate = GetConversionLock(previewReference);
         await gate.WaitAsync(cancellationToken);
         try
         {
@@ -209,7 +224,7 @@ public sealed class LearningPreviewService
                     null,
                     cancellationToken);
                 await using var sourceStream = storedObject.Content;
-                await using var artifact = await _converter.ConvertAsync(
+                await using var artifact = await ConvertWithLimitAsync(
                     sourceStream,
                     source.Length,
                     source.Format.Extension,
@@ -259,7 +274,7 @@ public sealed class LearningPreviewService
         CancellationToken cancellationToken)
     {
         var previewPath = GetLocalPreviewPath(clubId, itemId);
-        var gate = ConversionLocks.GetOrAdd(previewPath, _ => new SemaphoreSlim(1, 1));
+        var gate = GetConversionLock(previewPath);
         await gate.WaitAsync(cancellationToken);
         try
         {
@@ -273,7 +288,7 @@ public sealed class LearningPreviewService
                     FileShare.Read,
                     64 * 1024,
                     FileOptions.Asynchronous | FileOptions.SequentialScan);
-                await using var artifact = await _converter.ConvertAsync(
+                await using var artifact = await ConvertWithLimitAsync(
                     sourceStream,
                     source.Length,
                     source.Format.Extension,
@@ -349,6 +364,32 @@ public sealed class LearningPreviewService
 
     private static string BuildPreviewReference(int clubId, int itemId) =>
         $"clubs/{clubId}/learning/{itemId}/preview/converted.pdf";
+
+    private SemaphoreSlim GetConversionLock(string key)
+    {
+        var index = (key.GetHashCode(StringComparison.Ordinal) & int.MaxValue) % _conversionLocks.Length;
+        return _conversionLocks[index];
+    }
+
+    private Task<OfficePreviewArtifact> ConvertWithLimitAsync(
+        Stream source,
+        long sourceLength,
+        string extension,
+        CancellationToken cancellationToken) =>
+        _conversionLimiter.RunAsync(
+            token => _converter.ConvertAsync(source, sourceLength, extension, token),
+            cancellationToken);
+
+    /// <summary>
+    /// 释放固定数量的转换互斥锁。
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var conversionLock in _conversionLocks)
+        {
+            conversionLock.Dispose();
+        }
+    }
 
     private static LearningPreviewException InvalidRange(long contentLength) => new(
         LearningPreviewFailure.InvalidRange,

--- a/backend/Services/LearningPreviewService.cs
+++ b/backend/Services/LearningPreviewService.cs
@@ -1,0 +1,752 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Options;
+
+namespace ClubHub.Api.Services;
+
+public sealed class LearningPreviewService
+{
+    private const string LocalFileUrlPrefix = "/api/learning/items/";
+    private const int SignatureBytes = 512;
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> ConversionLocks = new();
+
+    private readonly ILearningObjectStorage _objectStorage;
+    private readonly IWebHostEnvironment _environment;
+    private readonly OfficePreviewConverter _converter;
+
+    public LearningPreviewService(
+        ILearningObjectStorage objectStorage,
+        IWebHostEnvironment environment,
+        OfficePreviewConverter converter)
+    {
+        _objectStorage = objectStorage;
+        _environment = environment;
+        _converter = converter;
+    }
+
+    public async Task<PreparedLearningPreview> PrepareAsync(
+        int itemId,
+        int clubId,
+        string? fileUrl,
+        CancellationToken cancellationToken)
+    {
+        var source = await ResolveSourceAsync(itemId, clubId, fileUrl, cancellationToken);
+        if (!source.Format.RequiresOfficeConversion)
+        {
+            return new PreparedLearningPreview(
+                source.Format.Kind,
+                source.Format.ContentType,
+                source.Length,
+                source.StorageReference,
+                source.PhysicalPath,
+                false);
+        }
+
+        return source.StorageReference is not null
+            ? await PrepareStoredOfficePreviewAsync(source, itemId, clubId, cancellationToken)
+            : await PrepareLocalOfficePreviewAsync(source, itemId, clubId, cancellationToken);
+    }
+
+    public async Task<LearningPreviewStream> OpenAsync(
+        PreparedLearningPreview preview,
+        string? rangeHeader,
+        CancellationToken cancellationToken)
+    {
+        if (preview.PhysicalPath is not null)
+        {
+            return new LearningPreviewStream(null, preview.PhysicalPath, null, preview.Length);
+        }
+
+        if (preview.StorageReference is null)
+        {
+            throw new LearningPreviewException(
+                LearningPreviewFailure.NotFound,
+                "预览文件不存在。");
+        }
+
+        var range = ParseRange(rangeHeader, preview.Length);
+        var storedObject = await _objectStorage.OpenReadAsync(
+            preview.StorageReference,
+            range is null ? null : new StoredObjectRange(range.Start, range.End),
+            cancellationToken);
+        return new LearningPreviewStream(
+            storedObject.Content,
+            null,
+            range,
+            range?.Length ?? preview.Length);
+    }
+
+    public async Task RemovePreviewAsync(
+        int itemId,
+        int clubId,
+        string? fileUrl,
+        CancellationToken cancellationToken)
+    {
+        if (_objectStorage.IsStorageReference(fileUrl))
+        {
+            var previewReference = BuildPreviewReference(clubId, itemId);
+            if (await _objectStorage.ExistsAsync(previewReference, cancellationToken))
+            {
+                await _objectStorage.RemoveAsync(previewReference, cancellationToken);
+            }
+        }
+
+        var localPath = GetLocalPreviewPath(clubId, itemId);
+        if (File.Exists(localPath)) File.Delete(localPath);
+    }
+
+    internal static PreviewByteRange? ParseRange(string? rangeHeader, long contentLength)
+    {
+        if (string.IsNullOrWhiteSpace(rangeHeader)) return null;
+        if (contentLength <= 0 || !RangeHeaderValue.TryParse(rangeHeader, out var parsed) ||
+            !string.Equals(parsed.Unit, "bytes", StringComparison.OrdinalIgnoreCase) ||
+            parsed.Ranges.Count != 1)
+        {
+            throw InvalidRange(contentLength);
+        }
+
+        var requested = parsed.Ranges.Single();
+        long start;
+        long end;
+        if (requested.From.HasValue)
+        {
+            start = requested.From.Value;
+            if (start < 0 || start >= contentLength) throw InvalidRange(contentLength);
+            end = requested.To.HasValue
+                ? Math.Min(requested.To.Value, contentLength - 1)
+                : contentLength - 1;
+            if (end < start) throw InvalidRange(contentLength);
+        }
+        else if (requested.To.HasValue && requested.To.Value > 0)
+        {
+            var suffixLength = Math.Min(requested.To.Value, contentLength);
+            start = contentLength - suffixLength;
+            end = contentLength - 1;
+        }
+        else
+        {
+            throw InvalidRange(contentLength);
+        }
+
+        return new PreviewByteRange(start, end, contentLength);
+    }
+
+    private async Task<PreviewSource> ResolveSourceAsync(
+        int itemId,
+        int clubId,
+        string? fileUrl,
+        CancellationToken cancellationToken)
+    {
+        if (_objectStorage.IsStorageReference(fileUrl))
+        {
+            var metadata = await _objectStorage.GetMetadataAsync(fileUrl!, cancellationToken);
+            if (metadata.ContentLength is null or <= 0)
+            {
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.NotFound,
+                    "资源文件为空或不存在。");
+            }
+
+            var signature = await ReadStoredSignatureAsync(
+                fileUrl!,
+                metadata.ContentLength.Value,
+                cancellationToken);
+            var format = LearningPreviewFormatDetector.Detect(Path.GetExtension(fileUrl), signature);
+            return new PreviewSource(
+                format,
+                metadata.ContentLength.Value,
+                fileUrl,
+                null,
+                metadata.LastModified);
+        }
+
+        if (fileUrl == $"{LocalFileUrlPrefix}{itemId}/file")
+        {
+            var clubStoragePath = Path.Combine(
+                _environment.ContentRootPath,
+                "App_Data",
+                "learning-files",
+                clubId.ToString(CultureInfo.InvariantCulture));
+            var storedPath = Directory.Exists(clubStoragePath)
+                ? Directory.EnumerateFiles(clubStoragePath, $"{itemId}.*").FirstOrDefault()
+                : null;
+            if (storedPath is null)
+            {
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.NotFound,
+                    "上传文件不存在。");
+            }
+
+            var info = new FileInfo(storedPath);
+            var signature = await ReadLocalSignatureAsync(storedPath, cancellationToken);
+            var format = LearningPreviewFormatDetector.Detect(info.Extension, signature);
+            return new PreviewSource(format, info.Length, null, storedPath, info.LastWriteTimeUtc);
+        }
+
+        throw new LearningPreviewException(
+            LearningPreviewFailure.Unsupported,
+            "当前资源不是受保护的上传文件，暂不支持在线预览。");
+    }
+
+    private async Task<PreparedLearningPreview> PrepareStoredOfficePreviewAsync(
+        PreviewSource source,
+        int itemId,
+        int clubId,
+        CancellationToken cancellationToken)
+    {
+        var previewReference = BuildPreviewReference(clubId, itemId);
+        var gate = ConversionLocks.GetOrAdd(previewReference, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!await _objectStorage.ExistsAsync(previewReference, cancellationToken))
+            {
+                var storedObject = await _objectStorage.OpenReadAsync(
+                    source.StorageReference!,
+                    null,
+                    cancellationToken);
+                await using var sourceStream = storedObject.Content;
+                await using var artifact = await _converter.ConvertAsync(
+                    sourceStream,
+                    source.Length,
+                    source.Format.Extension,
+                    cancellationToken);
+                await using var pdf = new FileStream(
+                    artifact.PdfPath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    64 * 1024,
+                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+                await _objectStorage.SaveAsync(
+                    previewReference,
+                    pdf,
+                    pdf.Length,
+                    "application/pdf",
+                    "inline; filename=preview.pdf",
+                    cancellationToken);
+            }
+
+            var metadata = await _objectStorage.GetMetadataAsync(previewReference, cancellationToken);
+            if (metadata.ContentLength is null or <= 0)
+            {
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.ConversionFailed,
+                    "Office 文档转换后的预览文件为空。");
+            }
+
+            return new PreparedLearningPreview(
+                LearningPreviewKind.Pdf,
+                "application/pdf",
+                metadata.ContentLength.Value,
+                previewReference,
+                null,
+                true);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task<PreparedLearningPreview> PrepareLocalOfficePreviewAsync(
+        PreviewSource source,
+        int itemId,
+        int clubId,
+        CancellationToken cancellationToken)
+    {
+        var previewPath = GetLocalPreviewPath(clubId, itemId);
+        var gate = ConversionLocks.GetOrAdd(previewPath, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!File.Exists(previewPath) ||
+                File.GetLastWriteTimeUtc(previewPath) < source.LastModified?.UtcDateTime)
+            {
+                await using var sourceStream = new FileStream(
+                    source.PhysicalPath!,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    64 * 1024,
+                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+                await using var artifact = await _converter.ConvertAsync(
+                    sourceStream,
+                    source.Length,
+                    source.Format.Extension,
+                    cancellationToken);
+                Directory.CreateDirectory(Path.GetDirectoryName(previewPath)!);
+                File.Copy(artifact.PdfPath, previewPath, true);
+            }
+
+            var info = new FileInfo(previewPath);
+            return new PreparedLearningPreview(
+                LearningPreviewKind.Pdf,
+                "application/pdf",
+                info.Length,
+                null,
+                previewPath,
+                true);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task<byte[]> ReadStoredSignatureAsync(
+        string storageReference,
+        long contentLength,
+        CancellationToken cancellationToken)
+    {
+        var end = Math.Min(contentLength, SignatureBytes) - 1;
+        var storedObject = await _objectStorage.OpenReadAsync(
+            storageReference,
+            new StoredObjectRange(0, end),
+            cancellationToken);
+        await using var content = storedObject.Content;
+        return await ReadSignatureAsync(content, cancellationToken);
+    }
+
+    private static async Task<byte[]> ReadLocalSignatureAsync(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        await using var content = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            SignatureBytes,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        return await ReadSignatureAsync(content, cancellationToken);
+    }
+
+    private static async Task<byte[]> ReadSignatureAsync(
+        Stream content,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[SignatureBytes];
+        var total = 0;
+        while (total < buffer.Length)
+        {
+            var read = await content.ReadAsync(buffer.AsMemory(total), cancellationToken);
+            if (read == 0) break;
+            total += read;
+        }
+        return buffer[..total];
+    }
+
+    private string GetLocalPreviewPath(int clubId, int itemId) => Path.Combine(
+        _environment.ContentRootPath,
+        "App_Data",
+        "learning-previews",
+        clubId.ToString(CultureInfo.InvariantCulture),
+        $"{itemId}.pdf");
+
+    private static string BuildPreviewReference(int clubId, int itemId) =>
+        $"clubs/{clubId}/learning/{itemId}/preview/converted.pdf";
+
+    private static LearningPreviewException InvalidRange(long contentLength) => new(
+        LearningPreviewFailure.InvalidRange,
+        $"请求的文件范围无效，资源长度为 {contentLength} 字节。");
+
+    private sealed record PreviewSource(
+        LearningPreviewFormat Format,
+        long Length,
+        string? StorageReference,
+        string? PhysicalPath,
+        DateTimeOffset? LastModified);
+}
+
+internal static class LearningPreviewFormatDetector
+{
+    internal static LearningPreviewFormat Detect(string? extension, ReadOnlySpan<byte> signature)
+    {
+        var normalizedExtension = (extension ?? string.Empty).Trim().ToLowerInvariant();
+        if (normalizedExtension == ".pdf" && signature.StartsWith("%PDF-"u8))
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Pdf, "application/pdf", ".pdf", false);
+        }
+        if (normalizedExtension is ".jpg" or ".jpeg" &&
+            signature.Length >= 3 && signature[0] == 0xff && signature[1] == 0xd8 && signature[2] == 0xff)
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Image, "image/jpeg", normalizedExtension, false);
+        }
+        if (normalizedExtension == ".png" && signature.StartsWith(new byte[] { 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a }))
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Image, "image/png", ".png", false);
+        }
+        if (normalizedExtension == ".gif" &&
+            (signature.StartsWith("GIF87a"u8) || signature.StartsWith("GIF89a"u8)))
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Image, "image/gif", ".gif", false);
+        }
+        if (normalizedExtension == ".webp" && signature.Length >= 12 &&
+            signature[..4].SequenceEqual("RIFF"u8) && signature.Slice(8, 4).SequenceEqual("WEBP"u8))
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Image, "image/webp", ".webp", false);
+        }
+        if (normalizedExtension == ".mp4" && signature.Length >= 12 &&
+            signature.Slice(4, 4).SequenceEqual("ftyp"u8))
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Video, "video/mp4", ".mp4", false);
+        }
+        if (normalizedExtension == ".webm" && signature.StartsWith(new byte[] { 0x1a, 0x45, 0xdf, 0xa3 }))
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Video, "video/webm", ".webm", false);
+        }
+        if (normalizedExtension is ".doc" or ".ppt" &&
+            signature.StartsWith(new byte[] { 0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1 }))
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Pdf, "application/pdf", normalizedExtension, true);
+        }
+        if (normalizedExtension is ".docx" or ".pptx" &&
+            signature.Length >= 4 && signature[0] == 0x50 && signature[1] == 0x4b &&
+            signature[2] is 0x03 or 0x05 or 0x07 && signature[3] is 0x04 or 0x06 or 0x08)
+        {
+            return new LearningPreviewFormat(LearningPreviewKind.Pdf, "application/pdf", normalizedExtension, true);
+        }
+
+        throw new LearningPreviewException(
+            LearningPreviewFailure.Unsupported,
+            "当前格式暂不支持在线预览，或文件内容与扩展名不一致。");
+    }
+}
+
+public sealed class OfficePreviewConverter
+{
+    private readonly LearningPreviewOptions _options;
+
+    public OfficePreviewConverter(IOptions<LearningPreviewOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public async Task<OfficePreviewArtifact> ConvertAsync(
+        Stream source,
+        long contentLength,
+        string extension,
+        CancellationToken cancellationToken)
+    {
+        if (contentLength <= 0 || contentLength > _options.MaxInputBytes)
+        {
+            throw new LearningPreviewException(
+                LearningPreviewFailure.ConversionFailed,
+                "Office 文件为空或超过允许转换的大小。");
+        }
+
+        var workingDirectory = Path.Combine(Path.GetTempPath(), $"clubhub-preview-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workingDirectory);
+        var inputPath = Path.Combine(workingDirectory, $"source{extension}");
+        var outputDirectory = Path.Combine(workingDirectory, "output");
+        var profileDirectory = Path.Combine(workingDirectory, "profile");
+        Directory.CreateDirectory(outputDirectory);
+        Directory.CreateDirectory(profileDirectory);
+        try
+        {
+            await using (var input = new FileStream(
+                inputPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                64 * 1024,
+                FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                await CopyBoundedAsync(source, input, _options.MaxInputBytes, cancellationToken);
+            }
+
+            ValidateOpenXmlPackage(inputPath, extension);
+
+            var usePrLimit = OperatingSystem.IsLinux() &&
+                _options.MaxWorkingSetBytes > 0 &&
+                File.Exists("/usr/bin/prlimit");
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = usePrLimit ? "/usr/bin/prlimit" : _options.OfficeExecutablePath,
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            if (usePrLimit)
+            {
+                startInfo.ArgumentList.Add($"--as={_options.MaxWorkingSetBytes}");
+                startInfo.ArgumentList.Add("--");
+                startInfo.ArgumentList.Add(_options.OfficeExecutablePath);
+            }
+            foreach (var argument in new[]
+            {
+                $"-env:UserInstallation={new Uri(profileDirectory).AbsoluteUri}",
+                "--headless",
+                "--nologo",
+                "--nodefault",
+                "--nolockcheck",
+                "--nofirststartwizard",
+                "--norestore",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                outputDirectory,
+                inputPath
+            })
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using var process = new Process { StartInfo = startInfo };
+            try
+            {
+                if (!process.Start()) throw new InvalidOperationException("Office converter did not start.");
+            }
+            catch (Exception exception)
+            {
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.ConversionFailed,
+                    "服务器未安装或无法启动 Office 预览转换工具。",
+                    exception);
+            }
+
+            var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, _options.ConversionTimeoutSeconds)));
+            try
+            {
+                while (!process.HasExited)
+                {
+                    await Task.Delay(200, timeout.Token);
+                    process.Refresh();
+                    if (_options.MaxWorkingSetBytes > 0 && process.WorkingSet64 > _options.MaxWorkingSetBytes)
+                    {
+                        process.Kill(true);
+                        throw new LearningPreviewException(
+                            LearningPreviewFailure.ConversionFailed,
+                            "Office 文档转换占用资源过高，已安全终止。");
+                    }
+                }
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                if (!process.HasExited) process.Kill(true);
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.ConversionFailed,
+                    "Office 文档转换超时，请稍后重试或下载后查看。");
+            }
+
+            var output = await standardOutput;
+            var error = await standardError;
+            if (process.ExitCode != 0)
+            {
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.ConversionFailed,
+                    $"Office 文档转换失败（退出码 {process.ExitCode}）。{TrimDiagnostic(error, output)}");
+            }
+
+            var pdfPath = Path.Combine(outputDirectory, "source.pdf");
+            if (!File.Exists(pdfPath))
+            {
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.ConversionFailed,
+                    "Office 文档转换失败，未生成 PDF 预览副本。");
+            }
+
+            var outputLength = new FileInfo(pdfPath).Length;
+            if (outputLength <= 0 || outputLength > _options.MaxOutputBytes)
+            {
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.ConversionFailed,
+                    "Office 文档转换结果为空或超过预览大小限制。");
+            }
+
+            return new OfficePreviewArtifact(workingDirectory, pdfPath);
+        }
+        catch
+        {
+            TryDeleteDirectory(workingDirectory);
+            throw;
+        }
+    }
+
+    private static async Task CopyBoundedAsync(
+        Stream source,
+        Stream destination,
+        long limit,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[64 * 1024];
+        long total = 0;
+        while (true)
+        {
+            var read = await source.ReadAsync(buffer, cancellationToken);
+            if (read == 0) break;
+            total += read;
+            if (total > limit)
+            {
+                throw new LearningPreviewException(
+                    LearningPreviewFailure.ConversionFailed,
+                    "Office 文件超过允许转换的大小。");
+            }
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+        }
+    }
+
+    private static void ValidateOpenXmlPackage(string inputPath, string extension)
+    {
+        if (extension is not (".docx" or ".pptx")) return;
+        try
+        {
+            using var archive = ZipFile.OpenRead(inputPath);
+            if (archive.Entries.Count > 10_000)
+            {
+                throw new InvalidDataException("The Office package contains too many entries.");
+            }
+
+            var requiredPart = extension == ".docx"
+                ? "word/document.xml"
+                : "ppt/presentation.xml";
+            if (archive.GetEntry("[Content_Types].xml") is null || archive.GetEntry(requiredPart) is null)
+            {
+                throw new InvalidDataException("The expected Office document part is missing.");
+            }
+        }
+        catch (InvalidDataException exception)
+        {
+            throw new LearningPreviewException(
+                LearningPreviewFailure.Unsupported,
+                "文件内容不是有效的 Word 或 PowerPoint 文档，无法在线预览。",
+                exception);
+        }
+    }
+
+    private static string TrimDiagnostic(params string[] values)
+    {
+        var text = string.Join(" ", values)
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .Trim();
+        return text.Length == 0 ? string.Empty : $" {text[..Math.Min(200, text.Length)]}";
+    }
+
+    internal static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path)) Directory.Delete(path, true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}
+
+public sealed class OfficePreviewArtifact : IAsyncDisposable
+{
+    private readonly string _workingDirectory;
+
+    public OfficePreviewArtifact(string workingDirectory, string pdfPath)
+    {
+        _workingDirectory = workingDirectory;
+        PdfPath = pdfPath;
+    }
+
+    public string PdfPath { get; }
+
+    public ValueTask DisposeAsync()
+    {
+        OfficePreviewConverter.TryDeleteDirectory(_workingDirectory);
+        return ValueTask.CompletedTask;
+    }
+}
+
+public enum LearningPreviewKind
+{
+    Image,
+    Video,
+    Pdf
+}
+
+public sealed record PreparedLearningPreview(
+    LearningPreviewKind Kind,
+    string ContentType,
+    long Length,
+    string? StorageReference,
+    string? PhysicalPath,
+    bool IsConverted);
+
+public sealed record LearningPreviewStream(
+    Stream? Content,
+    string? PhysicalPath,
+    PreviewByteRange? Range,
+    long ContentLength);
+
+public sealed record PreviewByteRange(long Start, long End, long TotalLength)
+{
+    public long Length => End - Start + 1;
+}
+
+internal sealed record LearningPreviewFormat(
+    LearningPreviewKind Kind,
+    string ContentType,
+    string Extension,
+    bool RequiresOfficeConversion);
+
+public enum LearningPreviewFailure
+{
+    Unsupported,
+    InvalidRange,
+    ConversionFailed,
+    NotFound
+}
+
+public sealed class LearningPreviewException : Exception
+{
+    public LearningPreviewException(
+        LearningPreviewFailure failure,
+        string message,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Failure = failure;
+    }
+
+    public LearningPreviewFailure Failure { get; }
+}
+
+internal static class LearningPreviewAccessPolicy
+{
+    internal static bool CanPreview(
+        bool isVisible,
+        bool isPublished,
+        bool canManage,
+        bool canReview,
+        bool canDelete) =>
+        isVisible && (isPublished || canManage || canReview || canDelete);
+}
+
+internal static class LearningPreviewHttpPolicy
+{
+    internal static void Apply(HttpResponse response, string contentType, string fileName)
+    {
+        var safeFileName = fileName.Replace('\r', '_').Replace('\n', '_');
+        response.ContentType = contentType;
+        response.Headers.ContentDisposition =
+            $"inline; filename*=UTF-8''{Uri.EscapeDataString(safeFileName)}";
+        response.Headers.AcceptRanges = "bytes";
+        response.Headers.CacheControl = "private, no-store, max-age=0";
+        response.Headers["X-Content-Type-Options"] = "nosniff";
+        response.Headers["X-Frame-Options"] = "SAMEORIGIN";
+        response.Headers["Cross-Origin-Resource-Policy"] = "same-origin";
+        response.Headers["Referrer-Policy"] = "no-referrer";
+        response.Headers["Content-Security-Policy"] =
+            "sandbox; default-src 'none'; img-src 'self' data: blob:; media-src 'self' blob:";
+    }
+}

--- a/backend/Services/LearningPreviewSessionStore.cs
+++ b/backend/Services/LearningPreviewSessionStore.cs
@@ -1,0 +1,67 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ClubHub.Api.Services;
+
+/// <summary>
+/// 在预览 Cookie 的短时生命周期内保存已经解析和校验过的预览元数据。
+/// </summary>
+public sealed class LearningPreviewSessionStore : IDisposable
+{
+    private const int MaxSessions = 4096;
+    private readonly MemoryCache _cache = new(new MemoryCacheOptions { SizeLimit = MaxSessions });
+
+    /// <summary>
+    /// 保存与预览令牌、用户和资源绑定的预览元数据。
+    /// </summary>
+    public void Store(
+        string token,
+        int userId,
+        int itemId,
+        PreparedLearningPreview preview,
+        TimeSpan lifetime)
+    {
+        _cache.Set(
+            BuildKey(token),
+            new LearningPreviewSession(userId, itemId, preview),
+            new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = lifetime,
+                Size = 1
+            });
+    }
+
+    /// <summary>
+    /// 读取与当前令牌、用户和资源完全匹配的预览元数据。
+    /// </summary>
+    public bool TryGet(
+        string token,
+        int userId,
+        int itemId,
+        out PreparedLearningPreview? preview)
+    {
+        preview = null;
+        if (!_cache.TryGetValue<LearningPreviewSession>(BuildKey(token), out var session) ||
+            session is null || session.UserId != userId || session.ItemId != itemId)
+        {
+            return false;
+        }
+
+        preview = session.Preview;
+        return true;
+    }
+
+    /// <summary>
+    /// 释放预览会话缓存。
+    /// </summary>
+    public void Dispose() => _cache.Dispose();
+
+    private static string BuildKey(string token) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
+
+    private sealed record LearningPreviewSession(
+        int UserId,
+        int ItemId,
+        PreparedLearningPreview Preview);
+}

--- a/backend/Services/OfficeConversionLimiter.cs
+++ b/backend/Services/OfficeConversionLimiter.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Options;
+
+namespace ClubHub.Api.Services;
+
+/// <summary>
+/// 限制单个 API 进程内同时运行的 Office 转换数量。
+/// </summary>
+public sealed class OfficeConversionLimiter : IDisposable
+{
+    private readonly SemaphoreSlim _gate;
+
+    /// <summary>
+    /// 使用预览配置创建进程级转换限流器。
+    /// </summary>
+    public OfficeConversionLimiter(IOptions<LearningPreviewOptions> options)
+        : this(options.Value.MaxConcurrentConversions)
+    {
+    }
+
+    internal OfficeConversionLimiter(int maxConcurrentConversions)
+    {
+        MaxConcurrency = Math.Clamp(maxConcurrentConversions, 1, 8);
+        _gate = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+    }
+
+    /// <summary>
+    /// 实际采用的最大转换并发数。
+    /// </summary>
+    public int MaxConcurrency { get; }
+
+    /// <summary>
+    /// 在全局并发配额内执行一次转换操作。
+    /// </summary>
+    public async Task<T> RunAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            return await operation(cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// 释放并发信号量。
+    /// </summary>
+    public void Dispose() => _gate.Dispose();
+}

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -8,6 +8,10 @@
     "Bucket": "clubhub-learning-prod-2026-c7h2",
     "RoleName": "ClubHubOssProdRole"
   },
+  "LearningPreview": {
+    "EnableOfficeConversion": false,
+    "MaxConcurrentConversions": 2
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       Oss__Endpoint: ${OSS_ENDPOINT:-oss-cn-shanghai-internal.aliyuncs.com}
       Oss__Bucket: ${OSS_BUCKET:-clubhub-learning-prod-2026-c7h2}
       Oss__RoleName: ${OSS_ROLE_NAME:-ClubHubOssProdRole}
+      LearningPreview__MaxConcurrentConversions: ${LEARNING_PREVIEW_MAX_CONCURRENT_CONVERSIONS:-2}
     expose:
       - "5000"
     networks:

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -610,6 +610,10 @@ export interface CreateLearningItemOperationRequest {
   createLearningItemRequest: CreateLearningItemRequest;
 }
 
+export interface CreateLearningPreviewSessionRequest {
+  itemId: number;
+}
+
 export interface CreateMaterialOperationRequest {
   createMaterialRequest: CreateMaterialRequest;
 }
@@ -797,6 +801,11 @@ export interface GetLearningItemStatisticsRequest {
 
 export interface GetLearningItemsRequest {
   clubId?: number;
+}
+
+export interface GetLearningPreviewRequest {
+  itemId: number;
+  range?: string;
 }
 
 export interface GetLearningRecordsRequest {
@@ -2694,6 +2703,68 @@ export class DefaultApi extends runtime.BaseAPI {
   ): Promise<LearningItem> {
     const response = await this.createLearningItemRaw(requestParameters, initOverrides);
     return await response.value();
+  }
+
+  /**
+   * Creates request options for createLearningPreviewSession without sending the request
+   */
+  async createLearningPreviewSessionRequestOpts(
+    requestParameters: CreateLearningPreviewSessionRequest,
+  ): Promise<runtime.RequestOpts> {
+    if (requestParameters["itemId"] == null) {
+      throw new runtime.RequiredError(
+        "itemId",
+        'Required parameter "itemId" was null or undefined when calling createLearningPreviewSession().',
+      );
+    }
+
+    const queryParameters: any = {};
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
+
+    let urlPath = `/api/learning/items/{itemId}/preview-session`;
+    urlPath = urlPath.replace("{itemId}", encodeURIComponent(String(requestParameters["itemId"])));
+
+    return {
+      path: urlPath,
+      method: "POST",
+      headers: headerParameters,
+      query: queryParameters,
+    };
+  }
+
+  /**
+   * 重新校验登录状态、发布状态、资源可见范围和管理权限；Office 文件首次访问时在受限服务端进程中转换并缓存为私有 OSS PDF。成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。
+   * 准备学习资源在线预览会话
+   */
+  async createLearningPreviewSessionRaw(
+    requestParameters: CreateLearningPreviewSessionRequest,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<runtime.ApiResponse<void>> {
+    const requestOptions = await this.createLearningPreviewSessionRequestOpts(requestParameters);
+    const response = await this.request(requestOptions, initOverrides);
+
+    return new runtime.VoidApiResponse(response);
+  }
+
+  /**
+   * 重新校验登录状态、发布状态、资源可见范围和管理权限；Office 文件首次访问时在受限服务端进程中转换并缓存为私有 OSS PDF。成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。
+   * 准备学习资源在线预览会话
+   */
+  async createLearningPreviewSession(
+    requestParameters: CreateLearningPreviewSessionRequest,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<void> {
+    await this.createLearningPreviewSessionRaw(requestParameters, initOverrides);
   }
 
   /**
@@ -5267,6 +5338,64 @@ export class DefaultApi extends runtime.BaseAPI {
     initOverrides?: RequestInit | runtime.InitOverrideFunction,
   ): Promise<Array<LearningItem>> {
     const response = await this.getLearningItemsRaw(requestParameters, initOverrides);
+    return await response.value();
+  }
+
+  /**
+   * Creates request options for getLearningPreview without sending the request
+   */
+  async getLearningPreviewRequestOpts(
+    requestParameters: GetLearningPreviewRequest,
+  ): Promise<runtime.RequestOpts> {
+    if (requestParameters["itemId"] == null) {
+      throw new runtime.RequiredError(
+        "itemId",
+        'Required parameter "itemId" was null or undefined when calling getLearningPreview().',
+      );
+    }
+
+    const queryParameters: any = {};
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (requestParameters["range"] != null) {
+      headerParameters["Range"] = String(requestParameters["range"]);
+    }
+
+    let urlPath = `/api/learning/items/{itemId}/preview`;
+    urlPath = urlPath.replace("{itemId}", encodeURIComponent(String(requestParameters["itemId"])));
+
+    return {
+      path: urlPath,
+      method: "GET",
+      headers: headerParameters,
+      query: queryParameters,
+    };
+  }
+
+  /**
+   * 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF，DOC、DOCX、PPT、PPTX 返回缓存的 PDF 副本。该操作不会写入下载时间或下载 IP。
+   * 获取受保护的学习资源在线预览内容
+   */
+  async getLearningPreviewRaw(
+    requestParameters: GetLearningPreviewRequest,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<runtime.ApiResponse<Blob>> {
+    const requestOptions = await this.getLearningPreviewRequestOpts(requestParameters);
+    const response = await this.request(requestOptions, initOverrides);
+
+    return new runtime.BlobApiResponse(response);
+  }
+
+  /**
+   * 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF，DOC、DOCX、PPT、PPTX 返回缓存的 PDF 副本。该操作不会写入下载时间或下载 IP。
+   * 获取受保护的学习资源在线预览内容
+   */
+  async getLearningPreview(
+    requestParameters: GetLearningPreviewRequest,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<Blob> {
+    const response = await this.getLearningPreviewRaw(requestParameters, initOverrides);
     return await response.value();
   }
 

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -2743,7 +2743,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 重新校验登录状态、发布状态、资源可见范围和管理权限；Office 文件首次访问时在受限服务端进程中转换并缓存为私有 OSS PDF。成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。
+   * 重新校验登录状态、发布状态、资源可见范围和管理权限；成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。Office 在线转换在独立低权限 worker 完成前保持禁用。
    * 准备学习资源在线预览会话
    */
   async createLearningPreviewSessionRaw(
@@ -2757,7 +2757,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 重新校验登录状态、发布状态、资源可见范围和管理权限；Office 文件首次访问时在受限服务端进程中转换并缓存为私有 OSS PDF。成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。
+   * 重新校验登录状态、发布状态、资源可见范围和管理权限；成功后设置仅限对应预览路径、HttpOnly、SameSite=Strict 的短时 Cookie，不记录下载时间或下载 IP。Office 在线转换在独立低权限 worker 完成前保持禁用。
    * 准备学习资源在线预览会话
    */
   async createLearningPreviewSession(
@@ -5374,7 +5374,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF，DOC、DOCX、PPT、PPTX 返回缓存的 PDF 副本。该操作不会写入下载时间或下载 IP。
+   * 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF；Office 在线转换在独立低权限 worker 完成前保持禁用。该操作不会写入下载时间或下载 IP。
    * 获取受保护的学习资源在线预览内容
    */
   async getLearningPreviewRaw(
@@ -5388,7 +5388,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF，DOC、DOCX、PPT、PPTX 返回缓存的 PDF 副本。该操作不会写入下载时间或下载 IP。
+   * 使用预览会话 Cookie 再次校验用户和资源权限；返回 inline 内容并支持单段 HTTP Range。原生支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF；Office 在线转换在独立低权限 worker 完成前保持禁用。该操作不会写入下载时间或下载 IP。
    * 获取受保护的学习资源在线预览内容
    */
   async getLearningPreview(

--- a/frontend/src/api/models/MarkNoticeReadRequest.ts
+++ b/frontend/src/api/models/MarkNoticeReadRequest.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/MarkNoticeReadRequest.ts
+++ b/frontend/src/api/models/MarkNoticeReadRequest.ts
@@ -3,6 +3,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -46,6 +46,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -45,6 +45,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/views/LearningCenter.vue
+++ b/frontend/src/views/LearningCenter.vue
@@ -99,6 +99,8 @@ const previewKind = ref<"image" | "video" | "pdf">("pdf");
 const previewConverted = ref(false);
 const previewUrl = ref("");
 const previewItem = ref<LearningItem | null>(null);
+let previewRequestId = 0;
+let previewObjectUrl: string | null = null;
 const statistics = ref<LearningItemStatistics | null>(null);
 const statisticsLoading = ref(false);
 const learningSection = ref<"course" | "resource">("course");
@@ -553,6 +555,16 @@ function openItemDetail(item: LearningItem) {
   detailDrawerVisible.value = true;
 }
 
+function revokePreviewObjectUrl() {
+  if (!previewObjectUrl) return;
+  URL.revokeObjectURL(previewObjectUrl);
+  previewObjectUrl = null;
+}
+
+function isCurrentPreviewRequest(requestId: number, itemId: number) {
+  return requestId === previewRequestId && previewItem.value?.id === itemId;
+}
+
 /** 建立短时预览会话；内容请求只携带 HttpOnly Cookie，不暴露登录令牌或 OSS 地址。 */
 async function openPreview(item: LearningItem) {
   if (isCourseItem(item)) {
@@ -560,6 +572,8 @@ async function openPreview(item: LearningItem) {
     return;
   }
 
+  const requestId = ++previewRequestId;
+  revokePreviewObjectUrl();
   previewItem.value = item;
   previewError.value = "";
   previewConverted.value = false;
@@ -572,16 +586,44 @@ async function openPreview(item: LearningItem) {
       credentials: "same-origin",
       headers: { Authorization: `Bearer ${auth.value?.token ?? ""}` },
     });
+    if (!isCurrentPreviewRequest(requestId, item.id)) return;
     if (!response.ok) {
       const message = (await response.text()).replace(/^"|"$/g, "");
+      if (!isCurrentPreviewRequest(requestId, item.id)) return;
       throw new Error(message || `在线预览准备失败：HTTP ${response.status}`);
     }
 
     const kind = response.headers.get("X-ClubHub-Preview-Kind");
-    previewKind.value = kind === "image" || kind === "video" ? kind : "pdf";
+    const resolvedKind = kind === "image" || kind === "video" ? kind : "pdf";
+    previewKind.value = resolvedKind;
     previewConverted.value = response.headers.get("X-ClubHub-Preview-Converted") === "true";
-    previewUrl.value = `/api/learning/items/${item.id}/preview?v=${Date.now()}`;
+    const contentUrl = `/api/learning/items/${item.id}/preview?v=${Date.now()}`;
+    if (resolvedKind !== "pdf") {
+      previewUrl.value = contentUrl;
+      return;
+    }
+
+    const previewResponse = await fetch(contentUrl, { credentials: "same-origin" });
+    if (!isCurrentPreviewRequest(requestId, item.id)) return;
+    if (!previewResponse.ok) {
+      throw new Error(`预览内容加载失败：HTTP ${previewResponse.status}`);
+    }
+
+    const previewBlob = await previewResponse.blob();
+    if (!isCurrentPreviewRequest(requestId, item.id)) return;
+    if (previewBlob.type && previewBlob.type !== "application/pdf") {
+      throw new Error("预览服务返回了非 PDF 内容");
+    }
+
+    const objectUrl = URL.createObjectURL(previewBlob);
+    if (!isCurrentPreviewRequest(requestId, item.id)) {
+      URL.revokeObjectURL(objectUrl);
+      return;
+    }
+    previewObjectUrl = objectUrl;
+    previewUrl.value = objectUrl;
   } catch (error) {
+    if (!isCurrentPreviewRequest(requestId, item.id)) return;
     previewLoading.value = false;
     previewError.value = toErrorMessage(error, "在线预览准备失败，请稍后重试");
   }
@@ -599,6 +641,8 @@ function markPreviewFailed() {
 }
 
 function clearPreview() {
+  previewRequestId += 1;
+  revokePreviewObjectUrl();
   previewUrl.value = "";
   previewItem.value = null;
   previewError.value = "";
@@ -1218,6 +1262,8 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  previewRequestId += 1;
+  revokePreviewObjectUrl();
   stopSessionChange?.();
 });
 </script>

--- a/frontend/src/views/LearningCenter.vue
+++ b/frontend/src/views/LearningCenter.vue
@@ -92,6 +92,13 @@ const progressSavingId = ref<number | null>(null);
 const learningId = ref<number | null>(null);
 const downloadingId = ref<number | null>(null);
 const deletingId = ref<number | null>(null);
+const previewDialogVisible = ref(false);
+const previewLoading = ref(false);
+const previewError = ref("");
+const previewKind = ref<"image" | "video" | "pdf">("pdf");
+const previewConverted = ref(false);
+const previewUrl = ref("");
+const previewItem = ref<LearningItem | null>(null);
 const statistics = ref<LearningItemStatistics | null>(null);
 const statisticsLoading = ref(false);
 const learningSection = ref<"course" | "resource">("course");
@@ -546,6 +553,58 @@ function openItemDetail(item: LearningItem) {
   detailDrawerVisible.value = true;
 }
 
+/** 建立短时预览会话；内容请求只携带 HttpOnly Cookie，不暴露登录令牌或 OSS 地址。 */
+async function openPreview(item: LearningItem) {
+  if (isCourseItem(item)) {
+    ElMessage.warning("培训课程没有可在线预览的资源文件");
+    return;
+  }
+
+  previewItem.value = item;
+  previewError.value = "";
+  previewConverted.value = false;
+  previewUrl.value = "";
+  previewLoading.value = true;
+  previewDialogVisible.value = true;
+  try {
+    const response = await fetch(`/api/learning/items/${item.id}/preview-session`, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { Authorization: `Bearer ${auth.value?.token ?? ""}` },
+    });
+    if (!response.ok) {
+      const message = (await response.text()).replace(/^"|"$/g, "");
+      throw new Error(message || `在线预览准备失败：HTTP ${response.status}`);
+    }
+
+    const kind = response.headers.get("X-ClubHub-Preview-Kind");
+    previewKind.value = kind === "image" || kind === "video" ? kind : "pdf";
+    previewConverted.value = response.headers.get("X-ClubHub-Preview-Converted") === "true";
+    previewUrl.value = `/api/learning/items/${item.id}/preview?v=${Date.now()}`;
+  } catch (error) {
+    previewLoading.value = false;
+    previewError.value = toErrorMessage(error, "在线预览准备失败，请稍后重试");
+  }
+}
+
+function markPreviewReady() {
+  previewLoading.value = false;
+}
+
+function markPreviewFailed() {
+  previewLoading.value = false;
+  previewError.value = previewConverted.value
+    ? "Office 文档转换后的预览加载失败，请稍后重试或在获得权限后下载查看。"
+    : "预览内容加载失败，请检查网络后重试。";
+}
+
+function clearPreview() {
+  previewUrl.value = "";
+  previewItem.value = null;
+  previewError.value = "";
+  previewLoading.value = false;
+}
+
 /** 确认后删除有权管理的课程或资源，并刷新当前列表。 */
 async function deleteResource(item: LearningItem) {
   if (!canDeleteItem(item)) return;
@@ -987,9 +1046,9 @@ async function startLearning(item: LearningItem) {
   learningId.value = item.id;
   try {
     await api.startLearningItem({ itemId: item.id });
-    ElMessage.success("学习记录已创建，可继续更新进度和时长");
+    ElMessage.success("学习记录已创建，正在打开资源内容");
     await loadLearningItems();
-    await openRecords(item);
+    await openPreview(item);
   } catch (error) {
     ElMessage.error(toErrorMessage(error, "开始学习失败"));
   } finally {
@@ -1356,6 +1415,9 @@ onUnmounted(() => {
           >
             退出课程
           </el-button>
+          <el-button v-if="!isCourseItem(row)" size="small" @click="openPreview(row)">
+            在线预览
+          </el-button>
           <el-button
             v-if="!isCourseItem(row)"
             size="small"
@@ -1470,8 +1532,94 @@ onUnmounted(() => {
             {{ detailItem.currentEnrollments }}
           </el-descriptions-item>
         </el-descriptions>
+        <div v-if="!isCourseItem(detailItem)" class="detail-actions">
+          <el-button type="primary" plain @click="openPreview(detailItem)">在线预览</el-button>
+          <el-button
+            type="primary"
+            :disabled="!detailItem.canStartLearning"
+            :loading="learningId === detailItem.id"
+            @click="startLearning(detailItem)"
+          >
+            {{ detailItem.currentUserRecordStatus === "none" ? "开始学习" : "继续学习" }}
+          </el-button>
+          <el-button
+            type="success"
+            :disabled="!detailItem.canDownload"
+            :loading="downloadingId === detailItem.id"
+            @click="downloadItem(detailItem)"
+          >
+            下载
+          </el-button>
+        </div>
       </template>
     </el-drawer>
+
+    <el-dialog
+      v-model="previewDialogVisible"
+      :title="previewItem ? `在线预览 · ${previewItem.title}` : '在线预览'"
+      width="min(1100px, 96vw)"
+      destroy-on-close
+      @closed="clearPreview"
+    >
+      <div
+        class="preview-stage"
+        v-loading="previewLoading"
+        :element-loading-text="
+          previewConverted ? '正在转换并加载 Office 文档…' : '正在安全加载预览内容…'
+        "
+      >
+        <el-alert
+          v-if="previewError"
+          :title="previewError"
+          type="error"
+          :closable="false"
+          show-icon
+        />
+        <img
+          v-else-if="previewUrl && previewKind === 'image'"
+          class="preview-image"
+          :src="previewUrl"
+          :alt="previewItem?.title ?? '学习资源图片'"
+          referrerpolicy="no-referrer"
+          @load="markPreviewReady"
+          @error="markPreviewFailed"
+        />
+        <video
+          v-else-if="previewUrl && previewKind === 'video'"
+          class="preview-video"
+          :src="previewUrl"
+          controls
+          preload="metadata"
+          @loadedmetadata="markPreviewReady"
+          @error="markPreviewFailed"
+        >
+          当前浏览器不支持该视频格式。
+        </video>
+        <iframe
+          v-else-if="previewUrl"
+          class="preview-document"
+          :src="previewUrl"
+          :title="previewItem?.title ?? '学习资源文档'"
+          referrerpolicy="no-referrer"
+          @load="markPreviewReady"
+        />
+      </div>
+      <p class="preview-security-tip">
+        在线预览与下载权限相互独立，不会记录下载时间或
+        IP。浏览器必须接收内容才能展示，在线预览不能作为 DRM，也无法完全阻止截图、抓包或另存。
+      </p>
+      <template #footer>
+        <el-button @click="previewDialogVisible = false">关闭</el-button>
+        <el-button
+          v-if="previewItem?.canDownload"
+          type="success"
+          :loading="downloadingId === previewItem.id"
+          @click="previewItem && downloadItem(previewItem)"
+        >
+          下载原文件
+        </el-button>
+      </template>
+    </el-dialog>
 
     <el-dialog v-model="uploadDialogVisible" title="资源上传" width="620px">
       <el-form label-width="100px">
@@ -1898,6 +2046,50 @@ onUnmounted(() => {
   white-space: pre-wrap;
 }
 
+.detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.preview-stage {
+  display: flex;
+  min-height: 520px;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid var(--el-border-color);
+  border-radius: 8px;
+  background: var(--el-fill-color-light);
+}
+
+.preview-image {
+  max-width: 100%;
+  max-height: 72vh;
+  object-fit: contain;
+}
+
+.preview-video {
+  width: 100%;
+  max-height: 72vh;
+  background: #000;
+}
+
+.preview-document {
+  width: 100%;
+  height: 72vh;
+  border: 0;
+  background: #fff;
+}
+
+.preview-security-tip {
+  margin: 12px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
 .field-tip {
   margin-left: 10px;
   color: var(--el-text-color-secondary);
@@ -1940,6 +2132,14 @@ onUnmounted(() => {
 
   .toolbar-spacer {
     display: none;
+  }
+
+  .preview-stage {
+    min-height: 360px;
+  }
+
+  .preview-document {
+    height: 60vh;
   }
 }
 </style>


### PR DESCRIPTION
## 改动内容

- 按 API-first 流程新增预览会话和受保护的预览内容接口，并由工作流生成对应的前端 API 客户端。
- 支持 MP4、WebM、JPG、JPEG、PNG、GIF、WebP 和 PDF 原生在线预览。
- 支持 DOC、DOCX、PPT、PPTX 通过受限的 LibreOffice 进程转换为 PDF，并将转换结果缓存到私有 OSS。
- 使用按资源隔离的短时 HttpOnly Cookie 加载预览内容，不向浏览器暴露登录令牌、OSS 内部地址或永久公开链接。
- 复用现有发布状态、资源可见范围、社团成员关系和管理权限校验。
- 支持单段 HTTP Range、正确的 inline MIME 响应和防 MIME 嗅探等安全响应头。
- 保持在线预览与显式下载相互独立，预览不会写入下载时间或下载 IP。
- 删除资源时同步清理 Office 预览副本。
- 在资源列表和详情中增加“在线预览”入口；“开始学习/继续学习”成功后直接打开预览。
- 新增格式识别、Range、权限策略、响应头、Office 文件校验和预览令牌测试。
- 生产后端镜像安装 LibreOffice Writer、Impress 和中文字体。

## 改动原因

学习中心原有文件接口以显式下载为主，无法满足禁止下载或需要审批的资源在系统内阅读的需求。浏览器也无法直接展示 Word 和 PowerPoint 文件。

本次改动建立独立的在线预览链路，在继续使用私有 OSS 和现有权限体系的同时，为浏览器原生格式提供流式读取，并为 Office 文件提供受限转换和缓存能力。

---

## 关联 Issue

Closes #144

## 审查关注点

- 预览权限是否完整复用资源可见范围、发布状态和管理权限。
- 短时预览 Cookie 是否正确限制到指定资源路径，且不能替代普通登录令牌。
- 私有 OSS 的 Range 请求、流释放和异常映射是否正确。
- Office 转换的文件签名校验、超时、内存、输入输出大小限制是否合理。
- 删除资源时数据库事务、原文件和预览缓存的清理顺序是否合适。
- 生产镜像新增 LibreOffice 后的体积和构建时间是否可以接受。

## UI 改动

Draft 阶段暂未附截图，待连接可用的后端与测试资源后补充。

| 改动前 | 改动后 |
|--------|--------|
| 资源仅支持开始学习和显式下载 | 列表及详情增加在线预览，开始/继续学习后直接打开内容 |

## 测试说明

已完成：

- OpenAPI Generator 2.39.1 契约校验通过，API 生成工作流成功。
- 拉取自动生成的前端 API 客户端后，`dotnet test` 仍为 32/32 通过。
- 拉取自动生成的前端 API 客户端后，`pnpm run build` 再次通过。
- 本次修改的 C# 文件通过 `dotnet format --verify-no-changes`。
- `LearningCenter.vue` 通过 Prettier 检查。
- 生产及开发 Compose 静态配置校验通过。
- `git diff --check` 通过。

待完成：

- 尚未连接真实私有 OSS 和 LibreOffice 运行时执行端到端手工预览。由于本地后端无法连接私有 OSS，可以合并到main后再手工测试。

已知基线警告：

- 测试项目现有的 `Microsoft.OpenApi 2.0.0` 依赖存在安全公告，本次改动未新增或升级该依赖。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过（`dotnet build`）
- [x] 前端代码已构建通过（`pnpm build`）
- [ ] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`（不适用）
- [ ] 种子数据、视图、索引、触发器、存储过程已同步（不适用）

**文档与部署（仅涉及时勾选）**
- [x] 无需修改课程文档、README 或协作流程文档
- [ ] 需要新增或修改 GitHub Secrets（不需要）
- [ ] 需要修改服务器配置或手动迁移（不需要，依赖由镜像安装）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增学习资源在线预览，支持图片、视频和 PDF。
  * 支持文档在线转换为 PDF，并提供短时安全预览会话。
  * 支持视频和大文件的分段加载。
  * 学习成功后可直接打开资源预览；列表和详情中新增预览入口。
  * 预览窗口支持加载状态、错误提示及下载原文件。

* **Bug 修复**
  * 优化预览权限校验、资源可见性判断及预览内容安全策略。
  * 改善无效格式、过期会话、无效范围和预览服务不可用时的错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->