### PR TITLE
fix(deploy): 暂停生产 Redis 部署依赖

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,35 @@ jobs:
           fi
           echo "数据库脚本检查通过：共 $table_count 张表。"
 
+      - name: 检查 production Redis 暂停配置
+        shell: bash
+        env:
+          BACKEND_IMAGE: ghcr.io/example/clubhub-backend:test
+          FRONTEND_IMAGE: ghcr.io/example/clubhub-frontend:test
+          DB_CONNECTION_STRING: validation-placeholder
+          AUTH_TOKEN_SIGNING_KEY: validation-placeholder
+        run: |
+          set -euo pipefail
+
+          services="$(docker compose -f docker-compose.yml config --services)"
+          if printf '%s\n' "$services" | grep -qx 'redis'; then
+            echo "::error::production docker-compose.yml 不应在 Redis 暂停期间定义 redis service。"
+            exit 1
+          fi
+
+          rendered="$(docker compose -f docker-compose.yml config)"
+          if ! printf '%s\n' "$rendered" | grep -Fq 'Redis__Enabled: "false"'; then
+            echo "::error::production backend 必须显式设置 Redis__Enabled=false。"
+            exit 1
+          fi
+
+          if grep -Fq 'REDIS_PASSWORD' .github/workflows/deploy.yml; then
+            echo "::error::Redis 暂停期间 Deploy workflow 不应要求或传递 REDIS_PASSWORD。"
+            exit 1
+          fi
+
+          echo "production Redis 暂停配置检查通过。"
+
   # ============================================================
   # 后端构建与测试（后端、两类后端测试或 .sln 变更时运行）
   # draft PR 阶段也运行，用于尽早发现编译问题

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,13 @@ jobs:
             exit 1
           fi
 
-          if grep -Fq 'REDIS_PASSWORD' .github/workflows/deploy.yml; then
-            echo "::error::Redis 暂停期间 Deploy workflow 不应要求或传递 REDIS_PASSWORD。"
+          if grep -Fq 'secrets.REDIS_PASSWORD' .github/workflows/deploy.yml; then
+            echo "::error::Redis 暂停期间 Deploy workflow 不应引用 REDIS_PASSWORD Secret。"
+            exit 1
+          fi
+
+          if grep -Eq '^[[:space:]]+envs:.*REDIS_' .github/workflows/deploy.yml; then
+            echo "::error::Redis 暂停期间 Deploy workflow 不应向服务器传递 Redis 环境变量。"
             exit 1
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,6 @@ jobs:
         env:
           DB_CONNECTION_STRING: ${{ secrets.DB_CONNECTION_STRING }}
           AUTH_TOKEN_SIGNING_KEY: ${{ secrets.AUTH_TOKEN_SIGNING_KEY }}
-          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
         run: |
           if [ -z "${DB_CONNECTION_STRING:-}" ]; then
             echo "::error::缺少 GitHub Secret：DB_CONNECTION_STRING。请先在仓库或目标环境的 Secrets 中配置 Oracle 连接串。"
@@ -50,10 +49,6 @@ jobs:
           fi
           if [ -z "${AUTH_TOKEN_SIGNING_KEY:-}" ]; then
             echo "::error::缺少 GitHub Secret：AUTH_TOKEN_SIGNING_KEY。请先在仓库或目标环境的 Secrets 中配置生产环境登录令牌签名密钥。"
-            exit 1
-          fi
-          if [ -z "${REDIS_PASSWORD:-}" ]; then
-            echo "::error::缺少 GitHub Secret：REDIS_PASSWORD。请先配置生产 Redis 认证密码。"
             exit 1
           fi
 
@@ -128,13 +123,6 @@ jobs:
         env:
           DB_CONNECTION_STRING: ${{ secrets.DB_CONNECTION_STRING }}
           AUTH_TOKEN_SIGNING_KEY: ${{ secrets.AUTH_TOKEN_SIGNING_KEY }}
-          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-          REDIS_CACHE_ENABLED: ${{ vars.REDIS_CACHE_ENABLED || 'false' }}
-          REDIS_AUTH_SESSIONS_ENABLED: ${{ vars.REDIS_AUTH_SESSIONS_ENABLED || 'false' }}
-          REDIS_PERMISSION_CACHE_ENABLED: ${{ vars.REDIS_PERMISSION_CACHE_ENABLED || 'false' }}
-          REDIS_PREVIEW_SESSIONS_ENABLED: ${{ vars.REDIS_PREVIEW_SESSIONS_ENABLED || 'false' }}
-          REDIS_RATE_LIMITING_ENABLED: ${{ vars.REDIS_RATE_LIMITING_ENABLED || 'false' }}
-          REDIS_IDEMPOTENCY_ENABLED: ${{ vars.REDIS_IDEMPOTENCY_ENABLED || 'false' }}
           BACKEND_IMAGE: ${{ steps.meta.outputs.backend_image }}:${{ steps.meta.outputs.sha_tag }}
           FRONTEND_IMAGE: ${{ steps.meta.outputs.frontend_image }}:${{ steps.meta.outputs.sha_tag }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -146,7 +134,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           timeout: 60s
           command_timeout: 20m
-          envs: DB_CONNECTION_STRING,AUTH_TOKEN_SIGNING_KEY,REDIS_PASSWORD,REDIS_CACHE_ENABLED,REDIS_AUTH_SESSIONS_ENABLED,REDIS_PERMISSION_CACHE_ENABLED,REDIS_PREVIEW_SESSIONS_ENABLED,REDIS_RATE_LIMITING_ENABLED,REDIS_IDEMPOTENCY_ENABLED,BACKEND_IMAGE,FRONTEND_IMAGE,GHCR_TOKEN,GHCR_USER
+          envs: DB_CONNECTION_STRING,AUTH_TOKEN_SIGNING_KEY,BACKEND_IMAGE,FRONTEND_IMAGE,GHCR_TOKEN,GHCR_USER
           script: |
             set -e
             cd "${{ secrets.DEPLOY_PATH }}"
@@ -183,6 +171,18 @@ jobs:
               chmod 600 .env
             }
 
+            remove_env_var() {
+              key="$1"
+              if [ ! -f .env ]; then
+                return 0
+              fi
+
+              tmp="$(mktemp)"
+              grep -v "^${key}=" .env > "$tmp" || true
+              mv "$tmp" .env
+              chmod 600 .env
+            }
+
             wait_for_services() {
               docker compose ps
               if ! docker compose ps --services --status running | grep -q "^backend$"; then
@@ -193,11 +193,6 @@ jobs:
               if ! docker compose ps --services --status running | grep -q "^frontend$"; then
                 echo "!!! 前端服务未运行 !!!"
                 docker compose logs --tail 50
-                return 1
-              fi
-              if ! docker compose ps --services --status running | grep -q "^redis$"; then
-                echo "!!! Redis 服务未运行 !!!"
-                docker compose logs --tail 50 redis
                 return 1
               fi
             }
@@ -217,18 +212,21 @@ jobs:
               fi
               write_env_var AUTH_TOKEN_SIGNING_KEY "$AUTH_TOKEN_SIGNING_KEY" || return 1
 
-              echo "=== 写入 Redis 认证配置 ==="
-              if [ -z "${REDIS_PASSWORD:-}" ]; then
-                echo "!!! REDIS_PASSWORD 为空，请检查 GitHub Secret 配置 !!!"
-                return 1
-              fi
-              write_env_var REDIS_PASSWORD "$REDIS_PASSWORD" || return 1
-              write_env_var REDIS_CACHE_ENABLED "${REDIS_CACHE_ENABLED:-false}" || return 1
-              write_env_var REDIS_AUTH_SESSIONS_ENABLED "${REDIS_AUTH_SESSIONS_ENABLED:-false}" || return 1
-              write_env_var REDIS_PERMISSION_CACHE_ENABLED "${REDIS_PERMISSION_CACHE_ENABLED:-false}" || return 1
-              write_env_var REDIS_PREVIEW_SESSIONS_ENABLED "${REDIS_PREVIEW_SESSIONS_ENABLED:-false}" || return 1
-              write_env_var REDIS_RATE_LIMITING_ENABLED "${REDIS_RATE_LIMITING_ENABLED:-false}" || return 1
-              write_env_var REDIS_IDEMPOTENCY_ENABLED "${REDIS_IDEMPOTENCY_ENABLED:-false}" || return 1
+              echo "=== 清理已停用的 production Redis 配置 ==="
+              for key in \
+                REDIS_PASSWORD \
+                REDIS_CACHE_ENABLED \
+                REDIS_AUTH_SESSIONS_ENABLED \
+                REDIS_PERMISSION_CACHE_ENABLED \
+                REDIS_PREVIEW_SESSIONS_ENABLED \
+                REDIS_RATE_LIMITING_ENABLED \
+                REDIS_IDEMPOTENCY_ENABLED \
+                REDIS_MAXMEMORY \
+                REDIS_CONTAINER_MEMORY_LIMIT \
+                REDIS_CPUS; do
+                remove_env_var "$key" || return 1
+              done
+
               if [ -z "${BACKEND_IMAGE:-}" ] || [ -z "${FRONTEND_IMAGE:-}" ]; then
                 echo "!!! 部署镜像引用为空，无法执行精确版本部署 !!!"
                 return 1
@@ -243,7 +241,7 @@ jobs:
               retry 3 20 docker compose pull || return 1
 
               echo "=== 启动服务 ==="
-              retry 3 20 docker compose up -d || return 1
+              retry 3 20 docker compose up -d --remove-orphans || return 1
 
               echo "=== 等待服务启动 ==="
               sleep 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,54 +1,10 @@
 # 生产环境 Docker Compose
 # 部署流程：CI 构建镜像 → 推送到 ghcr.io → 服务器 docker compose pull && up -d
+# Redis 当前在 production 暂停部署；后端 Redis 实现保留，后续启用功能时再恢复基础设施。
 #
 # 服务器上运行：docker compose up -d
 
 services:
-  redis:
-    image: redis:8.2.8-alpine
-    command:
-      - sh
-      - -ec
-      - |
-        exec redis-server \
-          --appendonly yes \
-          --appendfsync everysec \
-          --save 300 10 \
-          --maxmemory "$$REDIS_MAXMEMORY" \
-          --maxmemory-policy noeviction \
-          --dir /data \
-          --requirepass "$$REDIS_PASSWORD"
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD:?Set REDIS_PASSWORD in the deployment environment}
-      REDIS_MAXMEMORY: ${REDIS_MAXMEMORY:-384mb}
-    volumes:
-      - redis-data:/data
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          'REDISCLI_AUTH="$$REDIS_PASSWORD" redis-cli --no-auth-warning ping | grep -q PONG',
-        ]
-      interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 10s
-    networks:
-      - clubhub-net
-    restart: unless-stopped
-    stop_grace_period: 30s
-    mem_limit: ${REDIS_CONTAINER_MEMORY_LIMIT:-512m}
-    cpus: ${REDIS_CPUS:-0.50}
-    security_opt:
-      - no-new-privileges:true
-    tmpfs:
-      - /tmp
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "5"
-
   backend:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to an immutable tag or digest}
     environment:
@@ -56,19 +12,9 @@ services:
       ASPNETCORE_URLS: http://+:5000
       ConnectionStrings__Default: ${DB_CONNECTION_STRING}
       Authentication__TokenSigningKey: ${AUTH_TOKEN_SIGNING_KEY}
-      Redis__Enabled: "true"
-      Redis__ConnectionString: redis:6379
-      Redis__Username: default
-      Redis__Password: ${REDIS_PASSWORD}
-      Redis__EnvironmentPrefix: prod
-      Redis__Features__Cache: ${REDIS_CACHE_ENABLED:-false}
-      Redis__Features__AuthSessions: ${REDIS_AUTH_SESSIONS_ENABLED:-false}
-      Redis__Features__PermissionCache: ${REDIS_PERMISSION_CACHE_ENABLED:-false}
-      Redis__Features__PreviewSessions: ${REDIS_PREVIEW_SESSIONS_ENABLED:-false}
-      Redis__Features__RateLimiting: ${REDIS_RATE_LIMITING_ENABLED:-false}
-      Redis__Features__Idempotency: ${REDIS_IDEMPOTENCY_ENABLED:-false}
+      Redis__Enabled: "false"
       Authentication__Sessions__SlidingLifetimeMinutes: ${AUTH_SESSION_SLIDING_MINUTES:-30}
-      Authentication__Sessions__AbsoluteLifetimeHours: ${AUTH_SESSION_ABSOLUTE_HOURS:-12}
+      Authentication__Sessions__AbsoluteLifetimeHours: ${AUTH_SESSION_ABSOLUTE_LIFETIME_HOURS:-12}
       Authentication__Sessions__MaxSessionsPerUser: ${AUTH_SESSION_MAX_PER_USER:-10}
       Oss__Region: ${OSS_REGION:-cn-shanghai}
       Oss__Endpoint: ${OSS_ENDPOINT:-oss-cn-shanghai-internal.aliyuncs.com}
@@ -80,9 +26,6 @@ services:
     networks:
       - clubhub-net
     restart: unless-stopped
-    depends_on:
-      redis:
-        condition: service_healthy
 
   frontend:
     image: ${FRONTEND_IMAGE:?Set FRONTEND_IMAGE to an immutable tag or digest}
@@ -97,6 +40,3 @@ services:
 networks:
   clubhub-net:
     external: true
-
-volumes:
-  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       Authentication__TokenSigningKey: ${AUTH_TOKEN_SIGNING_KEY}
       Redis__Enabled: "false"
       Authentication__Sessions__SlidingLifetimeMinutes: ${AUTH_SESSION_SLIDING_MINUTES:-30}
-      Authentication__Sessions__AbsoluteLifetimeHours: ${AUTH_SESSION_ABSOLUTE_LIFETIME_HOURS:-12}
+      Authentication__Sessions__AbsoluteLifetimeHours: ${AUTH_SESSION_ABSOLUTE_HOURS:-12}
       Authentication__Sessions__MaxSessionsPerUser: ${AUTH_SESSION_MAX_PER_USER:-10}
       Oss__Region: ${OSS_REGION:-cn-shanghai}
       Oss__Endpoint: ${OSS_ENDPOINT:-oss-cn-shanghai-internal.aliyuncs.com}

--- a/docs/operations/redis-runbook.md
+++ b/docs/operations/redis-runbook.md
@@ -1,19 +1,41 @@
 # Redis 运维手册
 
-本文适用于 ClubHub 开发、演示和生产环境中的单实例 Redis。Oracle 仍是正式业务
+本文适用于 ClubHub 开发、演示以及未来重新启用 Redis 后的生产环境。Oracle 仍是正式业务
 数据的唯一事实来源；Redis 中的普通缓存可以自然重建，未来的会话、幂等状态和
 Stream 则依赖 AOF、备份和业务对账。
 
+## 当前生产状态（2026-08-20）
+
+production Redis **暂时停用**。当前 `docker-compose.yml` 不创建 Redis 容器，后端显式
+使用 `Redis__Enabled=false`；开发与 CI 测试环境仍保留 Redis，用于继续验证现有 Redis
+实现。
+
+暂停原因是当前生产服务器无法稳定访问 Docker Hub，而 production Redis 业务 feature
+flags 尚未启用。此次调整只取消生产部署硬依赖，不删除 Redis C# 实现，也不代表放弃
+后续 Redis 能力。
+
+当前 Deploy workflow：
+
+- 只要求 production 服务器拉取 ClubHub backend/frontend 的 GHCR 镜像。
+- 不再要求或传递 `REDIS_PASSWORD`。
+- 部署时会清理服务器 `.env` 中上一版遗留的 Redis 配置项。
+- `docker compose up -d --remove-orphans` 会移除旧编排遗留的 Redis 容器，但不会主动删除
+  已存在的命名卷；未来恢复前应先确认卷内容与是否需要保留。
+
+重新启用 production Redis 前必须先确定生产服务器可稳定获取的 Redis 镜像来源（例如
+受控镜像仓库或可靠 registry mirror），再恢复 Compose service、认证 Secret、readiness
+依赖和对应 Deploy 配置。不要只打开 Redis feature flag 而不恢复基础设施。
+
 ## 配置基线
 
-- 镜像固定为 `redis:8.2.8-alpine`。
-- Redis 只连接 Compose 内部网络，不映射宿主机或公网 `6379`。
-- 数据保存在 `redis-dev-data`（开发）或 `redis-data`（生产）命名卷。
-- AOF 使用 `appendfsync everysec`，同时每 300 秒且至少发生 10 次写入时生成 RDB。
+- 开发与 CI 测试使用固定镜像 `redis:8.2.8-alpine`；production 当前不部署 Redis 镜像。
+- Redis 启用时只连接 Compose 内部网络，不映射宿主机或公网 `6379`。
+- 开发数据保存在 `redis-dev-data` 命名卷；production 恢复 Redis 后再使用受控的生产命名卷。
+- Redis 启用时 AOF 使用 `appendfsync everysec`，同时每 300 秒且至少发生 10 次写入时生成 RDB。
 - `maxmemory-policy` 固定为 `noeviction`。达到上限后写入应失败，不能静默淘汰未来
   的会话、幂等状态或 Stream Pending 消息。
-- 密码通过 `.env` 或 GitHub Secret `REDIS_PASSWORD` 注入；仓库、镜像和日志中
-  不得保存真实密码。
+- 开发环境密码通过 `.env` 注入；未来恢复 production Redis 时通过目标 GitHub Environment
+  Secret `REDIS_PASSWORD` 注入。仓库、镜像和日志中不得保存真实密码。
 
 ## 启动和健康检查
 
@@ -35,18 +57,23 @@ docker compose -f docker-compose.dev.yml exec redis sh
 REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning ping
 ```
 
-`/health/live` 只检查 API 进程；`/health/ready` 同时检查启用的 Redis。Redis 故障时
-普通缓存查询应回源 Oracle，但 readiness 会返回 503，防止部署流程误判成功。
+`/health/live` 只检查 API 进程。Redis 启用时，`/health/ready` 同时检查 Redis；Redis 故障时
+readiness 会返回 503，防止部署流程误判成功。Redis 总开关关闭时，Redis health check
+按设计返回 Healthy（`Redis is disabled.`），因此当前 production readiness 不依赖 Redis。
 
 ## 功能启用与回滚顺序
 
-所有 Redis 业务开关默认关闭。生产或演示环境按以下顺序人工启用：
+所有 Redis 业务开关默认关闭。production 当前还需要先恢复 Redis 基础设施，之后才能按
+以下顺序人工启用：
 
-1. 先备份 Oracle 与 Redis，并在隔离 Schema 验证
+1. 确认生产服务器能够稳定拉取受控 Redis 镜像，恢复 Compose Redis service、
+   `REDIS_PASSWORD`、后端连接配置和 Redis readiness 依赖，并先保持所有业务 feature
+   flags 为关闭状态。
+2. 备份 Oracle 与 Redis，并在隔离 Schema 验证
    `database/migrations/20260726_add_idempotency_records.sql`。
-2. 人工执行迁移后启用 `REDIS_IDEMPOTENCY_ENABLED`，再按需启用权限缓存、预览会话
+3. 人工执行迁移后启用 `REDIS_IDEMPOTENCY_ENABLED`，再按需启用权限缓存、预览会话
    和限流。
-3. 最后启用 `REDIS_AUTH_SESSIONS_ENABLED`；已有纯签名 Token 会全部失效，需提前通知
+4. 最后启用 `REDIS_AUTH_SESSIONS_ENABLED`；已有纯签名 Token 会全部失效，需提前通知
    用户重新登录。
 
 认证会话回滚也会要求全员重新登录。权限缓存可关闭并直接回源 Oracle；限流、预览
@@ -55,11 +82,14 @@ REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning ping
 
 ## 备份
 
-至少在版本升级、密码轮换和重大功能上线前生成一次 RDB，并将文件复制到受控的
-异机存储。下面的命令不会打印密码：
+本节仅适用于实际正在运行 Redis 的环境；production Redis 暂停期间没有可由当前
+`docker-compose.yml` 执行的 Redis 备份命令。重新启用 production Redis 后，应在版本升级、
+密码轮换和重大功能上线前至少生成一次 RDB，并将文件复制到受控的异机存储。
+
+开发环境示例：
 
 ```powershell
-$composeFile = 'docker-compose.dev.yml' # 生产备份时改为 docker-compose.yml
+$composeFile = 'docker-compose.dev.yml'
 $before = [long](docker compose -f $composeFile exec -T redis sh -ec 'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning LASTSAVE')
 docker compose -f $composeFile exec -T redis sh -ec 'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning BGSAVE'
 do {
@@ -100,11 +130,16 @@ Get-FileHash ./redis-backup-dump.rdb -Algorithm SHA256
 2. 生成 RDB 备份并完成隔离恢复演练。
 3. 在开发或 staging 将 Compose 镜像改为精确补丁版本，运行构建、健康检查和业务
    故障测试。
-4. 生产维护窗口内拉取镜像并重新创建 Redis；确认 AOF 加载、readiness、内存和
-   业务查询均正常。
+4. production Redis 已恢复的情况下，在维护窗口拉取镜像并重新创建 Redis；确认 AOF
+   加载、readiness、内存和业务查询均正常。
 5. 回滚时恢复原镜像版本和原卷；禁止用空卷覆盖仍可恢复的数据。
 
+production Redis 仍处于暂停状态时，不执行 Redis 升级或轮换操作；应先完成“功能启用与
+回滚顺序”中的基础设施恢复步骤。
+
 ## 密码轮换
+
+production Redis 恢复后才需要执行以下流程：
 
 1. 生成新的高强度随机密码并更新目标 GitHub Environment 的 `REDIS_PASSWORD`。
 2. 在维护窗口重新部署 Redis 和后端，使服务端与客户端同时使用新密码。
@@ -116,7 +151,7 @@ Get-FileHash ./redis-backup-dump.rdb -Algorithm SHA256
 
 ## 容量和告警
 
-至少监控以下项目：
+以下指标只在 Redis 实际启用的环境中监控：
 
 | 指标 | 告警建议 |
 | --- | --- |
@@ -125,13 +160,13 @@ Get-FileHash ./redis-backup-dump.rdb -Algorithm SHA256
 | `evicted_keys` | 必须始终为 0，任何增长立即告警 |
 | `rejected_connections`、连接失败和超时 | 持续增长或连续 5 分钟异常时告警 |
 | `aof_last_write_status`、`aof_last_bgrewrite_status` | 非 `ok` 立即告警 |
-| `/health/ready` | 连续失败立即停止部署并通知维护者 |
+| `/health/ready` | Redis 启用后连续失败应立即停止部署并通知维护者 |
 | 缓存命中、未命中、回源和重建失败 | 回源或失败率突增时检查 Redis 与 Oracle |
 | 缓存重建租约 `owner-mismatch` | 持续出现时检查 Oracle 慢查询并调整租约 TTL |
 | 会话/限流/预览 503 比例 | 任一持续增长时停止新流量并检查 Redis 连通性、AOF 和容量 |
 | `IDEMPOTENCY_RECORDS` 过期清理积压 | 连续两个清理周期增长时检查 Oracle 任务和索引 |
 
-常用只读检查：
+常用只读检查（Redis 已启用环境）：
 
 ```powershell
 docker compose exec redis sh -ec 'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning INFO memory'
@@ -142,9 +177,12 @@ docker compose logs --tail 100 redis
 
 ## 故障排查
 
-- **认证失败**：确认 `.env` 或 GitHub Secret 已更新，并重新创建 Redis 与后端容器；
-  不要在日志中打印变量值。
-- **readiness 503**：检查 Redis 容器健康状态、网络、认证和 AOF 加载日志。
+- **production 找不到 Redis 容器**：先确认当前是否仍处于本手册顶部记录的“production
+  Redis 暂停”状态；暂停期间这是预期行为，不应通过临时拉取 Docker Hub 镜像绕过流程。
+- **认证失败**：Redis 已启用环境中确认 `.env` 或 GitHub Secret 已更新，并重新创建 Redis
+  与后端容器；不要在日志中打印变量值。
+- **readiness 503**：Redis 已启用时检查 Redis 容器健康状态、网络、认证和 AOF 加载日志；
+  Redis 总开关关闭时应先排查其他 readiness 项。
 - **写入失败且内存接近上限**：保持 `noeviction`，先停止产生可靠状态的新入口，分析
   Key、TTL 和 Stream backlog；不得临时改为淘汰策略。
 - **AOF/RDB 错误**：停止写流量，保留卷和日志，使用最近备份在隔离卷恢复。


### PR DESCRIPTION
Closes #183

## 改动内容

- `docker-compose.yml`
  - 暂停 production Redis service，移除 backend 对 Redis 的 `depends_on`。
  - production backend 显式设置 `Redis__Enabled=false`。
  - Redis C# 实现、开发/测试 Redis 均保留。
- `.github/workflows/deploy.yml`
  - 不再校验、读取或向服务器传递 `REDIS_PASSWORD` / Redis feature vars。
  - 不再要求 Redis 容器处于 running 状态。
  - 部署时清理服务器 `.env` 中上一版遗留的 Redis 配置键。
  - 使用 `docker compose up -d --remove-orphans`，使旧编排遗留 Redis 容器被移除；不会主动删除命名卷。
- `.github/workflows/ci.yml`
  - 增加 production Redis 暂停配置回归校验：production compose 不得出现 redis service、backend 必须保持 `Redis__Enabled=false`、Deploy 不得重新引用 Redis Secret 或通过 SSH 传递 Redis 变量。
- `docs/operations/redis-runbook.md`
  - 同步记录 2026-08-20 起 production Redis 暂停状态、恢复前置条件、readiness 行为与运维边界。

## 背景

生产 Deploy #25（run `32294167332`）中，ClubHub backend/frontend 的 GHCR 镜像均能正常拉取，但服务器无法访问 Docker Hub 的 `redis:8.2.8-alpine`，导致 `docker compose pull` 在多轮重试后失败。当前 production Redis feature flags 尚未启用，因此先取消这一未实际承载业务功能的生产硬依赖。

@wendaining FYI：这次不是删除你加入的 Redis 功能。Redis 的 C# 实现、开发/测试支持都会完整保留；只是当前生产服务器无法直接拉 Docker Hub Redis 镜像，而且 production 的 Redis 功能开关目前全部关闭，所以先暂停 production Redis 容器部署。后续真正启用缓存 / session / 限流等 Redis 能力时，再恢复 production Redis 基础设施并确定稳定镜像来源。

## 风险与影响

- 不修改业务逻辑、数据库或 Redis 实现代码。
- production 暂时不提供 Redis-backed 功能；当前这些 feature flags 原本即为关闭状态。
- 现有后端测试已经验证 Redis disabled 时不会打开 Redis 连接，并且 readiness 保持 Healthy。
- GitHub Environment 中现有 `REDIS_PASSWORD` Secret 不会删除，只是不再被当前 production Deploy 使用。

## 验证结果

- Ready 后最终 CI run `32296416159`（#814）：
  - 项目结构校验 ✅
  - production Redis 暂停配置回归校验 ✅
  - 后端构建 / 测试 ✅
  - 前端构建 / 测试 ✅
- Ready 后最终代码质量门禁 run `32296416186`（#724）：✅
- PR 最终变更范围：4 个文件，仅 production 编排、Deploy/CI workflow 与 Redis 运维文档。
- CodeRabbit 已尝试启动审查，但当前触发 review quota limit；没有产生 review thread 或代码阻塞意见。

## 上线后验证

合入 `main` 后重新执行 production Deploy，确认服务器只拉取 GHCR backend/frontend 镜像，旧 Redis 容器作为 orphan 被移除，backend/frontend 正常运行且 `/health/ready` 返回成功。
