### PR TITLE
fix(learning): 修复 PDF 上传和图片预览失败

### DIFF
--- a/backend.Tests/LearningPreviewEndpointTests.cs
+++ b/backend.Tests/LearningPreviewEndpointTests.cs
@@ -82,6 +82,57 @@ public sealed class LearningPreviewEndpointTests
         Assert.Equal(1, storage.MetadataReads);
     }
 
+    [Fact]
+    public async Task PreviewSession_OverHttp_AllowsCookieAuthenticatedContentRequest()
+    {
+        const string imageReference = "clubs/156102/learning/156104/test.png";
+        var imageBytes = new byte[] { 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a };
+        var storage = new PreviewObjectStorage(imageReference, imageBytes, "image/png");
+        await using var factory = CreateFactory(
+            new TestRateLimiter(RateLimiterMode.Allowed),
+            storage,
+            previewRedisUnavailable: false);
+        var (client, itemId) = await SeedAndAuthenticateAsync(factory, imageReference);
+
+        using var sessionResponse = await client.PostAsync(
+            $"/api/learning/items/{itemId}/preview-session",
+            null);
+        Assert.Equal(HttpStatusCode.NoContent, sessionResponse.StatusCode);
+
+        client.DefaultRequestHeaders.Authorization = null;
+        using var previewResponse = await client.GetAsync(
+            $"/api/learning/items/{itemId}/preview");
+
+        Assert.Equal(HttpStatusCode.OK, previewResponse.StatusCode);
+        Assert.Equal("image/png", previewResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(imageBytes, await previewResponse.Content.ReadAsByteArrayAsync());
+    }
+
+    [Fact]
+    public async Task PreviewSession_OverHttps_MarksPreviewCookieSecure()
+    {
+        var storage = new PreviewObjectStorage();
+        await using var factory = CreateFactory(
+            new TestRateLimiter(RateLimiterMode.Allowed),
+            storage,
+            previewRedisUnavailable: false);
+        var (client, itemId) = await SeedAndAuthenticateAsync(factory);
+        client.BaseAddress = new Uri("https://localhost");
+
+        using var response = await client.PostAsync(
+            $"/api/learning/items/{itemId}/preview-session",
+            null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var cookie = Assert.Single(response.Headers.GetValues("Set-Cookie"));
+        Assert.Contains("secure", cookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("httponly", cookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            $"path=/api/learning/items/{itemId}/preview",
+            cookie,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
     private static WebApplicationFactory<Program> CreateFactory(
         IDistributedRateLimiter limiter,
         ILearningObjectStorage storage,
@@ -123,7 +174,8 @@ public sealed class LearningPreviewEndpointTests
     }
 
     private static async Task<(HttpClient Client, int ItemId)> SeedAndAuthenticateAsync(
-        WebApplicationFactory<Program> factory)
+        WebApplicationFactory<Program> factory,
+        string fileUrl = PreviewObjectStorage.Reference)
     {
         const int userId = 156101;
         const int clubId = 156102;
@@ -172,7 +224,7 @@ public sealed class LearningPreviewEndpointTests
                     UploaderUserId = userId,
                     Title = "Redis 预览端点测试",
                     ItemType = "document",
-                    FileUrl = PreviewObjectStorage.Reference,
+                    FileUrl = fileUrl,
                     Visibility = "public",
                     ItemStatus = "published",
                     CreatedAt = now
@@ -220,9 +272,22 @@ public sealed class LearningPreviewEndpointTests
     private sealed class PreviewObjectStorage : ILearningObjectStorage
     {
         public const string Reference = "clubs/156102/learning/156104/test.pdf";
+        private readonly string _reference;
+        private readonly byte[] _content;
+        private readonly string _contentType;
         public int MetadataReads { get; private set; }
 
-        public bool IsStorageReference(string? value) => value == Reference;
+        public PreviewObjectStorage(
+            string reference = Reference,
+            byte[]? content = null,
+            string contentType = "application/pdf")
+        {
+            _reference = reference;
+            _content = content ?? "%PDF-1.7"u8.ToArray();
+            _contentType = contentType;
+        }
+
+        public bool IsStorageReference(string? value) => value == _reference;
 
         public Task<StoredObjectMetadata> GetMetadataAsync(
             string storageReference,
@@ -230,8 +295,8 @@ public sealed class LearningPreviewEndpointTests
         {
             MetadataReads++;
             return Task.FromResult(new StoredObjectMetadata(
-                8,
-                "application/pdf",
+                _content.Length,
+                _contentType,
                 null,
                 "etag",
                 DateTimeOffset.UtcNow));
@@ -241,7 +306,7 @@ public sealed class LearningPreviewEndpointTests
             string storageReference,
             StoredObjectRange? range,
             CancellationToken cancellationToken) =>
-            Task.FromResult(new StoredObjectDownload(new MemoryStream("%PDF-1.7"u8.ToArray())));
+            Task.FromResult(new StoredObjectDownload(new MemoryStream(_content)));
 
         public Task<string> UploadAsync(
             int clubId,

--- a/backend.Tests/LearningPreviewEndpointTests.cs
+++ b/backend.Tests/LearningPreviewEndpointTests.cs
@@ -86,7 +86,8 @@ public sealed class LearningPreviewEndpointTests
     public async Task PreviewSession_OverHttp_AllowsCookieAuthenticatedContentRequest()
     {
         const string imageReference = "clubs/156102/learning/156104/test.png";
-        var imageBytes = new byte[] { 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a };
+        var imageBytes = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
         var storage = new PreviewObjectStorage(imageReference, imageBytes, "image/png");
         await using var factory = CreateFactory(
             new TestRateLimiter(RateLimiterMode.Allowed),
@@ -125,12 +126,17 @@ public sealed class LearningPreviewEndpointTests
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         var cookie = Assert.Single(response.Headers.GetValues("Set-Cookie"));
-        Assert.Contains("secure", cookie, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("httponly", cookie, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(
-            $"path=/api/learning/items/{itemId}/preview",
-            cookie,
-            StringComparison.OrdinalIgnoreCase);
+        var cookieAttributes = cookie.Split(';', StringSplitOptions.TrimEntries);
+        Assert.Contains(cookieAttributes,
+            attribute => attribute.Equals("Secure", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(cookieAttributes,
+            attribute => attribute.Equals("HttpOnly", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(cookieAttributes,
+            attribute => attribute.Equals("SameSite=Strict", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(cookieAttributes,
+            attribute => attribute.Equals(
+                $"Path=/api/learning/items/{itemId}/preview",
+                StringComparison.OrdinalIgnoreCase));
     }
 
     private static WebApplicationFactory<Program> CreateFactory(

--- a/backend.Tests/NginxUploadLimitTests.cs
+++ b/backend.Tests/NginxUploadLimitTests.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+
+namespace ClubHub.Api.Tests;
+
+public sealed class NginxUploadLimitTests
+{
+    [Fact]
+    public void ApiProxy_AllowsLearningUploadRequestLimit()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var configuration = File.ReadAllText(Path.Combine(repositoryRoot, "nginx.conf"));
+
+        Assert.Matches(
+            new Regex(@"client_max_body_size\s+51m\s*;", RegexOptions.IgnoreCase),
+            configuration);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "nginx.conf")))
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Cannot locate the repository nginx.conf file.");
+    }
+}

--- a/backend.Tests/NginxUploadLimitTests.cs
+++ b/backend.Tests/NginxUploadLimitTests.cs
@@ -10,9 +10,14 @@ public sealed class NginxUploadLimitTests
         var repositoryRoot = FindRepositoryRoot();
         var configuration = File.ReadAllText(Path.Combine(repositoryRoot, "nginx.conf"));
 
+        var apiLocation = Regex.Match(
+            configuration,
+            @"(?mi)^[ \t]*location[ \t]+/api/[ \t]*\{(?<body>[^}]*)^[ \t]*\}");
+        Assert.True(apiLocation.Success, "Cannot locate the /api/ location.");
         Assert.Matches(
-            new Regex(@"client_max_body_size\s+51m\s*;", RegexOptions.IgnoreCase),
-            configuration);
+            new Regex(
+                @"(?mi)^[ \t]*client_max_body_size[ \t]+51m[ \t]*;[ \t]*(?:#.*)?$"),
+            apiLocation.Groups["body"].Value);
     }
 
     private static string FindRepositoryRoot()

--- a/backend/Controllers/LearningController.cs
+++ b/backend/Controllers/LearningController.cs
@@ -512,7 +512,9 @@ public class LearningController : ControllerBase
                 new CookieOptions
                 {
                     HttpOnly = true,
-                    Secure = !_environment.IsDevelopment() || Request.IsHttps,
+                    // UseForwardedHeaders 已在认证前解析 X-Forwarded-Proto；仅在浏览器实际
+                    // 使用 HTTPS 时标记 Secure，避免当前 HTTP 部署静默丢弃预览 Cookie。
+                    Secure = Request.IsHttps,
                     SameSite = SameSiteMode.Strict,
                     Path = $"/api/learning/items/{itemId}/preview",
                     MaxAge = _authTokenService.PreviewSessionLifetime,

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,6 +19,9 @@ server {
 
     # API 反向代理到后端
     location /api/ {
+        # 学习资源后端允许 50 MiB 文件，并为 multipart 边界预留 1 MiB。
+        # Nginx 默认仅允许约 1 MiB，请与 LearningController 的请求上限保持一致。
+        client_max_body_size 51m;
         proxy_pass http://backend:5000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## 改动内容

- 将 Nginx API 请求体上限调整为 51 MiB，为后端允许的 50 MiB 学习资源预留 multipart 开销。
- 让预览 Cookie 的 Secure 属性跟随经过转发头解析后的实际 HTTP/HTTPS 协议。
- 增加 HTTP 图片预览、HTTPS Cookie 安全属性和 Nginx 上传限制回归测试。

## 改动原因

- Nginx 默认约 1 MiB 的请求限制会在 PDF 到达后端前拒绝上传。
- 非开发环境原先无条件设置 Secure Cookie；当前直接使用 HTTP 的部署中，浏览器不会发送该 Cookie，导致图片预览内容请求未授权。

---

## 关联 Issue

Closes #177

## 审查关注点

- `client_max_body_size 51m` 是否与后端 50 MiB 文件限制及 multipart 预留保持一致。
- HTTP 下允许短时、HttpOnly、SameSite=Strict、限定 Path 的预览 Cookie是否符合当前部署需求；HTTPS 下仍会设置 Secure。
- 新增端点测试是否完整覆盖图片内容请求不携带 Bearer、仅依赖预览 Cookie 的实际浏览器行为。

## UI 改动

无界面改动，无需截图。

## 测试说明

- `dotnet test backend.Tests/ClubHub.Api.Tests.csproj --configuration Release --no-restore`：159/159 通过。
- `corepack pnpm@10 test`：59/59 通过。
- `corepack pnpm@10 run build`：通过。
- 一次性 `nginx:alpine` 容器执行 `nginx -t`：通过。
- `git diff --check`：通过。
- 未连接共享 Oracle，也未修改数据库或 OpenAPI 契约。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过（`dotnet build`）
- [x] 前端代码已构建通过（`pnpm build`）
- [ ] 已本地手工测试主要场景（真实 OSS 上传与浏览器预览待部署环境验证）

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets（请在 PR 描述中注明）
- [ ] 需要修改服务器配置或手动迁移（Nginx 配置随前端镜像发布，无手工迁移）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 上传请求现支持最大约 50 MiB 的请求体。

- **漏洞修复**
  - 预览会话 Cookie 会根据实际 HTTP/HTTPS 连接正确设置安全属性。
  - HTTPS 预览 Cookie 现包含 `Secure`、`HttpOnly` 和限定路径，提升安全性。

- **测试**
  - 新增 HTTP、HTTPS 预览会话及上传大小限制的自动化验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->