### PR TITLE
fix(notice): 完善公告通知角色权限边界

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -233,7 +233,12 @@ paths:
   /api/notices:
     get:
       summary: 查询公告通知
-      description: 从 Bearer Token 识别当前用户，按其权限返回面向全校、社团、部门或成员的有效通知，并附带已读状态。
+      description: |
+        从 Bearer Token 识别当前用户，并按权限码、社团作用域、目标范围和通知状态过滤结果：
+        普通用户仅能查看面向全校、本人或本人有效社团/部门的已发布通知；
+        具备目标社团 notice:publish 权限的干部、负责人和指导老师可查看该社团草稿、过期通知及阅读统计；
+        具备 notice:publish:school 权限的社团管理员可管理校级通知，系统管理员拥有全部范围。
+        普通接收者只返回本人已读状态，不返回受众人数和已读人数。
       operationId: getNotices
       security:
         - bearerAuth: []
@@ -294,7 +299,10 @@ paths:
                 $ref: "#/components/schemas/ApiError"
     post:
       summary: 新建公告通知
-      description: 从 Bearer Token 识别操作人，保存草稿或发布面向全校、指定社团、指定部门或指定成员的通知，并校验权限和目标对象。
+      description: |
+        从 Bearer Token 识别操作人。具备目标社团 notice:publish 权限的社团干部、负责人和指导老师
+        可以保存或发布本社团、部门或成员通知；具备 notice:publish:school 权限的社团管理员可发布
+        全校或跨社团通知，系统管理员拥有全部范围。服务端校验权限、社团作用域和目标对象。
       operationId: createNotice
       security:
         - bearerAuth: []
@@ -347,7 +355,7 @@ paths:
   /api/notices/{noticeId}:
     patch:
       summary: 编辑或发布通知草稿
-      description: 仅草稿允许修改；保存时保持草稿状态，发布时将发布时间更新为当前时间。操作人必须是草稿创建人或具备对应通知管理权限。
+      description: 仅草稿允许修改；保存时保持草稿状态，发布时将发布时间更新为当前时间。操作人必须是草稿创建人，或在对应范围具备 notice:publish / notice:publish:school 权限。
       operationId: updateNoticeDraft
       security:
         - bearerAuth: []
@@ -420,7 +428,7 @@ paths:
                 $ref: "#/components/schemas/ApiError"
     delete:
       summary: 删除通知草稿
-      description: 仅草稿允许删除；操作人必须是草稿创建人或具备对应通知管理权限。
+      description: 仅草稿允许删除；操作人必须是草稿创建人，或在对应范围具备 notice:publish / notice:publish:school 权限。
       operationId: deleteNoticeDraft
       security:
         - bearerAuth: []
@@ -477,7 +485,7 @@ paths:
   /api/notices/{noticeId}/reads:
     post:
       summary: 标记通知已读
-      description: 当前用户阅读可见通知后写入已读记录；重复标记会返回已有记录。
+      description: 当前用户阅读本人可见且处于已发布状态的通知后写入已读记录；重复标记会返回已有记录。
       operationId: markNoticeRead
       security:
         - bearerAuth: []
@@ -516,7 +524,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiError"
         "409":
-          description: 通知仍是草稿，不能标记已读
+          description: 通知不是已发布状态，不能标记已读
           content:
             application/json:
               schema:
@@ -5657,12 +5665,13 @@ components:
           nullable: true
         audienceCount:
           type: integer
-          description: 当前规则下可接收该通知的用户数。
+          description: 当前规则下可接收该通知的用户数；仅发布者或对应范围的通知管理者可见。
           nullable: true
           example: 28
         readCount:
           type: integer
-          description: 已读人数。
+          description: 已读人数；仅发布者或对应范围的通知管理者可见。
+          nullable: true
           example: 12
       required:
         - id
@@ -5674,7 +5683,6 @@ components:
         - publishAt
         - noticeStatus
         - isRead
-        - readCount
 
     CreateNoticeRequest:
       type: object

--- a/backend.Tests/NoticePermissionMatrixTests.cs
+++ b/backend.Tests/NoticePermissionMatrixTests.cs
@@ -1,0 +1,135 @@
+using ClubHub.Api.Services;
+
+namespace ClubHub.Api.Tests;
+
+public sealed class NoticePermissionMatrixTests
+{
+    private const int ManagedClubId = 10;
+    private const int OtherClubId = 20;
+
+    [Theory]
+    [InlineData("STUDENT", false, false, false)]
+    [InlineData("TEACHER", false, false, false)]
+    [InlineData("CLUB_MEMBER", true, false, false)]
+    [InlineData("CLUB_OFFICER", true, true, false)]
+    [InlineData("CLUB_LEADER", true, true, false)]
+    [InlineData("ADVISOR", true, true, false)]
+    [InlineData("VENUE_ADMIN", false, false, false)]
+    [InlineData("CLUB_ADMIN", true, true, true)]
+    [InlineData("SYSTEM_ADMIN", true, true, true)]
+    public void RolePermissions_EnforceNoticeScope(
+        string roleCode,
+        bool canViewManagedClub,
+        bool canPublishManagedClub,
+        bool canPublishSchool)
+    {
+        var roles = new[] { CreateRole(roleCode, ManagedClubId) };
+
+        Assert.Equal(
+            canViewManagedClub,
+            NoticeAuthorizationPolicy.CanViewClub(roles, ManagedClubId));
+        Assert.Equal(
+            canPublishManagedClub,
+            NoticeAuthorizationPolicy.CanPublishForClub(roles, ManagedClubId));
+        Assert.Equal(
+            canPublishSchool,
+            NoticeAuthorizationPolicy.CanPublishSchool(roles));
+
+        var hasGlobalScope = roleCode is "CLUB_ADMIN" or "SYSTEM_ADMIN";
+        Assert.Equal(
+            hasGlobalScope && canViewManagedClub,
+            NoticeAuthorizationPolicy.CanViewClub(roles, OtherClubId));
+        Assert.Equal(
+            hasGlobalScope && canPublishManagedClub,
+            NoticeAuthorizationPolicy.CanPublishForClub(roles, OtherClubId));
+    }
+
+    [Fact]
+    public void AdvisorNoticePermissions_MatchClubLeader()
+    {
+        var advisorPermissions = NoticePermissionsFor("ADVISOR");
+        var leaderPermissions = NoticePermissionsFor("CLUB_LEADER");
+
+        Assert.Equal(leaderPermissions, advisorPermissions);
+    }
+
+    [Fact]
+    public void StudentMemberPermissions_AreLimitedToJoinedClubs()
+    {
+        var permissions = AuthService.GetRolePermissions("STUDENT")
+            .Concat(AuthService.GetRolePermissions("CLUB_MEMBER"))
+            .Distinct()
+            .ToArray();
+        var roles = new[]
+        {
+            new AuthRole(
+                1,
+                "STUDENT",
+                "普通学生",
+                "普通学生",
+                "system",
+                null,
+                [ManagedClubId],
+                permissions,
+                null)
+        };
+
+        Assert.True(NoticeAuthorizationPolicy.CanViewClub(roles, ManagedClubId));
+        Assert.False(NoticeAuthorizationPolicy.CanViewClub(roles, OtherClubId));
+        Assert.False(NoticeAuthorizationPolicy.CanPublishForClub(roles, ManagedClubId));
+    }
+
+    [Fact]
+    public void ReadStatistics_AreVisibleOnlyToPublisherOrScopedManager()
+    {
+        var memberRoles = new[] { CreateRole("CLUB_MEMBER", ManagedClubId) };
+        var officerRoles = new[] { CreateRole("CLUB_OFFICER", ManagedClubId) };
+
+        Assert.True(NoticeAuthorizationPolicy.CanViewStatistics(
+            memberRoles,
+            viewerUserId: 7,
+            publisherUserId: 7,
+            clubId: ManagedClubId));
+        Assert.False(NoticeAuthorizationPolicy.CanViewStatistics(
+            memberRoles,
+            viewerUserId: 7,
+            publisherUserId: 8,
+            clubId: ManagedClubId));
+        Assert.True(NoticeAuthorizationPolicy.CanViewStatistics(
+            officerRoles,
+            viewerUserId: 7,
+            publisherUserId: 8,
+            clubId: ManagedClubId));
+        Assert.False(NoticeAuthorizationPolicy.CanViewStatistics(
+            officerRoles,
+            viewerUserId: 7,
+            publisherUserId: 8,
+            clubId: OtherClubId));
+    }
+
+    private static AuthRole CreateRole(string roleCode, int clubId)
+    {
+        var isSystemRole = roleCode is "STUDENT" or "TEACHER" or "VENUE_ADMIN" or
+            "CLUB_ADMIN" or "SYSTEM_ADMIN";
+        IReadOnlyList<int> scopedClubIds = isSystemRole ? [] : [clubId];
+
+        return new AuthRole(
+            1,
+            roleCode,
+            roleCode,
+            roleCode,
+            isSystemRole ? "system" : "club",
+            roleCode == "ADVISOR" || isSystemRole ? null : clubId,
+            scopedClubIds,
+            AuthService.GetRolePermissions(roleCode),
+            null);
+    }
+
+    private static string[] NoticePermissionsFor(string roleCode) =>
+        AuthService.GetRolePermissions(roleCode)
+            .Where(permission => permission is
+                NoticeAuthorizationPolicy.ClubViewPermission or
+                NoticeAuthorizationPolicy.ClubPublishPermission)
+            .OrderBy(permission => permission)
+            .ToArray();
+}

--- a/backend/Controllers/NoticesController.cs
+++ b/backend/Controllers/NoticesController.cs
@@ -324,7 +324,9 @@ public class NoticesController : ControllerBase
         }
         var permissionRoles = await _authService.GetPermissionRolesAsync(user.UserId);
 
-        var notice = await NoticeQuery().FirstOrDefaultAsync(n => n.NoticeId == noticeId);
+        var notice = await _db.Notices
+            .AsNoTracking()
+            .FirstOrDefaultAsync(n => n.NoticeId == noticeId);
         if (notice is null) return NotFound(new { message = "通知不存在。" });
 
         var effectiveStatus = EffectiveStatus(notice, DateTime.UtcNow);
@@ -332,7 +334,9 @@ public class NoticesController : ControllerBase
         {
             return Conflict(new { message = "只有已发布通知可以标记已读。" });
         }
-        var context = await NoticeListContext.LoadAsync(_db, [notice]);
+        var context = notice.TargetType == TargetDepartment
+            ? await NoticeListContext.LoadAsync(_db, [notice])
+            : NoticeListContext.Empty;
         if (!CanViewNotice(user, permissionRoles, notice, effectiveStatus, context))
         {
             return StatusCode(403, new { message = "当前用户不可阅读该通知。" });
@@ -534,12 +538,6 @@ public class NoticesController : ControllerBase
         string effectiveStatus,
         NoticeListContext context)
     {
-        if (effectiveStatus == StatusDraft)
-        {
-            return notice.PublisherUserId == viewer.UserId ||
-                NoticeAuthorizationPolicy.CanManageNotice(permissionRoles, notice.ClubId);
-        }
-
         if (effectiveStatus != StatusPublished)
         {
             return notice.PublisherUserId == viewer.UserId ||
@@ -809,6 +807,8 @@ public class NoticesController : ControllerBase
 
     private sealed class NoticeListContext
     {
+        public static NoticeListContext Empty { get; } = new();
+
         public Dictionary<int, ClubMember> DepartmentTargets { get; private init; } = [];
 
         public Dictionary<int, User> MemberTargets { get; private init; } = [];

--- a/backend/Controllers/NoticesController.cs
+++ b/backend/Controllers/NoticesController.cs
@@ -1,10 +1,12 @@
 using System.Globalization;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
+using ClubHub.Api.Services;
 using ClubHub.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using PermissionRole = ClubHub.Api.Services.AuthRole;
 using ApiCreateNoticeRequest = Org.OpenAPITools.Models.CreateNoticeRequest;
 using ApiNotice = Org.OpenAPITools.Models.Notice;
 using ApiNoticeReadResult = Org.OpenAPITools.Models.NoticeReadResult;
@@ -26,18 +28,14 @@ public class NoticesController : ControllerBase
     private const string StatusDeleting = "deleting";
     private const string MemberActive = "active";
 
-    private static readonly HashSet<string> NoticePublisherRoleCodes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "club_officer",
-        "club_leader",
-        "club_president",
-        "club_manager",
-        "president"
-    };
-
     private readonly ClubHubDbContext _db;
+    private readonly AuthService _authService;
 
-    public NoticesController(ClubHubDbContext db) => _db = db;
+    public NoticesController(ClubHubDbContext db, AuthService authService)
+    {
+        _db = db;
+        _authService = authService;
+    }
 
     [HttpGet]
     public async Task<IActionResult> GetAll(
@@ -55,6 +53,7 @@ public class NoticesController : ControllerBase
         {
             return StatusCode(403, new { message = "当前用户账号不可用，不能查看通知。" });
         }
+        var permissionRoles = await _authService.GetPermissionRolesAsync(viewer.UserId);
 
         var normalizedStatus = NormalizeStatus(noticeStatus);
         if (noticeStatus is not null && normalizedStatus is null)
@@ -92,12 +91,12 @@ public class NoticesController : ControllerBase
                 continue;
             }
 
-            if (!CanViewNotice(viewer, notice, effectiveStatus, context))
+            if (!CanViewNotice(viewer, permissionRoles, notice, effectiveStatus, context))
             {
                 continue;
             }
 
-            var dto = ToApiNotice(notice, viewer.UserId, context, effectiveStatus);
+            var dto = ToApiNotice(notice, viewer.UserId, permissionRoles, context, effectiveStatus);
             if (unreadOnly && dto.IsRead) continue;
             result.Add(dto);
         }
@@ -120,6 +119,7 @@ public class NoticesController : ControllerBase
         {
             return StatusCode(403, new { message = "发布人账号不可用，不能发布通知。" });
         }
+        var permissionRoles = await _authService.GetPermissionRolesAsync(publisher.UserId);
 
         var targetType = NormalizeTargetType(req.TargetType)!;
         var noticeType = req.NoticeType.Trim();
@@ -130,7 +130,7 @@ public class NoticesController : ControllerBase
             return BadRequest(new { message = "过期时间必须晚于当前时间。" });
         }
 
-        var target = await ResolveCreateTargetAsync(req, publisher, targetType);
+        var target = await ResolveCreateTargetAsync(req, permissionRoles, targetType);
         if (target.Result is not null) return target.Result;
 
         var maxId = await _db.Notices.MaxAsync(n => (int?)n.NoticeId) ?? 0;
@@ -154,7 +154,9 @@ public class NoticesController : ControllerBase
 
         var created = await NoticeQuery().FirstAsync(n => n.NoticeId == notice.NoticeId);
         var context = await NoticeListContext.LoadAsync(_db, [created]);
-        return CreatedAtAction(nameof(GetAll), ToApiNotice(created, publisher.UserId, context));
+        return CreatedAtAction(
+            nameof(GetAll),
+            ToApiNotice(created, publisher.UserId, permissionRoles, context));
     }
 
     [HttpPatch("{noticeId:int}")]
@@ -179,6 +181,7 @@ public class NoticesController : ControllerBase
         {
             return StatusCode(403, new { message = "当前用户账号不可用，不能维护通知草稿。" });
         }
+        var permissionRoles = await _authService.GetPermissionRolesAsync(operatorUser.UserId);
 
         var notice = await NoticeQuery(asNoTracking: true).FirstOrDefaultAsync(n => n.NoticeId == noticeId);
         if (notice is null) return NotFound(new { message = "通知草稿不存在。" });
@@ -191,7 +194,8 @@ public class NoticesController : ControllerBase
             return Conflict(new { message = "草稿已被其他操作修改，请刷新后重试。" });
         }
 
-        if (notice.PublisherUserId != operatorUser.UserId && !CanManageNotice(operatorUser, notice))
+        if (notice.PublisherUserId != operatorUser.UserId &&
+            !NoticeAuthorizationPolicy.CanManageNotice(permissionRoles, notice.ClubId))
         {
             return StatusCode(403, new { message = "当前用户没有维护该通知草稿的权限。" });
         }
@@ -204,7 +208,7 @@ public class NoticesController : ControllerBase
             return BadRequest(new { message = "过期时间必须晚于当前时间。" });
         }
 
-        var target = await ResolveCreateTargetAsync(req, operatorUser, targetType);
+        var target = await ResolveCreateTargetAsync(req, permissionRoles, targetType);
         if (target.Result is not null) return target.Result;
         var publishAt = status == StatusPublished
             ? requestTime
@@ -243,7 +247,7 @@ public class NoticesController : ControllerBase
 
         var updated = await NoticeQuery().FirstAsync(n => n.NoticeId == noticeId);
         var context = await NoticeListContext.LoadAsync(_db, [updated]);
-        return Ok(ToApiNotice(updated, operatorUser.UserId, context));
+        return Ok(ToApiNotice(updated, operatorUser.UserId, permissionRoles, context));
     }
 
     [HttpDelete("{noticeId:int}")]
@@ -264,6 +268,7 @@ public class NoticesController : ControllerBase
         {
             return StatusCode(403, new { message = "当前用户账号不可用，不能删除通知草稿。" });
         }
+        var permissionRoles = await _authService.GetPermissionRolesAsync(operatorUser.UserId);
 
         var notice = await NoticeQuery(asNoTracking: true).FirstOrDefaultAsync(n => n.NoticeId == noticeId);
         if (notice is null) return NotFound(new { message = "通知草稿不存在。" });
@@ -276,7 +281,8 @@ public class NoticesController : ControllerBase
             return Conflict(new { message = "草稿已被其他操作修改，请刷新后重试。" });
         }
 
-        if (notice.PublisherUserId != operatorUser.UserId && !CanManageNotice(operatorUser, notice))
+        if (notice.PublisherUserId != operatorUser.UserId &&
+            !NoticeAuthorizationPolicy.CanManageNotice(permissionRoles, notice.ClubId))
         {
             return StatusCode(403, new { message = "当前用户没有删除该通知草稿的权限。" });
         }
@@ -316,17 +322,18 @@ public class NoticesController : ControllerBase
         {
             return StatusCode(403, new { message = "当前用户账号不可用，不能标记通知已读。" });
         }
+        var permissionRoles = await _authService.GetPermissionRolesAsync(user.UserId);
 
         var notice = await NoticeQuery().FirstOrDefaultAsync(n => n.NoticeId == noticeId);
         if (notice is null) return NotFound(new { message = "通知不存在。" });
 
         var effectiveStatus = EffectiveStatus(notice, DateTime.UtcNow);
-        if (effectiveStatus == StatusDraft)
+        if (effectiveStatus != StatusPublished)
         {
-            return Conflict(new { message = "通知草稿尚未发布，不能标记已读。" });
+            return Conflict(new { message = "只有已发布通知可以标记已读。" });
         }
         var context = await NoticeListContext.LoadAsync(_db, [notice]);
-        if (!CanViewNotice(user, notice, effectiveStatus, context))
+        if (!CanViewNotice(user, permissionRoles, notice, effectiveStatus, context))
         {
             return StatusCode(403, new { message = "当前用户不可阅读该通知。" });
         }
@@ -395,22 +402,22 @@ public class NoticesController : ControllerBase
 
     private async Task<(IActionResult? Result, int? ClubId, int? TargetId)> ResolveCreateTargetAsync(
         ApiCreateNoticeRequest req,
-        User publisher,
+        IReadOnlyList<PermissionRole> permissionRoles,
         string targetType)
     {
         return targetType switch
         {
-            TargetSchool => await ResolveSchoolTargetAsync(req, publisher),
-            TargetClub => await ResolveClubTargetAsync(req, publisher),
-            TargetDepartment => await ResolveDepartmentTargetAsync(req, publisher),
-            TargetMember => await ResolveMemberTargetAsync(req, publisher),
+            TargetSchool => await ResolveSchoolTargetAsync(req, permissionRoles),
+            TargetClub => await ResolveClubTargetAsync(req, permissionRoles),
+            TargetDepartment => await ResolveDepartmentTargetAsync(req, permissionRoles),
+            TargetMember => await ResolveMemberTargetAsync(req, permissionRoles),
             _ => (BadRequest(new { message = "定向类型不合法。" }), null, null)
         };
     }
 
     private Task<(IActionResult? Result, int? ClubId, int? TargetId)> ResolveSchoolTargetAsync(
         ApiCreateNoticeRequest req,
-        User publisher)
+        IReadOnlyList<PermissionRole> permissionRoles)
     {
         if (req.TargetId is not null || req.ClubId is not null)
         {
@@ -418,7 +425,7 @@ public class NoticesController : ControllerBase
                 (BadRequest(new { message = "全校通知不需要填写社团或目标 ID。" }), null, null));
         }
 
-        if (!UsersController.IsPlatformAdmin(publisher))
+        if (!NoticeAuthorizationPolicy.CanPublishSchool(permissionRoles))
         {
             return Task.FromResult<(IActionResult? Result, int? ClubId, int? TargetId)>(
                 (StatusCode(403, new { message = "只有社团管理员或系统管理员可以发布全校通知。" }), null, null));
@@ -429,7 +436,7 @@ public class NoticesController : ControllerBase
 
     private async Task<(IActionResult? Result, int? ClubId, int? TargetId)> ResolveClubTargetAsync(
         ApiCreateNoticeRequest req,
-        User publisher)
+        IReadOnlyList<PermissionRole> permissionRoles)
     {
         if (req.TargetId is null or <= 0)
         {
@@ -438,7 +445,7 @@ public class NoticesController : ControllerBase
 
         var club = await _db.Clubs.FindAsync(req.TargetId.Value);
         if (club is null) return (NotFound(new { message = "目标社团不存在。" }), null, null);
-        if (!CanPublishForClub(publisher, club.ClubId))
+        if (!NoticeAuthorizationPolicy.CanPublishForClub(permissionRoles, club.ClubId))
         {
             return (StatusCode(403, new { message = "当前用户没有该社团的通知发布权限。" }), null, null);
         }
@@ -448,7 +455,7 @@ public class NoticesController : ControllerBase
 
     private async Task<(IActionResult? Result, int? ClubId, int? TargetId)> ResolveDepartmentTargetAsync(
         ApiCreateNoticeRequest req,
-        User publisher)
+        IReadOnlyList<PermissionRole> permissionRoles)
     {
         if (req.TargetId is null or <= 0)
         {
@@ -464,7 +471,7 @@ public class NoticesController : ControllerBase
             return (BadRequest(new { message = "目标成员未登记部门，不能作为部门通知目标。" }), null, null);
         }
 
-        if (!CanPublishForClub(publisher, member.ClubId))
+        if (!NoticeAuthorizationPolicy.CanPublishForClub(permissionRoles, member.ClubId))
         {
             return (StatusCode(403, new { message = "当前用户没有该社团部门的通知发布权限。" }), null, null);
         }
@@ -474,7 +481,7 @@ public class NoticesController : ControllerBase
 
     private async Task<(IActionResult? Result, int? ClubId, int? TargetId)> ResolveMemberTargetAsync(
         ApiCreateNoticeRequest req,
-        User publisher)
+        IReadOnlyList<PermissionRole> permissionRoles)
     {
         if (req.TargetId is null or <= 0)
         {
@@ -486,7 +493,7 @@ public class NoticesController : ControllerBase
 
         if (req.ClubId is null)
         {
-            if (!UsersController.IsPlatformAdmin(publisher))
+            if (!NoticeAuthorizationPolicy.CanPublishSchool(permissionRoles))
             {
                 return (StatusCode(403, new { message = "未指定社团时，只有社团管理员或系统管理员可以定向通知单个成员。" }), null, null);
             }
@@ -496,7 +503,7 @@ public class NoticesController : ControllerBase
 
         var club = await _db.Clubs.FindAsync(req.ClubId.Value);
         if (club is null) return (NotFound(new { message = "成员所属社团不存在。" }), null, null);
-        if (!CanPublishForClub(publisher, club.ClubId))
+        if (!NoticeAuthorizationPolicy.CanPublishForClub(permissionRoles, club.ClubId))
         {
             return (StatusCode(403, new { message = "当前用户没有该社团的成员通知发布权限。" }), null, null);
         }
@@ -520,58 +527,49 @@ public class NoticesController : ControllerBase
         return (null, club.ClubId, targetUser.UserId);
     }
 
-    private bool CanViewNotice(User viewer, Notice notice, string effectiveStatus, NoticeListContext context)
+    private bool CanViewNotice(
+        User viewer,
+        IReadOnlyList<PermissionRole> permissionRoles,
+        Notice notice,
+        string effectiveStatus,
+        NoticeListContext context)
     {
         if (effectiveStatus == StatusDraft)
         {
-            return notice.PublisherUserId == viewer.UserId || CanManageNotice(viewer, notice);
+            return notice.PublisherUserId == viewer.UserId ||
+                NoticeAuthorizationPolicy.CanManageNotice(permissionRoles, notice.ClubId);
         }
 
         if (effectiveStatus != StatusPublished)
         {
-            return CanManageNotice(viewer, notice);
+            return notice.PublisherUserId == viewer.UserId ||
+                NoticeAuthorizationPolicy.CanManageNotice(permissionRoles, notice.ClubId);
         }
 
         return notice.TargetType switch
         {
             TargetSchool => true,
-            TargetClub => notice.ClubId is not null && CanAccessClubNotice(viewer, notice.ClubId.Value),
-            TargetDepartment => CanAccessDepartmentNotice(viewer, notice, context),
-            TargetMember => notice.TargetId == viewer.UserId || CanManageNotice(viewer, notice),
+            TargetClub => notice.ClubId is not null &&
+                NoticeAuthorizationPolicy.CanViewClub(permissionRoles, notice.ClubId.Value),
+            TargetDepartment => CanAccessDepartmentNotice(
+                viewer,
+                permissionRoles,
+                notice,
+                context),
+            TargetMember => notice.TargetId == viewer.UserId ||
+                NoticeAuthorizationPolicy.CanManageNotice(permissionRoles, notice.ClubId),
             _ => false
         };
     }
 
-    private bool CanManageNotice(User user, Notice notice)
-    {
-        if (UsersController.IsPlatformAdmin(user)) return true;
-        return notice.ClubId is not null && CanPublishForClub(user, notice.ClubId.Value);
-    }
-
-    private bool CanPublishForClub(User user, int clubId)
-    {
-        if (UsersController.IsPlatformAdmin(user)) return true;
-        if (UsersController.IsClubPrincipal(user, clubId)) return true;
-
-        return user.UserRoles.Any(ur =>
-            ur.ClubId == clubId &&
-            ur.Role is not null &&
-            NoticePublisherRoleCodes.Contains(ur.Role.RoleCode));
-    }
-
-    private bool CanAccessClubNotice(User user, int clubId)
-    {
-        if (UsersController.IsPlatformAdmin(user)) return true;
-        if (CanPublishForClub(user, clubId)) return true;
-
-        return user.ClubMemberships.Any(cm => cm.ClubId == clubId && IsActiveMemberTerm(cm)) ||
-               user.UserRoles.Any(ur => ur.ClubId == clubId && ur.Role is not null);
-    }
-
-    private bool CanAccessDepartmentNotice(User user, Notice notice, NoticeListContext context)
+    private bool CanAccessDepartmentNotice(
+        User user,
+        IReadOnlyList<PermissionRole> permissionRoles,
+        Notice notice,
+        NoticeListContext context)
     {
         if (notice.TargetId is null || notice.ClubId is null) return false;
-        if (CanManageNotice(user, notice)) return true;
+        if (NoticeAuthorizationPolicy.CanManageNotice(permissionRoles, notice.ClubId)) return true;
 
         if (!context.DepartmentTargets.TryGetValue(notice.TargetId.Value, out var target) ||
             string.IsNullOrWhiteSpace(target.DepartmentName))
@@ -588,6 +586,7 @@ public class NoticesController : ControllerBase
     private ApiNotice ToApiNotice(
         Notice notice,
         int viewerUserId,
+        IReadOnlyList<PermissionRole> permissionRoles,
         NoticeListContext context,
         string? effectiveStatus = null)
     {
@@ -596,7 +595,11 @@ public class NoticesController : ControllerBase
             .Where(r => r.UserId == viewerUserId)
             .OrderByDescending(r => r.ReadAt)
             .FirstOrDefault();
-        var readCount = notice.Reads.Select(r => r.UserId).Distinct().Count();
+        var canViewStatistics = NoticeAuthorizationPolicy.CanViewStatistics(
+            permissionRoles,
+            viewerUserId,
+            notice.PublisherUserId,
+            notice.ClubId);
         return new ApiNotice
         {
             Id = notice.NoticeId,
@@ -615,8 +618,10 @@ public class NoticesController : ControllerBase
             NoticeStatus = ToApiNoticeStatus(effectiveStatus),
             IsRead = read is not null,
             ReadAt = read?.ReadAt,
-            AudienceCount = CountAudience(notice, context),
-            ReadCount = readCount
+            AudienceCount = canViewStatistics ? CountAudience(notice, context) : null,
+            ReadCount = canViewStatistics
+                ? notice.Reads.Select(r => r.UserId).Distinct().Count()
+                : null
         };
     }
 

--- a/backend/Models/Notice.cs
+++ b/backend/Models/Notice.cs
@@ -223,21 +223,20 @@ namespace Org.OpenAPITools.Models
         public DateTime? ReadAt { get; set; }
 
         /// <summary>
-        /// 当前规则下可接收该通知的用户数。
+        /// 当前规则下可接收该通知的用户数；仅发布者或对应范围的通知管理者可见。
         /// </summary>
-        /// <value>当前规则下可接收该通知的用户数。</value>
+        /// <value>当前规则下可接收该通知的用户数；仅发布者或对应范围的通知管理者可见。</value>
         /* <example>28</example> */
         [DataMember(Name="audienceCount", EmitDefaultValue=true)]
         public int? AudienceCount { get; set; }
 
         /// <summary>
-        /// 已读人数。
+        /// 已读人数；仅发布者或对应范围的通知管理者可见。
         /// </summary>
-        /// <value>已读人数。</value>
+        /// <value>已读人数；仅发布者或对应范围的通知管理者可见。</value>
         /* <example>12</example> */
-        [Required]
         [DataMember(Name="readCount", EmitDefaultValue=true)]
-        public int ReadCount { get; set; }
+        public int? ReadCount { get; set; }
 
     }
 }

--- a/backend/Services/AuthService.cs
+++ b/backend/Services/AuthService.cs
@@ -115,8 +115,8 @@ public class AuthService
             AdvisorRole,
             "指导老师",
             ClubScope,
-            "指定社团指导角色，可查看社团运营、处理本社团物资借还记录、维护并审核学习资源，以及审核活动、项目、经费和评价，可按负责人权限维护成员、考核与评奖评优。",
-            ["club:internal:view", "club:operation:view", "resource:upload", "resource:review", "material:borrow:use", "material:borrow:record", "activity:review", "project:review", "budget:review", "evaluation:review", "evaluation:draft", "club:info:manage", "club:member:manage", "club:role:assign", "club:stats:view"]),
+            "指定社团指导角色，可按负责人权限管理公告通知、成员、考核与评奖评优，并处理社团运营审核工作。",
+            ["club:internal:view", "club:notice:view", "club:operation:view", "notice:publish", "resource:upload", "resource:review", "material:borrow:use", "material:borrow:record", "activity:review", "project:review", "budget:review", "evaluation:review", "evaluation:draft", "club:info:manage", "club:member:manage", "club:role:assign", "club:stats:view"]),
         new(
             "CLUB_ADMIN",
             "社团管理员",
@@ -699,7 +699,7 @@ public class AuthService
         return $"{clubName}{roleSuffix}";
     }
 
-    private static IReadOnlyList<string> GetRolePermissions(string roleCode) =>
+    internal static IReadOnlyList<string> GetRolePermissions(string roleCode) =>
         BaseRoles.FirstOrDefault(role => role.Code == roleCode)?.Permissions ?? [];
 
     private static IReadOnlyList<string> MergePermissions(params IReadOnlyList<string>[] permissionGroups) =>

--- a/backend/Services/NoticeAuthorizationPolicy.cs
+++ b/backend/Services/NoticeAuthorizationPolicy.cs
@@ -1,0 +1,32 @@
+namespace ClubHub.Api.Services;
+
+internal static class NoticeAuthorizationPolicy
+{
+    internal const string ClubViewPermission = "club:notice:view";
+    internal const string ClubPublishPermission = "notice:publish";
+    internal const string SchoolPublishPermission = "notice:publish:school";
+
+    internal static bool CanPublishSchool(IReadOnlyList<AuthRole> roles) =>
+        AuthService.RolesAllow(roles, SchoolPublishPermission, null);
+
+    internal static bool CanPublishForClub(IReadOnlyList<AuthRole> roles, int clubId) =>
+        CanPublishSchool(roles) ||
+        AuthService.RolesAllow(roles, ClubPublishPermission, clubId);
+
+    internal static bool CanViewClub(IReadOnlyList<AuthRole> roles, int clubId) =>
+        CanPublishForClub(roles, clubId) ||
+        AuthService.RolesAllow(roles, ClubViewPermission, clubId);
+
+    internal static bool CanManageNotice(IReadOnlyList<AuthRole> roles, int? clubId) =>
+        clubId is null
+            ? CanPublishSchool(roles)
+            : CanPublishForClub(roles, clubId.Value);
+
+    internal static bool CanViewStatistics(
+        IReadOnlyList<AuthRole> roles,
+        int viewerUserId,
+        int publisherUserId,
+        int? clubId) =>
+        viewerUserId == publisherUserId ||
+        CanManageNotice(roles, clubId);
+}

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -2870,7 +2870,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 从 Bearer Token 识别操作人，保存草稿或发布面向全校、指定社团、指定部门或指定成员的通知，并校验权限和目标对象。
+   * 从 Bearer Token 识别操作人。具备目标社团 notice:publish 权限的社团干部、负责人和指导老师 可以保存或发布本社团、部门或成员通知；具备 notice:publish:school 权限的社团管理员可发布 全校或跨社团通知，系统管理员拥有全部范围。服务端校验权限、社团作用域和目标对象。
    * 新建公告通知
    */
   async createNoticeRaw(
@@ -2884,7 +2884,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 从 Bearer Token 识别操作人，保存草稿或发布面向全校、指定社团、指定部门或指定成员的通知，并校验权限和目标对象。
+   * 从 Bearer Token 识别操作人。具备目标社团 notice:publish 权限的社团干部、负责人和指导老师 可以保存或发布本社团、部门或成员通知；具备 notice:publish:school 权限的社团管理员可发布 全校或跨社团通知，系统管理员拥有全部范围。服务端校验权限、社团作用域和目标对象。
    * 新建公告通知
    */
   async createNotice(
@@ -3468,7 +3468,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 仅草稿允许删除；操作人必须是草稿创建人或具备对应通知管理权限。
+   * 仅草稿允许删除；操作人必须是草稿创建人，或在对应范围具备 notice:publish / notice:publish:school 权限。
    * 删除通知草稿
    */
   async deleteNoticeDraftRaw(
@@ -3482,7 +3482,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 仅草稿允许删除；操作人必须是草稿创建人或具备对应通知管理权限。
+   * 仅草稿允许删除；操作人必须是草稿创建人，或在对应范围具备 notice:publish / notice:publish:school 权限。
    * 删除通知草稿
    */
   async deleteNoticeDraft(
@@ -5699,7 +5699,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 从 Bearer Token 识别当前用户，按其权限返回面向全校、社团、部门或成员的有效通知，并附带已读状态。
+   * 从 Bearer Token 识别当前用户，并按权限码、社团作用域、目标范围和通知状态过滤结果： 普通用户仅能查看面向全校、本人或本人有效社团/部门的已发布通知； 具备目标社团 notice:publish 权限的干部、负责人和指导老师可查看该社团草稿、过期通知及阅读统计； 具备 notice:publish:school 权限的社团管理员可管理校级通知，系统管理员拥有全部范围。 普通接收者只返回本人已读状态，不返回受众人数和已读人数。
    * 查询公告通知
    */
   async getNoticesRaw(
@@ -5713,7 +5713,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 从 Bearer Token 识别当前用户，按其权限返回面向全校、社团、部门或成员的有效通知，并附带已读状态。
+   * 从 Bearer Token 识别当前用户，并按权限码、社团作用域、目标范围和通知状态过滤结果： 普通用户仅能查看面向全校、本人或本人有效社团/部门的已发布通知； 具备目标社团 notice:publish 权限的干部、负责人和指导老师可查看该社团草稿、过期通知及阅读统计； 具备 notice:publish:school 权限的社团管理员可管理校级通知，系统管理员拥有全部范围。 普通接收者只返回本人已读状态，不返回受众人数和已读人数。
    * 查询公告通知
    */
   async getNotices(
@@ -6831,7 +6831,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 当前用户阅读可见通知后写入已读记录；重复标记会返回已有记录。
+   * 当前用户阅读本人可见且处于已发布状态的通知后写入已读记录；重复标记会返回已有记录。
    * 标记通知已读
    */
   async markNoticeReadRaw(
@@ -6847,7 +6847,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 当前用户阅读可见通知后写入已读记录；重复标记会返回已有记录。
+   * 当前用户阅读本人可见且处于已发布状态的通知后写入已读记录；重复标记会返回已有记录。
    * 标记通知已读
    */
   async markNoticeRead(
@@ -9573,7 +9573,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 仅草稿允许修改；保存时保持草稿状态，发布时将发布时间更新为当前时间。操作人必须是草稿创建人或具备对应通知管理权限。
+   * 仅草稿允许修改；保存时保持草稿状态，发布时将发布时间更新为当前时间。操作人必须是草稿创建人，或在对应范围具备 notice:publish / notice:publish:school 权限。
    * 编辑或发布通知草稿
    */
   async updateNoticeDraftRaw(
@@ -9587,7 +9587,7 @@ export class DefaultApi extends runtime.BaseAPI {
   }
 
   /**
-   * 仅草稿允许修改；保存时保持草稿状态，发布时将发布时间更新为当前时间。操作人必须是草稿创建人或具备对应通知管理权限。
+   * 仅草稿允许修改；保存时保持草稿状态，发布时将发布时间更新为当前时间。操作人必须是草稿创建人，或在对应范围具备 notice:publish / notice:publish:school 权限。
    * 编辑或发布通知草稿
    */
   async updateNoticeDraft(

--- a/frontend/src/api/models/MarkNoticeReadRequest.ts
+++ b/frontend/src/api/models/MarkNoticeReadRequest.ts
@@ -4,6 +4,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/api/models/Notice.ts
+++ b/frontend/src/api/models/Notice.ts
@@ -117,17 +117,17 @@ export interface Notice {
    */
   readAt?: Date | null;
   /**
-   * 当前规则下可接收该通知的用户数。
+   * 当前规则下可接收该通知的用户数；仅发布者或对应范围的通知管理者可见。
    * @type {number}
    * @memberof Notice
    */
   audienceCount?: number | null;
   /**
-   * 已读人数。
+   * 已读人数；仅发布者或对应范围的通知管理者可见。
    * @type {number}
    * @memberof Notice
    */
-  readCount: number;
+  readCount?: number | null;
 }
 
 /**
@@ -165,7 +165,6 @@ export function instanceOfNotice(value: object): value is Notice {
   if (!("publishAt" in value) || value["publishAt"] === undefined) return false;
   if (!("noticeStatus" in value) || value["noticeStatus"] === undefined) return false;
   if (!("isRead" in value) || value["isRead"] === undefined) return false;
-  if (!("readCount" in value) || value["readCount"] === undefined) return false;
   return true;
 }
 
@@ -195,7 +194,7 @@ export function NoticeFromJSONTyped(json: any, ignoreDiscriminator: boolean): No
     isRead: json["isRead"],
     readAt: json["readAt"] == null ? undefined : new Date(json["readAt"]),
     audienceCount: json["audienceCount"] == null ? undefined : json["audienceCount"],
-    readCount: json["readCount"],
+    readCount: json["readCount"] == null ? undefined : json["readCount"],
   };
 }
 

--- a/frontend/src/api/models/activity-registration-result.ts
+++ b/frontend/src/api/models/activity-registration-result.ts
@@ -47,6 +47,7 @@
 // @ts-nocheck
 // @ts-nocheck
 // @ts-nocheck
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/frontend/src/views/NoticeCenter.vue
+++ b/frontend/src/views/NoticeCenter.vue
@@ -87,10 +87,7 @@ const canPublishSchool = computed(
 const canPublishClub = computed(
   () =>
     canPublishSchool.value ||
-    permissions.value.includes("notice:publish") ||
-    auth.value?.roles.some((role) =>
-      ["club_officer", "club_leader", "club_president"].includes(role.code.toLowerCase()),
-    ) === true,
+    auth.value?.roles.some((role) => role.permissions?.includes("notice:publish")) === true,
 );
 const canPublish = computed(() => canPublishSchool.value || canPublishClub.value);
 const managedClubIds = computed(() => {
@@ -98,11 +95,7 @@ const managedClubIds = computed(() => {
 
   const ids = new Set<number>();
   auth.value?.roles.forEach((role) => {
-    const roleCode = role.code.toLowerCase();
-    const canRolePublish =
-      role.permissions?.includes("notice:publish") ||
-      ["club_officer", "club_leader", "club_president"].includes(roleCode);
-    if (!canRolePublish) return;
+    if (!role.permissions?.includes("notice:publish")) return;
 
     if (role.clubId) ids.add(role.clubId);
     role.clubIds?.forEach((clubId) => ids.add(clubId));
@@ -143,6 +136,9 @@ const readSummary = computed(() => {
   const unread = notices.value.filter((notice) => !notice.isRead).length;
   return { total, unread, read: total - unread };
 });
+const canViewReadStatistics = computed(() =>
+  notices.value.some((notice) => notice.readCount != null || notice.audienceCount != null),
+);
 const publishDialogTitle = computed(() =>
   editingNoticeId.value === null ? "新建通知" : "编辑通知草稿",
 );
@@ -420,13 +416,13 @@ function buildTargetPayload():
 async function openNoticeDetail(row: Notice) {
   selectedNotice.value = row;
   detailDialogVisible.value = true;
-  if (row.noticeStatus !== "draft" && !row.isRead) await markRead(row);
+  if (row.noticeStatus === "published" && !row.isRead) await markRead(row);
 }
 
 async function markRead(row: Notice) {
   if (
     !currentUserId.value ||
-    row.noticeStatus === "draft" ||
+    row.noticeStatus !== "published" ||
     row.isRead ||
     markingId.value !== null
   )
@@ -451,7 +447,7 @@ async function markRead(row: Notice) {
     if (
       pendingNotice &&
       pendingNotice.id !== row.id &&
-      pendingNotice.noticeStatus !== "draft" &&
+      pendingNotice.noticeStatus === "published" &&
       !pendingNotice.isRead
     ) {
       void markRead(pendingNotice);
@@ -544,6 +540,10 @@ watch(filters, () => {
   void loadNotices();
 });
 
+watch(canPublish, (allowed) => {
+  if (!allowed && filters.noticeStatus !== "published") filters.noticeStatus = "published";
+});
+
 onMounted(() => {
   detailMediaQuery = window.matchMedia("(max-width: 900px)");
   syncDetailLayout();
@@ -599,8 +599,8 @@ onUnmounted(() => {
     <section class="filter-band">
       <el-select v-model="filters.noticeStatus" class="filter-item" placeholder="通知状态">
         <el-option label="已发布" value="published" />
-        <el-option label="草稿" value="draft" />
-        <el-option label="已过期" value="expired" />
+        <el-option v-if="canPublish" label="草稿" value="draft" />
+        <el-option v-if="canPublish" label="已过期" value="expired" />
       </el-select>
       <el-select v-model="filters.targetType" class="filter-item" clearable placeholder="定向范围">
         <el-option label="全校" value="school" />
@@ -626,10 +626,24 @@ onUnmounted(() => {
       <el-table-column label="状态" width="110">
         <template #default="{ row }">
           <el-tag
-            :type="row.noticeStatus === 'draft' ? 'warning' : row.isRead ? 'info' : 'danger'"
+            :type="
+              row.noticeStatus === 'draft'
+                ? 'warning'
+                : row.noticeStatus === 'expired' || row.isRead
+                  ? 'info'
+                  : 'danger'
+            "
             effect="plain"
           >
-            {{ row.noticeStatus === "draft" ? "草稿" : row.isRead ? "已读" : "未读" }}
+            {{
+              row.noticeStatus === "draft"
+                ? "草稿"
+                : row.noticeStatus === "expired"
+                  ? "已过期"
+                  : row.isRead
+                    ? "已读"
+                    : "未读"
+            }}
           </el-tag>
         </template>
       </el-table-column>
@@ -652,9 +666,13 @@ onUnmounted(() => {
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column v-if="filters.noticeStatus !== 'draft'" label="已读" width="110">
+      <el-table-column
+        v-if="filters.noticeStatus !== 'draft' && canViewReadStatistics"
+        label="已读"
+        width="110"
+      >
         <template #default="{ row }">
-          {{ row.readCount }} / {{ row.audienceCount ?? "-" }}
+          {{ row.readCount ?? "-" }} / {{ row.audienceCount ?? "-" }}
         </template>
       </el-table-column>
       <el-table-column label="内容 / 管理" min-width="250" fixed="right">
@@ -777,6 +795,9 @@ onUnmounted(() => {
       <template #footer>
         <div v-if="selectedNotice" class="notice-dialog__footer">
           <span v-if="selectedNotice.noticeStatus === 'draft'">草稿尚未发布，不产生已读记录</span>
+          <span v-else-if="selectedNotice.noticeStatus === 'expired'">
+            通知已过期，不能再标记已读
+          </span>
           <span v-else-if="markingId === selectedNotice.id">正在同步已读状态…</span>
           <span v-else-if="selectedNotice.isRead">
             已于 {{ formatDate(selectedNotice.readAt) }} 阅读
@@ -784,7 +805,7 @@ onUnmounted(() => {
           <span v-else>尚未标记已读</span>
           <div>
             <el-button
-              v-if="selectedNotice.noticeStatus !== 'draft' && !selectedNotice.isRead"
+              v-if="selectedNotice.noticeStatus === 'published' && !selectedNotice.isRead"
               type="primary"
               plain
               :loading="markingId === selectedNotice.id"


### PR DESCRIPTION
## 改动内容

- API-first 明确公告查询、发布、草稿维护、过期通知、已读操作与阅读统计的权限矩阵。
- 新增统一公告授权策略，后端只依据权限码和社团作用域校验发布、查看、草稿管理与统计权限。
- 指导老师显式获得 `club:notice:view`、`notice:publish`，在本人指导社团内与社团负责人权限一致，跨社团仍拒绝。
- 普通接收者不再获得 `audienceCount`、`readCount`；草稿和过期通知仅发布者或相应范围管理者可见。
- 草稿和过期通知禁止标记已读；已发布通知继续按当前 Bearer Token 用户幂等写入本人阅读记录。
- 前端移除公告权限的角色名硬编码，按权限作用域控制发布入口、社团目标、状态筛选、统计列和已读操作。
- 新增九类角色、跨社团、指导老师与统计权限矩阵测试。

## 改动原因

公告通知此前混用权限码和硬编码角色名，指导老师权限与社团负责人不一致，普通接收者还会收到管理统计。按 #142 收敛为统一、可回归的权限边界。

---

## 关联 Issue

Closes #142

## 审查关注点

- 指导老师是否严格限制在本人指导的社团范围。
- `notice:publish` 与 `notice:publish:school` 是否正确隔离社团级和校级范围。
- 普通接收者是否无法获得草稿、过期通知和阅读统计。
- 前端操作级权限是否与后端最终授权保持一致。

## UI 改动

| 改动前 | 改动后 |
| --- | --- |
| 所有登录角色均可选择草稿/过期筛选，列表固定显示阅读统计 | 仅发布/管理角色显示管理状态筛选；仅后端返回统计时展示统计列 |

本次为权限与状态交互收敛，无布局或视觉样式调整，未附截图。

## 测试说明

- `git diff --check`
- `dotnet format ClubHub.sln --verify-no-changes --include backend/Controllers/NoticesController.cs backend/Services/AuthService.cs backend/Services/NoticeAuthorizationPolicy.cs backend.Tests/NoticePermissionMatrixTests.cs`
- `dotnet build ClubHub.sln --configuration Release`
- `dotnet test backend.Tests/ClubHub.Api.Tests.csproj --configuration Release --no-restore`（46 项通过）
- `pnpm exec prettier --check src/views/NoticeCenter.vue`
- `pnpm run build`
- CodeRabbit：已处理 `MarkRead` 轻量查询和重复授权分支两项审查建议

---

### 检查清单

**代码质量**

- [x] 后端代码已构建通过（`dotnet build`）
- [x] 前端代码已构建通过（`pnpm build`）
- [ ] 已本地手工测试主要场景（本地未连接 Oracle 演示数据，使用权限矩阵自动化测试覆盖）

**数据库（仅涉及时勾选）**

- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**

- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets（请在 PR 描述中注明）
- [ ] 需要修改服务器配置或手动迁移