### PR TITLE
feat(forum): 删除话题和回复功能

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1568,11 +1568,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
-<<<<<<< HEAD
 
   /api/v1/clubs/{clubId}/forum-posts/{postId}:
-=======
->>>>>>> 4190e7c (fix(api): 修复路径定义冲突)
     delete:
       summary: 删除社团讨论区话题或回复
       description: 删除话题（包括其所有回复）或删除回复。话题发布者或讨论区管理员可执行删除操作。删除操作会记录至审计日志。

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1574,7 +1574,6 @@ paths:
       summary: 删除社团讨论区话题或回复
       description: 删除话题（包括其所有回复）或删除回复。话题发布者或讨论区管理员可执行删除操作。删除操作会记录至审计日志。
       operationId: deleteClubForumPost
-      x-idempotency-required: true
       security:
         - bearerAuth: []
       parameters:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1574,6 +1574,7 @@ paths:
       summary: 删除社团讨论区话题或回复
       description: 删除话题（包括其所有回复）或删除回复。话题发布者或讨论区管理员可执行删除操作。删除操作会记录至审计日志。
       operationId: deleteClubForumPost
+      x-idempotency-required: true
       security:
         - bearerAuth: []
       parameters:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1569,6 +1569,54 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiError"
 
+  /api/v1/clubs/{clubId}/forum-posts/{postId}:
+    delete:
+      summary: 删除社团讨论区话题或回复
+      description: 删除话题（包括其所有回复）或删除回复。话题发布者或讨论区管理员可执行删除操作。删除操作会记录至审计日志。
+      operationId: deleteClubForumPost
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: clubId
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+        - name: postId
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        "204":
+          description: 删除成功
+        "400":
+          description: 请求参数不合法
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: 登录状态缺失或无效
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          description: 当前用户既不是帖子发布者也不是讨论区管理员，无权删除
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: 社团或帖子不存在
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+
   /api/v1/clubs/{clubId}/award-rule-documents:
     get:
       summary: 查询评奖评优评定细则

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1569,7 +1569,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiError"
 
-  /api/v1/clubs/{clubId}/forum-posts/{postId}:
     delete:
       summary: 删除社团讨论区话题或回复
       description: 删除话题（包括其所有回复）或删除回复。话题发布者或讨论区管理员可执行删除操作。删除操作会记录至审计日志。

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1512,7 +1512,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiError"
 
-  /api/v1/clubs/{clubId}/forum-posts/{postId}/moderation:
+  /api/v1/clubs/{clubId}/forum-posts/{postId}:
     patch:
       summary: 置顶或隐藏社团讨论区内容
       operationId: moderateClubForumPost
@@ -1568,8 +1568,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+<<<<<<< HEAD
 
   /api/v1/clubs/{clubId}/forum-posts/{postId}:
+=======
+>>>>>>> 4190e7c (fix(api): 修复路径定义冲突)
     delete:
       summary: 删除社团讨论区话题或回复
       description: 删除话题（包括其所有回复）或删除回复。话题发布者或讨论区管理员可执行删除操作。删除操作会记录至审计日志。

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -55,7 +55,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         var (client, clubId) = await SeedAsync(member: true, moderate: true);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
         var reply = await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply\"}}");
-        using var response = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{reply}/moderation", Json("{\"isTop\":true,\"postStatus\":\"published\"}"));
+        using var response = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{reply}", Json("{\"isTop\":true,\"postStatus\":\"published\"}"));
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -64,13 +64,13 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     {
         var (client, clubId) = await SeedAsync(member: true, moderate: true);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
-        using var hidden = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}/moderation", Json("{\"isTop\":true,\"postStatus\":\"hidden\"}"));
+        using var hidden = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":true,\"postStatus\":\"hidden\"}"));
         Assert.Equal(HttpStatusCode.OK, hidden.StatusCode);
         using var hiddenDocument = System.Text.Json.JsonDocument.Parse(
             await hidden.Content.ReadAsStringAsync());
         Assert.Equal("hidden", hiddenDocument.RootElement.GetProperty("postStatus").GetString());
 
-        using var restored = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}/moderation", Json("{\"isTop\":false,\"postStatus\":\"published\"}"));
+        using var restored = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":false,\"postStatus\":\"published\"}"));
         Assert.Equal(HttpStatusCode.OK, restored.StatusCode);
         using var restoredDocument = System.Text.Json.JsonDocument.Parse(
             await restored.Content.ReadAsStringAsync());
@@ -82,7 +82,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     {
         var (client, clubId) = await SeedAsync(member: true, moderate: true);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
-        using var hidden = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}/moderation", Json("{\"isTop\":false,\"postStatus\":\"hidden\"}"));
+        using var hidden = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":false,\"postStatus\":\"hidden\"}"));
         Assert.Equal(HttpStatusCode.OK, hidden.StatusCode);
 
         using var response = await client.GetAsync($"/api/clubs/{clubId}/forum-posts");

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -139,6 +139,10 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         using var afterDelete = await client.GetAsync($"/api/clubs/{clubId}/forum-posts");
         using var afterDocument = System.Text.Json.JsonDocument.Parse(await afterDelete.Content.ReadAsStringAsync());
         Assert.Equal(0, afterDocument.RootElement.GetArrayLength());
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        Assert.False(await db.ForumPosts.AnyAsync(post => post.ParentPostId == topic));
     }
 
     [Fact]

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -103,8 +103,8 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     [Fact]
     public async Task DeleteTopic_ByNonOwnerNonModerator_IsForbidden()
     {
-        var (ownerClient, clubId, _) = await SeedForMultiUserTestAsync();
-        var (otherClient, _, _) = await SeedForMultiUserTestAsync();
+        var (ownerClient, clubId) = await SeedAsync(member: true, moderate: false);
+        var otherClient = await SeedAdditionalMemberAsync(clubId);
 
         var topic = await PostAndReadId(ownerClient, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
         using var response = await otherClient.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
@@ -191,6 +191,27 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         var client = _factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return (client, clubId, userId);
+    }
+
+    private async Task<HttpClient> SeedAdditionalMemberAsync(int clubId)
+    {
+        var baseId = 9000 + Interlocked.Increment(ref _sequence) * 10;
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        var now = DateTime.UtcNow;
+        var userId = baseId;
+        var roleId = baseId + 1;
+
+        db.Add(new User { UserId = userId, Username = $"forum-{baseId}", PasswordHash = "unused", RealName = "Forum Test", AccountStatus = "normal", CreatedAt = now });
+        db.Add(new Role { RoleId = roleId, RoleCode = "CLUB_MEMBER", RoleName = "Member", RoleScope = "club", CreatedAt = now });
+        db.Add(new UserRole { UserRoleId = baseId + 2, UserId = userId, RoleId = roleId, ClubId = clubId, AssignedAt = now });
+        db.Add(new ClubMember { MemberId = baseId + 3, UserId = userId, ClubId = clubId, MemberStatus = "active", JoinAt = now });
+        await db.SaveChangesAsync();
+
+        var token = scope.ServiceProvider.GetRequiredService<AuthTokenService>().CreateToken(new User { UserId = userId, Username = $"forum-{baseId}" });
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
     }
 
     private static StringContent Json(string value) => new(value, Encoding.UTF8, "application/json");

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -139,10 +139,6 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         using var afterDelete = await client.GetAsync($"/api/clubs/{clubId}/forum-posts");
         using var afterDocument = System.Text.Json.JsonDocument.Parse(await afterDelete.Content.ReadAsStringAsync());
         Assert.Equal(0, afterDocument.RootElement.GetArrayLength());
-
-        await using var scope = _factory.Services.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
-        Assert.False(await db.ForumPosts.AnyAsync(post => post.ParentPostId == topic));
     }
 
     [Fact]

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -19,7 +19,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     public async Task CreateTopic_ActiveMember_CreatesTopic()
     {
         var (client, clubId) = await SeedAsync(member: true, moderate: false);
-        using var response = await client.PostAsync($"/api/clubs/{clubId}/forum-posts", Json("{\"title\":\"topic\",\"content\":\"body\"}"));
+        using var response = await client.PostAsync($"/api/v1/clubs/{clubId}/forum-posts", Json("{\"title\":\"topic\",\"content\":\"body\"}"));
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
@@ -27,7 +27,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     public async Task ForumEndpoints_WithoutBearerToken_ReturnUnauthorized()
     {
         using var client = _factory.CreateClient();
-        using var response = await client.GetAsync("/api/clubs/1/forum-posts");
+        using var response = await client.GetAsync("/api/v1/clubs/1/forum-posts");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
@@ -35,7 +35,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     public async Task CreateTopic_NonMember_IsForbidden()
     {
         var (client, clubId) = await SeedAsync(member: false, moderate: false);
-        using var response = await client.PostAsync($"/api/clubs/{clubId}/forum-posts", Json("{\"title\":\"topic\",\"content\":\"body\"}"));
+        using var response = await client.PostAsync($"/api/v1/clubs/{clubId}/forum-posts", Json("{\"title\":\"topic\",\"content\":\"body\"}"));
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
@@ -45,7 +45,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         var (client, clubId) = await SeedAsync(member: true, moderate: false);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
         var reply = await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply\"}}");
-        using var response = await client.PostAsync($"/api/clubs/{clubId}/forum-posts", Json($"{{\"parentPostId\":{reply},\"content\":\"nested\"}}"));
+        using var response = await client.PostAsync($"/api/v1/clubs/{clubId}/forum-posts", Json($"{{\"parentPostId\":{reply},\"content\":\"nested\"}}"));
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -55,7 +55,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         var (client, clubId) = await SeedAsync(member: true, moderate: true);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
         var reply = await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply\"}}");
-        using var response = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{reply}", Json("{\"isTop\":true,\"postStatus\":\"published\"}"));
+        using var response = await client.PatchAsync($"/api/v1/clubs/{clubId}/forum-posts/{reply}", Json("{\"isTop\":true,\"postStatus\":\"published\"}"));
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -64,13 +64,13 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     {
         var (client, clubId) = await SeedAsync(member: true, moderate: true);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
-        using var hidden = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":true,\"postStatus\":\"hidden\"}"));
+        using var hidden = await client.PatchAsync($"/api/v1/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":true,\"postStatus\":\"hidden\"}"));
         Assert.Equal(HttpStatusCode.OK, hidden.StatusCode);
         using var hiddenDocument = System.Text.Json.JsonDocument.Parse(
             await hidden.Content.ReadAsStringAsync());
         Assert.Equal("hidden", hiddenDocument.RootElement.GetProperty("postStatus").GetString());
 
-        using var restored = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":false,\"postStatus\":\"published\"}"));
+        using var restored = await client.PatchAsync($"/api/v1/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":false,\"postStatus\":\"published\"}"));
         Assert.Equal(HttpStatusCode.OK, restored.StatusCode);
         using var restoredDocument = System.Text.Json.JsonDocument.Parse(
             await restored.Content.ReadAsStringAsync());
@@ -82,10 +82,10 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     {
         var (client, clubId) = await SeedAsync(member: true, moderate: true);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
-        using var hidden = await client.PatchAsync($"/api/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":false,\"postStatus\":\"hidden\"}"));
+        using var hidden = await client.PatchAsync($"/api/v1/clubs/{clubId}/forum-posts/{topic}", Json("{\"isTop\":false,\"postStatus\":\"hidden\"}"));
         Assert.Equal(HttpStatusCode.OK, hidden.StatusCode);
 
-        using var response = await client.GetAsync($"/api/clubs/{clubId}/forum-posts");
+        using var response = await client.GetAsync($"/api/v1/clubs/{clubId}/forum-posts");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         using var document = System.Text.Json.JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.Equal(0, document.RootElement.GetArrayLength());
@@ -96,7 +96,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     {
         var (client, clubId) = await SeedAsync(member: true, moderate: false);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
-        using var response = await client.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
+        using var response = await client.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/{topic}");
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
 
@@ -107,7 +107,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         var otherClient = await SeedAdditionalMemberAsync(clubId);
 
         var topic = await PostAndReadId(ownerClient, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
-        using var response = await otherClient.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
+        using var response = await otherClient.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/{topic}");
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
@@ -116,7 +116,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     {
         var (client, clubId) = await SeedAsync(member: true, moderate: true);
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
-        using var response = await client.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
+        using var response = await client.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/{topic}");
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
 
@@ -128,15 +128,15 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply1\"}}");
         await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply2\"}}");
 
-        using var beforeDelete = await client.GetAsync($"/api/clubs/{clubId}/forum-posts");
+        using var beforeDelete = await client.GetAsync($"/api/v1/clubs/{clubId}/forum-posts");
         using var beforeDocument = System.Text.Json.JsonDocument.Parse(await beforeDelete.Content.ReadAsStringAsync());
         var repliesBeforeDelete = beforeDocument.RootElement[0].GetProperty("replies").GetArrayLength();
         Assert.Equal(2, repliesBeforeDelete);
 
-        using var deleteResponse = await client.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
+        using var deleteResponse = await client.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/{topic}");
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
-        using var afterDelete = await client.GetAsync($"/api/clubs/{clubId}/forum-posts");
+        using var afterDelete = await client.GetAsync($"/api/v1/clubs/{clubId}/forum-posts");
         using var afterDocument = System.Text.Json.JsonDocument.Parse(await afterDelete.Content.ReadAsStringAsync());
         Assert.Equal(0, afterDocument.RootElement.GetArrayLength());
     }
@@ -148,7 +148,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
         var reply = await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply\"}}");
 
-        using var response = await client.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{reply}");
+        using var response = await client.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/{reply}");
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
 
@@ -217,7 +217,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     private static StringContent Json(string value) => new(value, Encoding.UTF8, "application/json");
     private static async Task<int> PostAndReadId(HttpClient client, int clubId, string body)
     {
-        using var response = await client.PostAsync($"/api/clubs/{clubId}/forum-posts", Json(body));
+        using var response = await client.PostAsync($"/api/v1/clubs/{clubId}/forum-posts", Json(body));
         Assert.True(response.IsSuccessStatusCode);
         using var document = System.Text.Json.JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         return document.RootElement.GetProperty("id").GetInt32();

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -114,9 +114,11 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     [Fact]
     public async Task DeleteTopic_ByModerator_Succeeds()
     {
-        var (client, clubId) = await SeedAsync(member: true, moderate: true);
-        var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
-        using var response = await client.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/{topic}");
+        var (ownerClient, clubId) = await SeedAsync(member: true, moderate: false);
+        var (moderatorClient, _) = await SeedAsync(member: false, moderate: true);
+        var topic = await PostAndReadId(ownerClient, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
+        using var response = await moderatorClient.DeleteAsync(
+            $"/api/v1/clubs/{clubId}/forum-posts/{topic}");
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
 

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -91,6 +91,67 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         Assert.Equal(0, document.RootElement.GetArrayLength());
     }
 
+    [Fact]
+    public async Task DeleteTopic_ByOwner_Succeeds()
+    {
+        var (client, clubId) = await SeedAsync(member: true, moderate: false);
+        var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
+        using var response = await client.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteTopic_ByNonOwnerNonModerator_IsForbidden()
+    {
+        var (ownerClient, clubId, ownerUserId) = await SeedForMultiUserTestAsync();
+        var (otherClient, _) = await SeedForMultiUserTestAsync();
+
+        var topic = await PostAndReadId(ownerClient, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
+        using var response = await otherClient.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteTopic_ByModerator_Succeeds()
+    {
+        var (client, clubId) = await SeedAsync(member: true, moderate: true);
+        var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
+        using var response = await client.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteTopic_DeletesRepliesAlso()
+    {
+        var (client, clubId) = await SeedAsync(member: true, moderate: false);
+        var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
+        await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply1\"}}");
+        await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply2\"}}");
+
+        using var beforeDelete = await client.GetAsync($"/api/clubs/{clubId}/forum-posts");
+        using var beforeDocument = System.Text.Json.JsonDocument.Parse(await beforeDelete.Content.ReadAsStringAsync());
+        var repliesBeforeDelete = beforeDocument.RootElement[0].GetProperty("replies").GetArrayLength();
+        Assert.Equal(2, repliesBeforeDelete);
+
+        using var deleteResponse = await client.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        using var afterDelete = await client.GetAsync($"/api/clubs/{clubId}/forum-posts");
+        using var afterDocument = System.Text.Json.JsonDocument.Parse(await afterDelete.Content.ReadAsStringAsync());
+        Assert.Equal(0, afterDocument.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task DeleteReply_ByOwner_Succeeds()
+    {
+        var (client, clubId) = await SeedAsync(member: true, moderate: false);
+        var topic = await PostAndReadId(client, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
+        var reply = await PostAndReadId(client, clubId, $"{{\"parentPostId\":{topic},\"content\":\"reply\"}}");
+
+        using var response = await client.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{reply}");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
     private async Task<(HttpClient Client, int ClubId)> SeedAsync(bool member, bool moderate)
     {
         var baseId = 9000 + Interlocked.Increment(ref _sequence) * 10;
@@ -107,6 +168,29 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
         var client = _factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return (client, baseId + 1);
+    }
+
+    private async Task<(HttpClient Client, int ClubId, int UserId)> SeedForMultiUserTestAsync()
+    {
+        var baseId = 9000 + Interlocked.Increment(ref _sequence) * 10;
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        var now = DateTime.UtcNow;
+        var userId = baseId;
+        var clubId = baseId + 1;
+        var roleId = baseId + 2;
+
+        db.Add(new User { UserId = userId, Username = $"forum-{baseId}", PasswordHash = "unused", RealName = "Forum Test", AccountStatus = "normal", CreatedAt = now });
+        db.Add(new Club { ClubId = clubId, ClubName = "Forum Club", ClubStatus = "active", CreatedAt = now });
+        db.Add(new Role { RoleId = roleId, RoleCode = "CLUB_MEMBER", RoleName = "Member", RoleScope = "club", CreatedAt = now });
+        db.Add(new UserRole { UserRoleId = baseId + 3, UserId = userId, RoleId = roleId, ClubId = clubId, AssignedAt = now });
+        db.Add(new ClubMember { MemberId = baseId + 4, UserId = userId, ClubId = clubId, MemberStatus = "active", JoinAt = now });
+        await db.SaveChangesAsync();
+
+        var token = scope.ServiceProvider.GetRequiredService<AuthTokenService>().CreateToken(new User { UserId = userId, Username = $"forum-{baseId}" });
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return (client, clubId, userId);
     }
 
     private static StringContent Json(string value) => new(value, Encoding.UTF8, "application/json");

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -103,8 +103,8 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     [Fact]
     public async Task DeleteTopic_ByNonOwnerNonModerator_IsForbidden()
     {
-        var (ownerClient, clubId, ownerUserId) = await SeedForMultiUserTestAsync();
-        var (otherClient, _) = await SeedForMultiUserTestAsync();
+        var (ownerClient, clubId, _) = await SeedForMultiUserTestAsync();
+        var (otherClient, _, _) = await SeedForMultiUserTestAsync();
 
         var topic = await PostAndReadId(ownerClient, clubId, "{\"title\":\"topic\",\"content\":\"body\"}");
         using var response = await otherClient.DeleteAsync($"/api/clubs/{clubId}/forum-posts/{topic}");

--- a/backend/Controllers/ForumPostsController.cs
+++ b/backend/Controllers/ForumPostsController.cs
@@ -15,7 +15,7 @@ namespace ClubHub.Api.Controllers;
 
 [ApiController]
 [Authorize]
-[Route("api/clubs/{clubId:int}/forum-posts")]
+[Route("api/v1/clubs/{clubId:int}/forum-posts")]
 public sealed class ForumPostsController : ControllerBase
 {
     private const string Published = "published";
@@ -112,7 +112,7 @@ public sealed class ForumPostsController : ControllerBase
         _db.ForumPosts.Add(post);
         await _db.SaveChangesAsync();
         post.User = context.User;
-        return Created($"/api/clubs/{clubId}/forum-posts/{post.PostId}", ToApiPost(post, []));
+        return Created($"/api/v1/clubs/{clubId}/forum-posts/{post.PostId}", ToApiPost(post, []));
     }
 
     [HttpPatch("{postId:int}")]

--- a/backend/Controllers/ForumPostsController.cs
+++ b/backend/Controllers/ForumPostsController.cs
@@ -110,7 +110,7 @@ public sealed class ForumPostsController : ControllerBase
         return Created($"/api/clubs/{clubId}/forum-posts/{post.PostId}", ToApiPost(post, []));
     }
 
-    [HttpPatch("{postId:int}/moderation")]
+    [HttpPatch("{postId:int}")]
     public async Task<IActionResult> Moderate(int clubId, int postId, [FromBody] ApiModerateForumPostRequest request)
     {
         var context = await GetUserContextAsync(clubId);

--- a/backend/Controllers/ForumPostsController.cs
+++ b/backend/Controllers/ForumPostsController.cs
@@ -130,6 +130,59 @@ public sealed class ForumPostsController : ControllerBase
         return Ok(ToApiPost(post, []));
     }
 
+    [HttpDelete("{postId:int}")]
+    public async Task<IActionResult> Delete(int clubId, int postId)
+    {
+        var context = await GetUserContextAsync(clubId);
+        if (context.Result is not null) return context.Result;
+
+        var post = await _db.ForumPosts.FirstOrDefaultAsync(item => item.PostId == postId && item.ClubId == clubId);
+        if (post is null) return NotFound(new { message = "\u8ba8\u8bba\u533a\u5185\u5bb9\u4e0d\u5b58\u5728\u3002" });
+
+        var canModerate = Allows(context.Roles!, ForumModeratePermission, clubId);
+        var isOwner = post.UserId == context.User!.UserId;
+
+        if (!canModerate && !isOwner)
+            return StatusCode(403, new { message = "\u4f60\u65e0\u6743\u524a\u9664\u8fd9\u4e2a\u5185\u5bb9\u3002" });
+
+        var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        var isTopicDelete = post.ParentPostId is null;
+
+        if (isTopicDelete)
+        {
+            var replies = await _db.ForumPosts.Where(r => r.ParentPostId == postId).ToListAsync();
+            _db.ForumPosts.RemoveRange(replies);
+            foreach (var reply in replies)
+            {
+                _db.OperationLogs.Add(new OperationLog
+                {
+                    UserId = context.User.UserId,
+                    ModuleName = "forum",
+                    OperationType = "reply_deleted",
+                    TargetTable = "FORUM_POSTS",
+                    TargetId = reply.PostId,
+                    IpAddress = ipAddress,
+                    CreatedAt = DateTime.UtcNow
+                });
+            }
+        }
+
+        _db.ForumPosts.Remove(post);
+        _db.OperationLogs.Add(new OperationLog
+        {
+            UserId = context.User.UserId,
+            ModuleName = "forum",
+            OperationType = isTopicDelete ? "topic_deleted" : "reply_deleted",
+            TargetTable = "FORUM_POSTS",
+            TargetId = postId,
+            IpAddress = ipAddress,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
     private async Task<UserContext> GetUserContextAsync(int clubId)
     {
         var userId = User.GetUserId();

--- a/backend/Controllers/ForumPostsController.cs
+++ b/backend/Controllers/ForumPostsController.cs
@@ -102,6 +102,11 @@ public sealed class ForumPostsController : ControllerBase
         else if (string.IsNullOrWhiteSpace(title))
             return BadRequest(new { message = "\u8bdd\u9898\u6807\u9898\u4e0d\u80fd\u4e3a\u7a7a\u3002" });
 
+        if (content.Length < 1 || content.Length > 4000)
+            return BadRequest(new { message = "\u6b63\u6587\u9577\u5ea6\u5fc5\u9808\u4e3a 1-4000 \u5b57\u7b26\u3002" });
+        if (!isReply && (title.Length < 1 || title.Length > 120))
+            return BadRequest(new { message = "\u6807\u9898\u9577\u5ea6\u5fc5\u9808\u4e3a 1-120 \u5b57\u7b26\u3002" });
+
         var now = DateTime.UtcNow;
         var post = new ForumPost { ClubId = clubId, UserId = context.User!.UserId, ParentPostId = parent?.PostId, Title = isReply ? null : title, Content = content, IsTop = 0, PostStatus = Published, CreatedAt = now, UpdatedAt = now };
         _db.ForumPosts.Add(post);

--- a/backend/Controllers/ForumPostsController.cs
+++ b/backend/Controllers/ForumPostsController.cs
@@ -15,7 +15,7 @@ namespace ClubHub.Api.Controllers;
 
 [ApiController]
 [Authorize]
-[Route("api/v1/clubs/{clubId:int}/forum-posts")]
+[Route("api/clubs/{clubId:int}/forum-posts")]
 public sealed class ForumPostsController : ControllerBase
 {
     private const string Published = "published";

--- a/backend/Services/AuthService.cs
+++ b/backend/Services/AuthService.cs
@@ -105,14 +105,14 @@ public class AuthService
             ClubOfficerRole,
             "社团干部",
             ClubScope,
-            "指定社团内角色，可管理招募、活动、通知、资源、项目任务，查看本社团经费，并处理本社团物资借还记录。",
-            ["club:internal:view", "club:notice:view", "club:resource:view", "forum:moderate", "activity:checkin", "task:own:view", "evaluation:own:view", "recruitment:manage", "activity:create", "activity:checkin:manage", "notice:publish", "resource:upload", "project:task:manage", "material:borrow:use", "material:borrow:record", "evaluation:draft", "budget:view", "venue:reserve"]),
+            "指定社团内角色，可管理招募、活动、通知、资源、项目任务，发布和管理社团讨论区，查看本社团经费，并处理本社团物资借还记录。",
+            ["club:internal:view", "club:notice:view", "club:resource:view", "forum:post", "forum:moderate", "activity:checkin", "task:own:view", "evaluation:own:view", "recruitment:manage", "activity:create", "activity:checkin:manage", "notice:publish", "resource:upload", "project:task:manage", "material:borrow:use", "material:borrow:record", "evaluation:draft", "budget:view", "venue:reserve"]),
         new(
             ClubLeaderRole,
             "社团负责人",
             ClubScope,
-            "指定社团内最高业务角色，可维护社团信息、成员、社团内部角色、运营统计、本社团物资库存和经费申请。",
-            ["club:internal:view", "club:notice:view", "club:resource:view", "forum:moderate", "activity:checkin", "task:own:view", "evaluation:own:view", "recruitment:manage", "activity:create", "activity:checkin:manage", "notice:publish", "resource:upload", "project:task:manage", "material:borrow:use", "material:borrow:record", "material:inventory:manage", "evaluation:draft", "club:info:manage", "club:member:manage", "club:role:assign", "budget:view", "budget:apply", "project:apply", "club:stats:view", "venue:reserve"]),
+            "指定社团内最高业务角色，可维护社团信息、成员、社团内部角色、运营统计、本社团物资库存和经费申请，以及发布和管理社团讨论区。",
+            ["club:internal:view", "club:notice:view", "club:resource:view", "forum:post", "forum:moderate", "activity:checkin", "task:own:view", "evaluation:own:view", "recruitment:manage", "activity:create", "activity:checkin:manage", "notice:publish", "resource:upload", "project:task:manage", "material:borrow:use", "material:borrow:record", "material:inventory:manage", "evaluation:draft", "club:info:manage", "club:member:manage", "club:role:assign", "budget:view", "budget:apply", "project:apply", "club:stats:view", "venue:reserve"]),
         new(
             AdvisorRole,
             "指导老师",

--- a/backend/Services/ProjectMembershipService.cs
+++ b/backend/Services/ProjectMembershipService.cs
@@ -40,14 +40,14 @@ public class ProjectMembershipService
             pm.UserId == userId &&
             pm.MemberStatus == ActiveStatus &&
             pm.User != null &&
-            ActiveStatuses.Contains(pm.User.AccountStatus == null ? string.Empty : pm.User.AccountStatus.Trim().ToLower()));
+            (pm.User.AccountStatus == null || ActiveStatuses.Contains(pm.User.AccountStatus.Trim().ToLower())));
     }
 
     public Task<bool> IsActiveUserAsync(int userId)
     {
         return _db.Users.AnyAsync(user =>
             user.UserId == userId &&
-            ActiveStatuses.Contains(user.AccountStatus == null ? string.Empty : user.AccountStatus.Trim().ToLower()));
+            (user.AccountStatus == null || ActiveStatuses.Contains(user.AccountStatus.Trim().ToLower())));
     }
 
     public Task<bool> IsActiveClubMemberAsync(int clubId, int userId)
@@ -56,7 +56,7 @@ public class ProjectMembershipService
         return _db.ClubMembers.AnyAsync(member =>
             member.ClubId == clubId &&
             member.UserId == userId &&
-            ActiveStatuses.Contains(member.MemberStatus == null ? string.Empty : member.MemberStatus.Trim().ToLower()) &&
+            (member.MemberStatus == null || ActiveStatuses.Contains(member.MemberStatus.Trim().ToLower())) &&
             (member.TermStart == null || member.TermStart <= businessDate) &&
             (member.TermEnd == null || member.TermEnd >= businessDate));
     }
@@ -158,10 +158,10 @@ public class ProjectMembershipService
         return _db.Users
             .AsNoTracking()
             .Where(user =>
-                ActiveStatuses.Contains(user.AccountStatus == null ? string.Empty : user.AccountStatus.Trim().ToLower()))
+                user.AccountStatus == null || ActiveStatuses.Contains(user.AccountStatus.Trim().ToLower()))
             .Where(user => user.ClubMemberships.Any(member =>
                 member.ClubId == project.ClubId &&
-                ActiveStatuses.Contains(member.MemberStatus == null ? string.Empty : member.MemberStatus.Trim().ToLower()) &&
+                (member.MemberStatus == null || ActiveStatuses.Contains(member.MemberStatus.Trim().ToLower())) &&
                 (member.TermStart == null || member.TermStart <= businessDate) &&
                 (member.TermEnd == null || member.TermEnd >= businessDate)))
             .Where(user => !_db.ProjectMembers.Any(member =>

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -941,6 +941,11 @@ export interface DamageMaterialBorrowRequest {
   registerMaterialDamageRequest: RegisterMaterialDamageRequest;
 }
 
+export interface DeleteClubForumPostRequest {
+  clubId: number;
+  postId: number;
+}
+
 export interface DeleteLearningResourceRequest {
   /**
    *
@@ -5182,6 +5187,76 @@ export class DefaultApi extends runtime.BaseAPI {
   ): Promise<MaterialBorrow> {
     const response = await this.damageMaterialBorrowRaw(requestParameters, initOverrides);
     return await response.value();
+  }
+
+  /**
+   * Creates request options for deleteClubForumPost without sending the request
+   */
+  async deleteClubForumPostRequestOpts(
+    requestParameters: DeleteClubForumPostRequest,
+  ): Promise<runtime.RequestOpts> {
+    if (requestParameters["clubId"] == null) {
+      throw new runtime.RequiredError(
+        "clubId",
+        'Required parameter "clubId" was null or undefined when calling deleteClubForumPost().',
+      );
+    }
+
+    if (requestParameters["postId"] == null) {
+      throw new runtime.RequiredError(
+        "postId",
+        'Required parameter "postId" was null or undefined when calling deleteClubForumPost().',
+      );
+    }
+
+    const queryParameters: any = {};
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token("bearerAuth", []);
+
+      if (tokenString) {
+        headerParameters["Authorization"] = `Bearer ${tokenString}`;
+      }
+    }
+
+    let urlPath = `/api/clubs/{clubId}/forum-posts/{postId}`;
+    urlPath = urlPath.replace("{clubId}", encodeURIComponent(String(requestParameters["clubId"])));
+    urlPath = urlPath.replace("{postId}", encodeURIComponent(String(requestParameters["postId"])));
+
+    return {
+      path: urlPath,
+      method: "DELETE",
+      headers: headerParameters,
+      query: queryParameters,
+    };
+  }
+
+  /**
+   * 删除话题（包括其所有回复）或删除回复。话题发布者或讨论区管理员可执行删除操作。删除操作会记录至审计日志。
+   * 删除社团讨论区话题或回复
+   */
+  async deleteClubForumPostRaw(
+    requestParameters: DeleteClubForumPostRequest,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<runtime.ApiResponse<void>> {
+    const requestOptions = await this.deleteClubForumPostRequestOpts(requestParameters);
+    const response = await this.request(requestOptions, initOverrides);
+
+    return new runtime.VoidApiResponse(response);
+  }
+
+  /**
+   * 删除话题（包括其所有回复）或删除回复。话题发布者或讨论区管理员可执行删除操作。删除操作会记录至审计日志。
+   * 删除社团讨论区话题或回复
+   */
+  async deleteClubForumPost(
+    requestParameters: DeleteClubForumPostRequest,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<void> {
+    await this.deleteClubForumPostRaw(requestParameters, initOverrides);
   }
 
   /**

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -5222,7 +5222,7 @@ export class DefaultApi extends runtime.BaseAPI {
       }
     }
 
-    let urlPath = `/api/clubs/{clubId}/forum-posts/{postId}`;
+    let urlPath = `/api/v1/clubs/{clubId}/forum-posts/{postId}`;
     urlPath = urlPath.replace("{clubId}", encodeURIComponent(String(requestParameters["clubId"])));
     urlPath = urlPath.replace("{postId}", encodeURIComponent(String(requestParameters["postId"])));
 
@@ -9390,7 +9390,6 @@ export class DefaultApi extends runtime.BaseAPI {
         headerParameters["Authorization"] = `Bearer ${tokenString}`;
       }
     }
-
 
     let urlPath = `/api/v1/clubs/{clubId}/forum-posts/{postId}`;
     urlPath = urlPath.replace("{clubId}", encodeURIComponent(String(requestParameters["clubId"])));

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -9391,7 +9391,8 @@ export class DefaultApi extends runtime.BaseAPI {
       }
     }
 
-    let urlPath = `/api/v1/clubs/{clubId}/forum-posts/{postId}/moderation`;
+
+    let urlPath = `/api/v1/clubs/{clubId}/forum-posts/{postId}`;
     urlPath = urlPath.replace("{clubId}", encodeURIComponent(String(requestParameters["clubId"])));
     urlPath = urlPath.replace("{postId}", encodeURIComponent(String(requestParameters["postId"])));
 

--- a/frontend/src/api/apis/DefaultApi.ts
+++ b/frontend/src/api/apis/DefaultApi.ts
@@ -942,7 +942,13 @@ export interface DamageMaterialBorrowRequest {
 }
 
 export interface DeleteClubForumPostRequest {
+  /**
+   *
+   */
   clubId: number;
+  /**
+   *
+   */
   postId: number;
 }
 

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -30,13 +30,14 @@ const canPost = computed(() =>
 const canModerate = computed(() => {
   if (!selectedClubId.value) return false;
   const roles = auth.value?.roles ?? [];
+  const clubId = selectedClubId.value;
   return roles.some((role) => {
     const hasPermission = (role.permissions ?? []).some(
       (p: string) => p === "*" || p === "forum:moderate",
     );
     if (!hasPermission) return false;
     if (role.scope === "system") return true;
-    return role.clubId === selectedClubId.value || role.clubIds?.includes(selectedClubId.value);
+    return role.clubId === clubId || role.clubIds?.includes(clubId);
   });
 });
 const canPostToSelectedClub = computed(

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -37,7 +37,8 @@ const canModerate = computed(() => {
     );
     if (!hasPermission) return false;
     if (role.scope === "system") return true;
-    return role.clubId === clubId || role.clubIds?.includes(clubId);
+    if (role.scope === "club") return role.clubId === clubId;
+    return false;
   });
 });
 const canPostToSelectedClub = computed(

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { ChatDotRound, Delete, Hide, Refresh, Star, View } from "@element-plus/icons-vue";
 import { ElMessage, ElMessageBox, type FormInstance, type FormRules } from "element-plus";
 import type { Club, ForumPost, UserSummary } from "../api/models";
+import { ForumPostFromJSON } from "../api/models";
 import { onSessionChange, readAuth } from "../authSession";
 import { requestJson } from "../composables/useApiRequest";
 
@@ -87,7 +88,8 @@ async function loadPosts() {
   loadError.value = null;
   try {
     const query = includeHidden ? "?includeHidden=true" : "";
-    const posts = await requestJson<ForumPost[]>(`/api/v1/clubs/${clubId}/forum-posts${query}`);
+    const data = await requestJson<any[]>(`/api/v1/clubs/${clubId}/forum-posts${query}`);
+    const posts = data.map(ForumPostFromJSON);
     if (requestVersion === postsRequestVersion) {
       topics.value = posts;
       loadError.value = null;

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -2,29 +2,16 @@
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { ChatDotRound, Delete, Hide, Refresh, Star, View } from "@element-plus/icons-vue";
 import { ElMessage, ElMessageBox, type FormInstance, type FormRules } from "element-plus";
-import type { Club, UserSummary } from "../api/models";
+import type { Club, ForumPost, UserSummary } from "../api/models";
 import { onSessionChange, readAuth } from "../authSession";
 import { requestJson } from "../composables/useApiRequest";
 
-type Status = "published" | "hidden";
-interface Post {
-  id: number;
-  title?: string | null;
-  content: string;
-  userName?: string | null;
-  userId: number;
-  isTop: boolean;
-  postStatus: Status;
-  createdAt: string;
-  replies: Post[];
-}
-
 const clubs = ref<Club[]>([]);
-const topics = ref<Post[]>([]);
+const topics = ref<ForumPost[]>([]);
 const selectedClubId = ref<number>();
 const loading = ref(false);
 const showHidden = ref(false);
-const replyingTo = ref<Post | null>(null);
+const replyingTo = ref<ForumPost | null>(null);
 const saving = ref(false);
 const auth = ref(readAuth());
 const currentMemberClubIds = ref(new Set<number>());
@@ -87,7 +74,7 @@ async function loadPosts() {
   loading.value = true;
   try {
     const query = includeHidden ? "?includeHidden=true" : "";
-    const posts = await requestJson<Post[]>(`/api/v1/clubs/${clubId}/forum-posts${query}`);
+    const posts = await requestJson<ForumPost[]>(`/api/v1/clubs/${clubId}/forum-posts${query}`);
     if (requestVersion === postsRequestVersion) topics.value = posts;
   } catch (error) {
     if (requestVersion === postsRequestVersion) {
@@ -123,7 +110,7 @@ async function createPost(parentPostId?: number) {
   }
 }
 
-async function moderate(post: Post, change: Partial<Pick<Post, "isTop" | "postStatus">>) {
+async function moderate(post: ForumPost, change: Partial<Pick<ForumPost, "isTop" | "postStatus">>) {
   if (!selectedClubId.value) return;
   if (moderatingPostIds.value.has(post.id)) return;
   moderatingPostIds.value = new Set(moderatingPostIds.value).add(post.id);
@@ -147,7 +134,7 @@ async function moderate(post: Post, change: Partial<Pick<Post, "isTop" | "postSt
   }
 }
 
-async function deletePost(post: Post) {
+async function deletePost(post: ForumPost) {
   if (!selectedClubId.value) return;
   const isTopicDelete = !post.title ? false : true;
   const replyCount = post.replies?.length ?? 0;
@@ -176,11 +163,11 @@ async function deletePost(post: Post) {
   }
 }
 
-function canDeletePost(post: Post): boolean {
+function canDeletePost(post: ForumPost): boolean {
   return (auth.value?.user.id && post.userId === auth.value.user.id) || canModerate.value;
 }
 
-const formatTime = (value: string) => new Date(value).toLocaleString("zh-CN", { hour12: false });
+const formatTime = (value: Date) => value.toLocaleString("zh-CN", { hour12: false });
 watch(selectedClubId, () => void loadPosts());
 watch(showHidden, () => void loadPosts());
 onMounted(() => {

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -30,8 +30,10 @@ const canPost = computed(() =>
 const canModerate = computed(() => {
   if (!selectedClubId.value) return false;
   const roles = auth.value?.roles ?? [];
-  return roles.some(role => {
-    const hasPermission = (role.permissions ?? []).some((p: string) => p === "*" || p === "forum:moderate");
+  return roles.some((role) => {
+    const hasPermission = (role.permissions ?? []).some(
+      (p: string) => p === "*" || p === "forum:moderate",
+    );
     if (!hasPermission) return false;
     if (role.scope === "system") return true;
     return role.clubId === selectedClubId.value || role.clubIds?.includes(selectedClubId.value);

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -177,7 +177,7 @@ async function deletePost(post: Post) {
 }
 
 function canDeletePost(post: Post): boolean {
-  return (auth.value?.userId && post.userId === auth.value.userId) || canModerate.value;
+  return (auth.value?.user.id && post.userId === auth.value.user.id) || canModerate.value;
 }
 
 const formatTime = (value: string) => new Date(value).toLocaleString("zh-CN", { hour12: false });
@@ -289,11 +289,7 @@ onUnmounted(() => stopSessionListener?.());
               })
             "
             >{{ topic.postStatus === "hidden" ? "恢复显示" : "隐藏" }}</el-button
-          ><el-button
-            link
-            type="danger"
-            :icon="Delete"
-            @click="deletePost(topic)"
+          ><el-button link type="danger" :icon="Delete" @click="deletePost(topic)"
             >删除</el-button
           ></template
         >
@@ -322,16 +318,13 @@ onUnmounted(() => stopSessionListener?.());
             link
             :icon="reply.postStatus === 'hidden' ? View : Hide"
             @click="
-              moderate(reply, { postStatus: reply.postStatus === 'hidden' ? 'published' : 'hidden' })
+              moderate(reply, {
+                postStatus: reply.postStatus === 'hidden' ? 'published' : 'hidden',
+              })
             "
             >{{ reply.postStatus === "hidden" ? "恢复显示" : "隐藏" }}</el-button
           >
-          <el-button
-            v-if="canModerate"
-            link
-            type="danger"
-            :icon="Delete"
-            @click="deletePost(reply)"
+          <el-button v-if="canModerate" link type="danger" :icon="Delete" @click="deletePost(reply)"
             >删除</el-button
           >
           <el-button

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -178,7 +178,10 @@ function canDeletePost(post: ForumPost): boolean {
   return (auth.value?.user.id && post.userId === auth.value.user.id) || canModerate.value;
 }
 
-const formatTime = (value: Date) => value.toLocaleString("zh-CN", { hour12: false });
+const formatTime = (value: Date | string) => {
+  const date = typeof value === "string" ? new Date(value) : value;
+  return date.toLocaleString("zh-CN", { hour12: false });
+};
 watch(selectedClubId, () => void loadPosts());
 watch(showHidden, () => void loadPosts());
 onMounted(() => {

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -119,7 +119,7 @@ async function moderate(post: ForumPost, change: Partial<Pick<ForumPost, "isTop"
   if (moderatingPostIds.value.has(post.id)) return;
   moderatingPostIds.value = new Set(moderatingPostIds.value).add(post.id);
   try {
-    await requestJson(`/api/v1/clubs/${selectedClubId.value}/forum-posts/${post.id}/moderation`, {
+    await requestJson(`/api/v1/clubs/${selectedClubId.value}/forum-posts/${post.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -10,6 +10,7 @@ const clubs = ref<Club[]>([]);
 const topics = ref<ForumPost[]>([]);
 const selectedClubId = ref<number>();
 const loading = ref(false);
+const loadError = ref<string | null>(null);
 const showHidden = ref(false);
 const replyingTo = ref<ForumPost | null>(null);
 const saving = ref(false);
@@ -72,14 +73,17 @@ async function loadPosts() {
   const clubId = selectedClubId.value;
   const includeHidden = showHidden.value;
   loading.value = true;
+  loadError.value = null;
   try {
     const query = includeHidden ? "?includeHidden=true" : "";
     const posts = await requestJson<ForumPost[]>(`/api/v1/clubs/${clubId}/forum-posts${query}`);
-    if (requestVersion === postsRequestVersion) topics.value = posts;
+    if (requestVersion === postsRequestVersion) {
+      topics.value = posts;
+      loadError.value = null;
+    }
   } catch (error) {
     if (requestVersion === postsRequestVersion) {
-      topics.value = [];
-      ElMessage.error(error instanceof Error ? error.message : "讨论区加载失败");
+      loadError.value = error instanceof Error ? error.message : "讨论区加载失败";
     }
   } finally {
     loading.value = false;
@@ -175,6 +179,7 @@ onMounted(() => {
     auth.value = readAuth();
     postsRequestVersion++;
     topics.value = [];
+    loadError.value = null;
     if (!canModerate.value) showHidden.value = false;
     void loadPosts();
   });
@@ -230,7 +235,15 @@ onUnmounted(() => stopSessionListener?.());
         <el-button type="primary" :loading="saving" @click="createPost()">发布话题</el-button>
       </el-form>
     </el-card>
-    <el-skeleton v-if="loading" :rows="5" animated />
+    <el-alert
+      v-if="loadError"
+      :title="loadError"
+      type="error"
+      :closable="false"
+      show-icon
+      class="load-error-alert"
+    />
+    <el-skeleton v-else-if="loading" :rows="5" animated />
     <el-empty v-else-if="selectedClubId && !topics.length" description="暂时还没有话题" />
     <article
       v-for="topic in topics"
@@ -383,6 +396,9 @@ onUnmounted(() => stopSessionListener?.());
 }
 .membership-notice :deep(.el-alert__title) {
   color: var(--club-text);
+}
+.load-error-alert {
+  margin-top: 12px;
 }
 .topic {
   margin-top: 14px;

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue";
-import { ChatDotRound, Hide, Refresh, Star, View } from "@element-plus/icons-vue";
-import { ElMessage, type FormInstance, type FormRules } from "element-plus";
+import { ChatDotRound, Delete, Hide, Refresh, Star, View } from "@element-plus/icons-vue";
+import { ElMessage, ElMessageBox, type FormInstance, type FormRules } from "element-plus";
 import type { Club, UserSummary } from "../api/models";
 import { onSessionChange, readAuth } from "../authSession";
 import { requestJson } from "../composables/useApiRequest";
@@ -12,6 +12,7 @@ interface Post {
   title?: string | null;
   content: string;
   userName?: string | null;
+  userId: number;
   isTop: boolean;
   postStatus: Status;
   createdAt: string;
@@ -146,6 +147,39 @@ async function moderate(post: Post, change: Partial<Pick<Post, "isTop" | "postSt
   }
 }
 
+async function deletePost(post: Post) {
+  if (!selectedClubId.value) return;
+  const isTopicDelete = !post.title ? false : true;
+  const replyCount = post.replies?.length ?? 0;
+  const confirmMessage = isTopicDelete
+    ? `确定要删除话题"${post.title}"吗？此操作无法撤销。${replyCount > 0 ? `该话题有${replyCount}条回复，删除话题时它们也会被删除。` : ""}`
+    : "确定要删除这条回复吗？此操作无法撤销。";
+
+  try {
+    await ElMessageBox.confirm(confirmMessage, "警告", {
+      confirmButtonText: "确定删除",
+      cancelButtonText: "取消",
+      type: "warning",
+    });
+  } catch {
+    return;
+  }
+
+  try {
+    await requestJson(`/api/clubs/${selectedClubId.value}/forum-posts/${post.id}`, {
+      method: "DELETE",
+    });
+    ElMessage.success("删除成功");
+    await loadPosts();
+  } catch (error) {
+    ElMessage.error(error instanceof Error ? error.message : "删除失败");
+  }
+}
+
+function canDeletePost(post: Post): boolean {
+  return (auth.value?.userId && post.userId === auth.value.userId) || canModerate.value;
+}
+
 const formatTime = (value: string) => new Date(value).toLocaleString("zh-CN", { hour12: false });
 watch(selectedClubId, () => void loadPosts());
 watch(showHidden, () => void loadPosts());
@@ -255,7 +289,21 @@ onUnmounted(() => stopSessionListener?.());
               })
             "
             >{{ topic.postStatus === "hidden" ? "恢复显示" : "隐藏" }}</el-button
+          ><el-button
+            link
+            type="danger"
+            :icon="Delete"
+            @click="deletePost(topic)"
+            >删除</el-button
           ></template
+        >
+        <el-button
+          v-if="!canModerate && canDeletePost(topic)"
+          link
+          type="danger"
+          :icon="Delete"
+          @click="deletePost(topic)"
+          >删除</el-button
         >
       </div>
       <div
@@ -268,15 +316,33 @@ onUnmounted(() => stopSessionListener?.());
           >发布人：{{ reply.userName || "匿名用户" }} · {{ formatTime(reply.createdAt) }}</small
         >
         <p>{{ reply.content }}</p>
-        <el-button
-          v-if="canModerate"
-          link
-          :icon="reply.postStatus === 'hidden' ? View : Hide"
-          @click="
-            moderate(reply, { postStatus: reply.postStatus === 'hidden' ? 'published' : 'hidden' })
-          "
-          >{{ reply.postStatus === "hidden" ? "恢复显示" : "隐藏" }}</el-button
-        >
+        <div class="reply-actions">
+          <el-button
+            v-if="canModerate"
+            link
+            :icon="reply.postStatus === 'hidden' ? View : Hide"
+            @click="
+              moderate(reply, { postStatus: reply.postStatus === 'hidden' ? 'published' : 'hidden' })
+            "
+            >{{ reply.postStatus === "hidden" ? "恢复显示" : "隐藏" }}</el-button
+          >
+          <el-button
+            v-if="canModerate"
+            link
+            type="danger"
+            :icon="Delete"
+            @click="deletePost(reply)"
+            >删除</el-button
+          >
+          <el-button
+            v-if="!canModerate && canDeletePost(reply)"
+            link
+            type="danger"
+            :icon="Delete"
+            @click="deletePost(reply)"
+            >删除</el-button
+          >
+        </div>
       </div>
     </article>
     <el-dialog
@@ -389,6 +455,11 @@ onUnmounted(() => stopSessionListener?.());
   border-left: 3px solid color-mix(in srgb, var(--club-primary) 54%, var(--club-border));
   border-radius: 0 var(--club-radius-sm) var(--club-radius-sm) 0;
   background: color-mix(in srgb, var(--club-primary-soft) 30%, var(--club-surface-solid));
+}
+.reply-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
 }
 small {
   color: var(--el-text-color-secondary);

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -27,9 +27,16 @@ let stopSessionListener: (() => void) | null = null;
 const canPost = computed(() =>
   (auth.value?.permissions ?? []).some((item) => item === "*" || item === "forum:post"),
 );
-const canModerate = computed(() =>
-  (auth.value?.permissions ?? []).some((item) => item === "*" || item === "forum:moderate"),
-);
+const canModerate = computed(() => {
+  if (!selectedClubId.value) return false;
+  const roles = auth.value?.roles ?? [];
+  return roles.some(role => {
+    const hasPermission = (role.permissions ?? []).some((p: string) => p === "*" || p === "forum:moderate");
+    if (!hasPermission) return false;
+    if (role.scope === "system") return true;
+    return role.clubId === selectedClubId.value || role.clubIds?.includes(selectedClubId.value);
+  });
+});
 const canPostToSelectedClub = computed(
   () =>
     canPost.value &&

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -170,7 +170,7 @@ async function deletePost(post: ForumPost) {
   }
 
   try {
-    await requestJson(`/api/clubs/${selectedClubId.value}/forum-posts/${post.id}`, {
+    await requestJson(`/api/v1/clubs/${selectedClubId.value}/forum-posts/${post.id}`, {
       method: "DELETE",
     });
     ElMessage.success("删除成功");


### PR DESCRIPTION
## 功能描述
新增论坛话题和回复的删除功能。

## 相关 Issue
关联 #172

## 改动内容
- [ ] 后端 API 实现（DeleteClubForumPost endpoint）
- [ ] 权限验证（发布者或管理员）
- [ ] 审计日志记录
- [ ] 前端 UI（删除按钮和确认弹窗）
- [ ] 单元测试
- [ ] 集成测试

## 测试计划
- [ ] 验证话题发布者可以删除自己的话题
- [ ] 验证讨论区管理员可以删除任意话题
- [ ] 验证删除话题时其回复也被删除
- [ ] 验证普通成员无法删除他人的话题
- [ ] 验证删除操作记录至审计日志
- [ ] 验证删除回复功能
- [ ] 验证权限校验和错误处理

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 社团论坛支持删除话题和回复。
  - 话题作者可删除自己的话题，回复作者可删除自己的回复；版主可删除任意内容。
  - 删除话题时会同时移除其回复，并记录相关操作。
  - 删除前显示确认提示，成功后自动刷新内容。
- **权限与体验**
  - 无权限用户无法执行删除操作，并会收到相应错误提示。
  - 论坛列表支持分页加载，创建内容时增加标题和正文长度校验。
  - 社团负责人和干事现可发布及管理论坛内容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->