### PR TITLE
refactor(activity): 统一复用生成活动响应模型

### DIFF
--- a/backend.Tests/ActivityResponseModelTests.cs
+++ b/backend.Tests/ActivityResponseModelTests.cs
@@ -134,6 +134,41 @@ public sealed class ActivityResponseModelTests
     }
 
     [Fact]
+    public async Task ActivityListIncludesNormalizedStatusInPaginationCount()
+    {
+        await using var factory = new ClubHubWebApplicationFactory();
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+            db.Clubs.Add(new Club
+            {
+                ClubId = 1,
+                ClubName = "数据库社",
+                CreatedAt = DateTime.UtcNow
+            });
+            db.Activities.Add(new Activity
+            {
+                ActivityId = 119,
+                ClubId = 1,
+                Title = "状态归一化活动",
+                ActivityStatus = " PUBLISHED ",
+                CreatedAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync("/api/activities?page=1&pageSize=10");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("1", response.Headers.GetValues("X-Total-Count").Single());
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var item = Assert.Single(document.RootElement.EnumerateArray());
+        Assert.Equal(119, item.GetProperty("id").GetInt32());
+        Assert.Equal("published", item.GetProperty("status").GetString());
+    }
+
+    [Fact]
     public async Task ActivityListSkipsNullAndUnknownStatuses()
     {
         await using var baseFactory = new ClubHubWebApplicationFactory();

--- a/backend.Tests/ActivityResponseModelTests.cs
+++ b/backend.Tests/ActivityResponseModelTests.cs
@@ -176,9 +176,10 @@ public sealed class ActivityResponseModelTests
         }
 
         using var client = factory.CreateClient();
-        using var response = await client.GetAsync("/api/activities");
+        using var response = await client.GetAsync("/api/activities?page=1&pageSize=10");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("1", response.Headers.GetValues("X-Total-Count").Single());
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         var item = Assert.Single(document.RootElement.EnumerateArray());
         Assert.Equal(119, item.GetProperty("id").GetInt32());

--- a/backend.Tests/ActivityResponseModelTests.cs
+++ b/backend.Tests/ActivityResponseModelTests.cs
@@ -1,9 +1,12 @@
 using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text.Json;
 using ClubHub.Api.Controllers;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
 using ClubHub.Api.Infrastructure.Rest;
+using ClubHub.Api.Services;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -90,6 +93,49 @@ public sealed class ActivityResponseModelTests
     public void StatusMappingReturnsFalseForValuesOutsideOpenApiContract(string? status)
     {
         Assert.False(ActivitiesController.TryParseActivityStatus(status, out _));
+    }
+
+    [Fact]
+    public void RegistrationStatusGateAcceptsPublishedStatusWithWhitespace()
+    {
+        Assert.True(ActivitiesController.IsPublishedActivityStatus(" PUBLISHED "));
+    }
+
+    [Fact]
+    public async Task CheckinSettingsAcceptPublishedStatusWithWhitespace()
+    {
+        await using var factory = new ClubHubWebApplicationFactory();
+        using var client = await CreateAuthenticatedActivityClient(factory, "CLUB_OFFICER");
+        var now = DateTime.Now;
+
+        using var response = await client.PutAsJsonAsync(
+            "/api/activities/119/checkin-settings",
+            new
+            {
+                checkinCode = "check",
+                checkinStartAt = now.AddMinutes(-5),
+                checkinEndAt = now.AddMinutes(20),
+                checkoutCode = "checkout",
+                checkoutStartAt = now.AddMinutes(30),
+                checkoutEndAt = now.AddMinutes(50)
+            });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckinAcceptsPublishedStatusWithWhitespace()
+    {
+        await using var factory = new ClubHubWebApplicationFactory();
+        using var client = await CreateAuthenticatedActivityClient(factory, "CLUB_MEMBER");
+
+        using var response = await client.PostAsJsonAsync(
+            "/api/activities/119/checkin",
+            new { code = "check" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("checked_in", document.RootElement.GetProperty("signStatus").GetString());
     }
 
     [Fact]
@@ -265,6 +311,73 @@ public sealed class ActivityResponseModelTests
     {
         Assert.Null(typeof(ActivitiesController).Assembly.GetType(
             "ClubHub.Api.Controllers.ActivityDto"));
+    }
+
+    private static async Task<HttpClient> CreateAuthenticatedActivityClient(
+        ClubHubWebApplicationFactory factory,
+        string roleCode)
+    {
+        await using var scope = factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        var now = DateTime.Now;
+        var user = new User
+        {
+            UserId = 21,
+            Username = "activity-status-test",
+            PasswordHash = "unused",
+            RealName = "活动状态测试用户",
+            AccountStatus = "normal",
+            CreatedAt = now
+        };
+        db.Users.Add(user);
+        db.Clubs.Add(new Club
+        {
+            ClubId = 1,
+            ClubName = "数据库社",
+            ClubStatus = "active",
+            CreatedAt = now
+        });
+        db.Roles.Add(new Role
+        {
+            RoleId = 31,
+            RoleCode = roleCode,
+            RoleName = "活动状态测试角色",
+            RoleScope = "club",
+            CreatedAt = now
+        });
+        db.UserRoles.Add(new UserRole
+        {
+            UserRoleId = 41,
+            UserId = user.UserId,
+            RoleId = 31,
+            ClubId = 1,
+            AssignedAt = now
+        });
+        db.Activities.Add(new Activity
+        {
+            ActivityId = 119,
+            ClubId = 1,
+            Title = "状态门禁归一化活动",
+            ActivityStatus = " PUBLISHED ",
+            StartAt = now.AddHours(-1),
+            EndAt = now.AddHours(2),
+            CheckinCode = "check",
+            CheckinStartAt = now.AddMinutes(-10),
+            CheckinEndAt = now.AddMinutes(10),
+            CheckoutCode = "checkout",
+            CheckoutStartAt = now.AddMinutes(20),
+            CheckoutEndAt = now.AddMinutes(40),
+            CreatedAt = now
+        });
+        await db.SaveChangesAsync();
+
+        var token = scope.ServiceProvider
+            .GetRequiredService<AuthTokenService>()
+            .CreateToken(user);
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+        return client;
     }
 
     private static WebApplicationFactory<Program> WithNullActivityLogger(

--- a/backend.Tests/ActivityResponseModelTests.cs
+++ b/backend.Tests/ActivityResponseModelTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Text.Json;
+using ClubHub.Api.Controllers;
+using ClubHub.Api.Data;
+using ClubHub.Api.Data.Entities;
+using Microsoft.Extensions.DependencyInjection;
+using ApiActivity = Org.OpenAPITools.Models.Activity;
+
+namespace ClubHub.Api.Tests;
+
+public sealed class ActivityResponseModelTests
+{
+    [Fact]
+    public void EntityMappingUsesGeneratedActivityModel()
+    {
+        var startTime = new DateTime(2026, 8, 27, 9, 0, 0, DateTimeKind.Utc);
+        var activity = new Activity
+        {
+            ActivityId = 119,
+            ClubId = 7,
+            CreatorUserId = 21,
+            Title = "数据库设计交流会",
+            ActivityType = "seminar",
+            Description = "统一活动响应模型",
+            Location = "济事楼 119",
+            StartAt = startTime,
+            EndAt = startTime.AddHours(2),
+            ActivityStatus = "pending_review",
+            Capacity = 80,
+            RegistrationDeadline = startTime.AddDays(-1),
+            ReviewerUserId = 22,
+            ReviewComment = "等待审核",
+            BudgetAmount = 1199.50m,
+            BudgetPurpose = "活动物料",
+            BudgetDetail = "海报与打印",
+            BudgetStatus = "pending",
+            BudgetReviewerId = 23,
+            BudgetComment = "等待经费审核",
+            PublishedAt = null,
+            CheckinStartAt = startTime,
+            CheckinEndAt = startTime.AddMinutes(30),
+            CheckoutStartAt = startTime.AddHours(1),
+            CheckoutEndAt = startTime.AddHours(2),
+            Club = new Club { ClubId = 7, ClubName = "数据库社" }
+        };
+
+        var result = ActivitiesController.ToApiModel(activity, 12, true);
+
+        Assert.IsType<ApiActivity>(result);
+        Assert.Equal(119, result.Id);
+        Assert.Equal("数据库设计交流会", result.Title);
+        Assert.Equal("数据库社", result.ClubName);
+        Assert.Equal(ApiActivity.StatusEnum.PendingReviewEnum, result.Status);
+        Assert.Equal(1199.50d, result.BudgetAmount);
+        Assert.Equal(12, result.CurrentParticipants);
+        Assert.True(result.IsRegistered);
+    }
+
+    [Theory]
+    [InlineData("draft", ApiActivity.StatusEnum.DraftEnum)]
+    [InlineData("pending_review", ApiActivity.StatusEnum.PendingReviewEnum)]
+    [InlineData("published", ApiActivity.StatusEnum.PublishedEnum)]
+    [InlineData("rejected", ApiActivity.StatusEnum.RejectedEnum)]
+    [InlineData("ongoing", ApiActivity.StatusEnum.OngoingEnum)]
+    [InlineData("finished", ApiActivity.StatusEnum.FinishedEnum)]
+    [InlineData("cancelled", ApiActivity.StatusEnum.CancelledEnum)]
+    public void StatusMappingCoversOpenApiEnumValues(
+        string status,
+        ApiActivity.StatusEnum expected)
+    {
+        Assert.Equal(expected, ActivitiesController.ParseActivityStatus(status));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("archived")]
+    public void StatusMappingRejectsValuesOutsideOpenApiContract(string? status)
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => ActivitiesController.ParseActivityStatus(status));
+    }
+
+    [Fact]
+    public async Task ActivityListKeepsOpenApiJsonWireFormat()
+    {
+        await using var factory = new ClubHubWebApplicationFactory();
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+            db.Clubs.Add(new Club
+            {
+                ClubId = 1,
+                ClubName = "数据库社",
+                CreatedAt = DateTime.UtcNow
+            });
+            db.Activities.Add(new Activity
+            {
+                ActivityId = 119,
+                ClubId = 1,
+                Title = "活动响应模型测试",
+                ActivityStatus = "published",
+                BudgetAmount = 119.50m,
+                CreatedAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync("/api/activities?page=1&pageSize=10");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var item = Assert.Single(document.RootElement.EnumerateArray());
+        Assert.Equal("published", item.GetProperty("status").GetString());
+        Assert.Equal(119.50d, item.GetProperty("budgetAmount").GetDouble());
+        Assert.Equal(0, item.GetProperty("currentParticipants").GetInt32());
+        Assert.False(item.GetProperty("isRegistered").GetBoolean());
+    }
+
+    [Fact]
+    public void HandwrittenActivityDtoIsRemoved()
+    {
+        Assert.Null(typeof(ActivitiesController).Assembly.GetType(
+            "ClubHub.Api.Controllers.ActivityDto"));
+    }
+}

--- a/backend.Tests/ActivityResponseModelTests.cs
+++ b/backend.Tests/ActivityResponseModelTests.cs
@@ -3,7 +3,12 @@ using System.Text.Json;
 using ClubHub.Api.Controllers;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
+using ClubHub.Api.Infrastructure.Rest;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ApiActivity = Org.OpenAPITools.Models.Activity;
 
 namespace ClubHub.Api.Tests;
@@ -44,8 +49,9 @@ public sealed class ActivityResponseModelTests
             Club = new Club { ClubId = 7, ClubName = "数据库社" }
         };
 
-        var result = ActivitiesController.ToApiModel(activity, 12, true);
+        var mapped = ActivitiesController.TryToApiModel(activity, 12, true, out var result);
 
+        Assert.True(mapped);
         Assert.IsType<ApiActivity>(result);
         Assert.Equal(119, result.Id);
         Assert.Equal("数据库设计交流会", result.Title);
@@ -58,6 +64,8 @@ public sealed class ActivityResponseModelTests
 
     [Theory]
     [InlineData("draft", ApiActivity.StatusEnum.DraftEnum)]
+    [InlineData(" PUBLISHED ", ApiActivity.StatusEnum.PublishedEnum)]
+    [InlineData("OnGoInG", ApiActivity.StatusEnum.OngoingEnum)]
     [InlineData("pending_review", ApiActivity.StatusEnum.PendingReviewEnum)]
     [InlineData("published", ApiActivity.StatusEnum.PublishedEnum)]
     [InlineData("rejected", ApiActivity.StatusEnum.RejectedEnum)]
@@ -68,17 +76,20 @@ public sealed class ActivityResponseModelTests
         string status,
         ApiActivity.StatusEnum expected)
     {
-        Assert.Equal(expected, ActivitiesController.ParseActivityStatus(status));
+        var parsed = ActivitiesController.TryParseActivityStatus(status, out var result);
+
+        Assert.True(parsed);
+        Assert.Equal(expected, result);
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
+    [InlineData("   ")]
     [InlineData("archived")]
-    public void StatusMappingRejectsValuesOutsideOpenApiContract(string? status)
+    public void StatusMappingReturnsFalseForValuesOutsideOpenApiContract(string? status)
     {
-        Assert.Throws<InvalidOperationException>(
-            () => ActivitiesController.ParseActivityStatus(status));
+        Assert.False(ActivitiesController.TryParseActivityStatus(status, out _));
     }
 
     [Fact]
@@ -110,6 +121,10 @@ public sealed class ActivityResponseModelTests
         using var response = await client.GetAsync("/api/activities?page=1&pageSize=10");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("1", response.Headers.GetValues("X-Page").Single());
+        Assert.Equal("10", response.Headers.GetValues("X-Page-Size").Single());
+        Assert.Equal("1", response.Headers.GetValues("X-Total-Count").Single());
+        Assert.True(response.Headers.Contains("Link"));
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         var item = Assert.Single(document.RootElement.EnumerateArray());
         Assert.Equal("published", item.GetProperty("status").GetString());
@@ -119,9 +134,109 @@ public sealed class ActivityResponseModelTests
     }
 
     [Fact]
+    public async Task ActivityListSkipsNullAndUnknownStatuses()
+    {
+        await using var baseFactory = new ClubHubWebApplicationFactory();
+        await using var factory = WithNullActivityLogger(baseFactory);
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+            db.Clubs.Add(new Club
+            {
+                ClubId = 1,
+                ClubName = "数据库社",
+                CreatedAt = DateTime.UtcNow
+            });
+            db.Activities.AddRange(
+                new Activity
+                {
+                    ActivityId = 117,
+                    ClubId = 1,
+                    Title = "空状态活动",
+                    ActivityStatus = null,
+                    CreatedAt = DateTime.UtcNow
+                },
+                new Activity
+                {
+                    ActivityId = 118,
+                    ClubId = 1,
+                    Title = "未知状态活动",
+                    ActivityStatus = "archived",
+                    CreatedAt = DateTime.UtcNow
+                },
+                new Activity
+                {
+                    ActivityId = 119,
+                    ClubId = 1,
+                    Title = "有效活动",
+                    ActivityStatus = "published",
+                    CreatedAt = DateTime.UtcNow
+                });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync("/api/activities");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var item = Assert.Single(document.RootElement.EnumerateArray());
+        Assert.Equal(119, item.GetProperty("id").GetInt32());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("archived")]
+    public async Task ActivityDetailReturnsControlledErrorForInvalidStatus(string? status)
+    {
+        await using var baseFactory = new ClubHubWebApplicationFactory();
+        await using var factory = WithNullActivityLogger(baseFactory);
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+            db.Clubs.Add(new Club
+            {
+                ClubId = 1,
+                ClubName = "数据库社",
+                CreatedAt = DateTime.UtcNow
+            });
+            db.Activities.Add(new Activity
+            {
+                ActivityId = 119,
+                ClubId = 1,
+                Title = "异常状态活动",
+                ActivityStatus = status,
+                CreatedAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync("/api/activities/119");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(
+            ApiErrorCodes.ServiceUnavailable,
+            document.RootElement.GetProperty("code").GetString());
+        Assert.Equal(
+            "活动状态数据异常，请稍后重试。",
+            document.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
     public void HandwrittenActivityDtoIsRemoved()
     {
         Assert.Null(typeof(ActivitiesController).Assembly.GetType(
             "ClubHub.Api.Controllers.ActivityDto"));
+    }
+
+    private static WebApplicationFactory<Program> WithNullActivityLogger(
+        ClubHubWebApplicationFactory factory)
+    {
+        return factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.AddSingleton<ILogger<ActivitiesController>>(
+                    NullLogger<ActivitiesController>.Instance)));
     }
 }

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -64,7 +64,8 @@ public class ActivitiesController : ControllerBase
 
         var query = _db.Activities
             .AsNoTracking()
-            .Where(a => a.ActivityStatus != null && ApiActivityStatuses.Contains(a.ActivityStatus))
+            .Where(a => ApiActivityStatuses.Contains(
+                (a.ActivityStatus ?? string.Empty).Trim().ToLower()))
             .OrderBy(a => a.ActivityId)
             .Select(a => new
             {

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -246,7 +246,7 @@ public class ActivitiesController : ControllerBase
                 return Error(StatusCodes.Status404NotFound, "ACTIVITY_NOT_FOUND", "活动不存在");
             }
 
-            if (!string.Equals(activity.ActivityStatus, ActivityStatusPublished, StringComparison.OrdinalIgnoreCase))
+            if (!IsPublishedActivityStatus(activity.ActivityStatus))
             {
                 return Error(StatusCodes.Status400BadRequest, "ACTIVITY_NOT_PUBLISHED", "活动未发布，暂不能报名");
             }
@@ -353,7 +353,8 @@ public class ActivitiesController : ControllerBase
             return BadRequest(new { message = "必须提供审核结果 approved。" });
         }
 
-        if (activity.ActivityStatus is "published" or "ongoing" or "finished" or "cancelled")
+        if (NormalizeActivityStatus(activity.ActivityStatus)
+            is "published" or "ongoing" or "finished" or "cancelled")
         {
             return BadRequest(new { message = "已发布或已结束的活动不能重复审核。" });
         }
@@ -441,7 +442,7 @@ public class ActivitiesController : ControllerBase
             return permissionError;
         }
 
-        if (activity.ActivityStatus is not "published" and not "ongoing")
+        if (!IsCheckinEnabledActivityStatus(activity.ActivityStatus))
         {
             return BadRequest(new { message = "只有已发布或进行中的活动才能设置签到签退规则。" });
         }
@@ -599,7 +600,7 @@ public class ActivitiesController : ControllerBase
             return BadRequest(new { message = isCheckin ? "签到码不能为空。" : "签退码不能为空。" });
         }
 
-        if (activity.ActivityStatus is not "published" and not "ongoing")
+        if (!IsCheckinEnabledActivityStatus(activity.ActivityStatus))
         {
             return BadRequest(new { message = "只有已发布或进行中的活动可以签到或签退。" });
         }
@@ -900,7 +901,7 @@ public class ActivitiesController : ControllerBase
         string? status,
         out ApiActivity.StatusEnum parsedStatus)
     {
-        switch (status?.Trim().ToLowerInvariant())
+        switch (NormalizeActivityStatus(status))
         {
             case "draft":
                 parsedStatus = ApiActivity.StatusEnum.DraftEnum;
@@ -928,6 +929,18 @@ public class ActivitiesController : ControllerBase
                 return false;
         }
     }
+
+    internal static string? NormalizeActivityStatus(string? status) =>
+        status?.Trim().ToLowerInvariant();
+
+    internal static bool IsPublishedActivityStatus(string? status) =>
+        string.Equals(
+            NormalizeActivityStatus(status),
+            ActivityStatusPublished,
+            StringComparison.Ordinal);
+
+    private static bool IsCheckinEnabledActivityStatus(string? status) =>
+        NormalizeActivityStatus(status) is "published" or "ongoing";
 
     private void LogInvalidActivityStatus(int activityId, string? status)
     {

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
+using ApiActivity = Org.OpenAPITools.Models.Activity;
 using ActivityRegistrationResult = Org.OpenAPITools.Models.ActivityRegistrationResult;
 using ApiError = Org.OpenAPITools.Models.ApiError;
 using ApplyActivityBudgetRequest = Org.OpenAPITools.Models.ApplyActivityBudgetRequest;
@@ -55,54 +56,38 @@ public class ActivitiesController : ControllerBase
         var viewerUserId = currentUserId.GetValueOrDefault();
 
         var query = _db.Activities
+            .AsNoTracking()
             .OrderBy(a => a.ActivityId)
-            .Select(a => new ActivityDto(
-                a.ActivityId,
-                a.Title,
-                a.ActivityType,
-                a.Description,
-                a.Club != null ? a.Club.ClubName : "",
-                a.ClubId,
-                a.CreatorUserId,
-                a.StartAt,
-                a.EndAt,
-                a.Location,
-                a.ActivityStatus,
-                a.Capacity,
-                a.RegistrationDeadline,
-                a.ReviewerUserId,
-                a.ReviewComment,
-                a.BudgetAmount,
-                a.BudgetPurpose,
-                a.BudgetDetail,
-                a.BudgetStatus,
-                a.BudgetReviewerId,
-                a.BudgetComment,
-                a.PublishedAt,
-                a.CheckinStartAt,
-                a.CheckinEndAt,
-                a.CheckoutStartAt,
-                a.CheckoutEndAt,
-                _db.ActivityParticipations.Count(p =>
+            .Select(a => new
+            {
+                Entity = a,
+                ClubName = a.Club != null ? a.Club.ClubName : "",
+                CurrentParticipants = _db.ActivityParticipations.Count(p =>
                     p.ActivityId == a.ActivityId &&
                     (p.RegisterStatus == RegisterStatusPending ||
                      p.RegisterStatus == RegisterStatusAccepted ||
                      p.RegisterStatus == RegisterStatusOnsite)),
-                shouldCheckRegistration &&
+                IsRegistered = shouldCheckRegistration &&
                 _db.ActivityParticipations.Any(p =>
                     p.ActivityId == a.ActivityId &&
                     p.UserId == viewerUserId &&
                     (p.RegisterStatus == RegisterStatusPending ||
                      p.RegisterStatus == RegisterStatusAccepted ||
                      p.RegisterStatus == RegisterStatusOnsite))
-            ));
+            });
         var page = await ApiPaginationQuery.MaterializeAsync(
             query,
             HttpContext,
             HttpContext.RequestAborted);
         if (page.Error is not null) return BadRequest(page.Error);
 
-        return Ok(page.Items);
+        return Ok(page.Items
+            .Select(item => ToApiModel(
+                item.Entity,
+                item.ClubName,
+                item.CurrentParticipants,
+                item.IsRegistered))
+            .ToArray());
     }
 
     [HttpPost]
@@ -170,7 +155,10 @@ public class ActivitiesController : ControllerBase
             activity.ActivityId,
             CancellationToken.None);
 
-        return CreatedAtAction(nameof(GetById), new { activityId = activity.ActivityId }, ToDto(activity, 0));
+        return CreatedAtAction(
+            nameof(GetById),
+            new { activityId = activity.ActivityId },
+            ToApiModel(activity, 0));
     }
 
     [HttpGet("{activityId:int}")]
@@ -200,7 +188,7 @@ public class ActivitiesController : ControllerBase
             })
             .FirstOrDefaultAsync();
 
-        return Ok(ToDto(
+        return Ok(ToApiModel(
             activity,
             registrationStats?.CurrentParticipants ?? 0,
             registrationStats?.IsRegistered ?? false));
@@ -359,7 +347,7 @@ public class ActivitiesController : ControllerBase
             activityId,
             CancellationToken.None);
         var currentParticipants = await CountActiveParticipants(activityId);
-        return Ok(ToDto(activity, currentParticipants));
+        return Ok(ToApiModel(activity, currentParticipants));
     }
 
     [HttpPut("{activityId:int}/budget")]
@@ -469,7 +457,7 @@ public class ActivitiesController : ControllerBase
             activityId,
             CancellationToken.None);
         var currentParticipants = await CountActiveParticipants(activityId);
-        return Ok(ToDto(activity, currentParticipants));
+        return Ok(ToApiModel(activity, currentParticipants));
     }
 
     [HttpGet("{activityId:int}/participations")]
@@ -748,74 +736,108 @@ public class ActivitiesController : ControllerBase
              p.RegisterStatus == RegisterStatusOnsite));
     }
 
-    private static ActivityDto ToDto(Activity activity, int currentParticipants, bool isRegistered = false)
+    internal static ApiActivity ToApiModel(
+        Activity activity,
+        int currentParticipants,
+        bool isRegistered = false)
     {
-        return new ActivityDto(
-            activity.ActivityId,
-            activity.Title,
-            activity.ActivityType,
-            activity.Description,
+        return ToApiModel(
+            activity,
             activity.Club?.ClubName ?? "",
-            activity.ClubId,
-            activity.CreatorUserId,
-            activity.StartAt,
-            activity.EndAt,
-            activity.Location,
-            activity.ActivityStatus,
-            activity.Capacity,
-            activity.RegistrationDeadline,
-            activity.ReviewerUserId,
-            activity.ReviewComment,
-            activity.BudgetAmount,
-            activity.BudgetPurpose,
-            activity.BudgetDetail,
-            activity.BudgetStatus,
-            activity.BudgetReviewerId,
-            activity.BudgetComment,
-            activity.PublishedAt,
-            activity.CheckinStartAt,
-            activity.CheckinEndAt,
-            activity.CheckoutStartAt,
-            activity.CheckoutEndAt,
             currentParticipants,
-            isRegistered
-        );
+            isRegistered);
     }
 
-    private static ActivityDto ToDto(
+    private static ApiActivity ToApiModel(
+        Activity activity,
+        string clubName,
+        int currentParticipants,
+        bool isRegistered)
+    {
+        return new ApiActivity
+        {
+            Id = activity.ActivityId,
+            Title = activity.Title,
+            ActivityType = activity.ActivityType,
+            Description = activity.Description,
+            ClubName = clubName,
+            ClubId = activity.ClubId,
+            CreatorUserId = activity.CreatorUserId,
+            StartTime = activity.StartAt,
+            EndTime = activity.EndAt,
+            Location = activity.Location,
+            Status = ParseActivityStatus(activity.ActivityStatus),
+            MaxParticipants = activity.Capacity,
+            RegistrationDeadline = activity.RegistrationDeadline,
+            ReviewerUserId = activity.ReviewerUserId,
+            ReviewComment = activity.ReviewComment,
+            BudgetAmount = activity.BudgetAmount is { } amount ? decimal.ToDouble(amount) : null,
+            BudgetPurpose = activity.BudgetPurpose,
+            BudgetDetail = activity.BudgetDetail,
+            BudgetStatus = activity.BudgetStatus,
+            BudgetReviewerId = activity.BudgetReviewerId,
+            BudgetComment = activity.BudgetComment,
+            PublishedAt = activity.PublishedAt,
+            CheckinStartAt = activity.CheckinStartAt,
+            CheckinEndAt = activity.CheckinEndAt,
+            CheckoutStartAt = activity.CheckoutStartAt,
+            CheckoutEndAt = activity.CheckoutEndAt,
+            CurrentParticipants = currentParticipants,
+            IsRegistered = isRegistered
+        };
+    }
+
+    internal static ApiActivity ToApiModel(
         ActivityPublicCacheEntry activity,
         int currentParticipants,
         bool isRegistered)
     {
-        return new ActivityDto(
-            activity.Id,
-            activity.Title,
-            activity.ActivityType,
-            activity.Description,
-            activity.ClubName,
-            activity.ClubId,
-            activity.CreatorUserId,
-            activity.StartTime,
-            activity.EndTime,
-            activity.Location,
-            activity.Status,
-            activity.MaxParticipants,
-            activity.RegistrationDeadline,
-            activity.ReviewerUserId,
-            activity.ReviewComment,
-            activity.BudgetAmount,
-            activity.BudgetPurpose,
-            activity.BudgetDetail,
-            activity.BudgetStatus,
-            activity.BudgetReviewerId,
-            activity.BudgetComment,
-            activity.PublishedAt,
-            activity.CheckinStartAt,
-            activity.CheckinEndAt,
-            activity.CheckoutStartAt,
-            activity.CheckoutEndAt,
-            currentParticipants,
-            isRegistered);
+        return new ApiActivity
+        {
+            Id = activity.Id,
+            Title = activity.Title,
+            ActivityType = activity.ActivityType,
+            Description = activity.Description,
+            ClubName = activity.ClubName,
+            ClubId = activity.ClubId,
+            CreatorUserId = activity.CreatorUserId,
+            StartTime = activity.StartTime,
+            EndTime = activity.EndTime,
+            Location = activity.Location,
+            Status = ParseActivityStatus(activity.Status),
+            MaxParticipants = activity.MaxParticipants,
+            RegistrationDeadline = activity.RegistrationDeadline,
+            ReviewerUserId = activity.ReviewerUserId,
+            ReviewComment = activity.ReviewComment,
+            BudgetAmount = activity.BudgetAmount is { } amount ? decimal.ToDouble(amount) : null,
+            BudgetPurpose = activity.BudgetPurpose,
+            BudgetDetail = activity.BudgetDetail,
+            BudgetStatus = activity.BudgetStatus,
+            BudgetReviewerId = activity.BudgetReviewerId,
+            BudgetComment = activity.BudgetComment,
+            PublishedAt = activity.PublishedAt,
+            CheckinStartAt = activity.CheckinStartAt,
+            CheckinEndAt = activity.CheckinEndAt,
+            CheckoutStartAt = activity.CheckoutStartAt,
+            CheckoutEndAt = activity.CheckoutEndAt,
+            CurrentParticipants = currentParticipants,
+            IsRegistered = isRegistered
+        };
+    }
+
+    internal static ApiActivity.StatusEnum ParseActivityStatus(string? status)
+    {
+        return status?.Trim().ToLowerInvariant() switch
+        {
+            "draft" => ApiActivity.StatusEnum.DraftEnum,
+            "pending_review" => ApiActivity.StatusEnum.PendingReviewEnum,
+            "published" => ApiActivity.StatusEnum.PublishedEnum,
+            "rejected" => ApiActivity.StatusEnum.RejectedEnum,
+            "ongoing" => ApiActivity.StatusEnum.OngoingEnum,
+            "finished" => ApiActivity.StatusEnum.FinishedEnum,
+            "cancelled" => ApiActivity.StatusEnum.CancelledEnum,
+            _ => throw new InvalidOperationException($"未知活动状态：{status ?? "<null>"}")
+        };
     }
 
     private static ObjectResult Error(int statusCode, string code, string message)
@@ -830,37 +852,6 @@ public class ActivitiesController : ControllerBase
         };
     }
 }
-
-public record ActivityDto(
-    int Id,
-    string Title,
-    string? ActivityType,
-    string? Description,
-    string ClubName,
-    int ClubId,
-    int? CreatorUserId,
-    DateTime? StartTime,
-    DateTime? EndTime,
-    string? Location,
-    string? Status,
-    int? MaxParticipants,
-    DateTime? RegistrationDeadline,
-    int? ReviewerUserId,
-    string? ReviewComment,
-    decimal? BudgetAmount,
-    string? BudgetPurpose,
-    string? BudgetDetail,
-    string? BudgetStatus,
-    int? BudgetReviewerId,
-    string? BudgetComment,
-    DateTime? PublishedAt,
-    DateTime? CheckinStartAt,
-    DateTime? CheckinEndAt,
-    DateTime? CheckoutStartAt,
-    DateTime? CheckoutEndAt,
-    int CurrentParticipants,
-    bool IsRegistered
-);
 
 public class CreateActivityRequest
 {

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -32,6 +32,10 @@ public class ActivitiesController : ControllerBase
     private const string ActivityReviewPermission = "activity:review";
     private const string ActivityCheckinManagePermission = "activity:checkin:manage";
     private const string ActivityCheckinPermission = "activity:checkin";
+    private static readonly string[] ApiActivityStatuses =
+    [
+        "draft", "pending_review", "published", "rejected", "ongoing", "finished", "cancelled"
+    ];
     private readonly ClubHubDbContext _db;
     private readonly AuthService _authService;
     private readonly PublicQueryCacheService _publicQueryCache;
@@ -60,6 +64,7 @@ public class ActivitiesController : ControllerBase
 
         var query = _db.Activities
             .AsNoTracking()
+            .Where(a => a.ActivityStatus != null && ApiActivityStatuses.Contains(a.ActivityStatus))
             .OrderBy(a => a.ActivityId)
             .Select(a => new
             {

--- a/backend/Controllers/ActivitiesController.cs
+++ b/backend/Controllers/ActivitiesController.cs
@@ -36,17 +36,20 @@ public class ActivitiesController : ControllerBase
     private readonly AuthService _authService;
     private readonly PublicQueryCacheService _publicQueryCache;
     private readonly IDistributedRateLimiter _rateLimiter;
+    private readonly ILogger<ActivitiesController> _logger;
 
     public ActivitiesController(
         ClubHubDbContext db,
         AuthService authService,
         PublicQueryCacheService publicQueryCache,
-        IDistributedRateLimiter rateLimiter)
+        IDistributedRateLimiter rateLimiter,
+        ILogger<ActivitiesController> logger)
     {
         _db = db;
         _authService = authService;
         _publicQueryCache = publicQueryCache;
         _rateLimiter = rateLimiter;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -81,13 +84,24 @@ public class ActivitiesController : ControllerBase
             HttpContext.RequestAborted);
         if (page.Error is not null) return BadRequest(page.Error);
 
-        return Ok(page.Items
-            .Select(item => ToApiModel(
-                item.Entity,
-                item.ClubName,
-                item.CurrentParticipants,
-                item.IsRegistered))
-            .ToArray());
+        var response = new List<ApiActivity>(page.Items.Count);
+        foreach (var item in page.Items)
+        {
+            if (!TryToApiModel(
+                    item.Entity,
+                    item.ClubName,
+                    item.CurrentParticipants,
+                    item.IsRegistered,
+                    out var apiActivity))
+            {
+                LogInvalidActivityStatus(item.Entity.ActivityId, item.Entity.ActivityStatus);
+                continue;
+            }
+
+            response.Add(apiActivity);
+        }
+
+        return Ok(response);
     }
 
     [HttpPost]
@@ -155,10 +169,15 @@ public class ActivitiesController : ControllerBase
             activity.ActivityId,
             CancellationToken.None);
 
+        if (!TryToApiModel(activity, 0, false, out var response))
+        {
+            return InvalidActivityStatus(activity.ActivityId, activity.ActivityStatus);
+        }
+
         return CreatedAtAction(
             nameof(GetById),
             new { activityId = activity.ActivityId },
-            ToApiModel(activity, 0));
+            response);
     }
 
     [HttpGet("{activityId:int}")]
@@ -188,10 +207,16 @@ public class ActivitiesController : ControllerBase
             })
             .FirstOrDefaultAsync();
 
-        return Ok(ToApiModel(
-            activity,
-            registrationStats?.CurrentParticipants ?? 0,
-            registrationStats?.IsRegistered ?? false));
+        if (!TryToApiModel(
+                activity,
+                registrationStats?.CurrentParticipants ?? 0,
+                registrationStats?.IsRegistered ?? false,
+                out var response))
+        {
+            return InvalidActivityStatus(activity.Id, activity.Status);
+        }
+
+        return Ok(response);
     }
 
     [HttpPost("{activityId:int}/registrations")]
@@ -347,7 +372,12 @@ public class ActivitiesController : ControllerBase
             activityId,
             CancellationToken.None);
         var currentParticipants = await CountActiveParticipants(activityId);
-        return Ok(ToApiModel(activity, currentParticipants));
+        if (!TryToApiModel(activity, currentParticipants, false, out var response))
+        {
+            return InvalidActivityStatus(activity.ActivityId, activity.ActivityStatus);
+        }
+
+        return Ok(response);
     }
 
     [HttpPut("{activityId:int}/budget")]
@@ -457,7 +487,12 @@ public class ActivitiesController : ControllerBase
             activityId,
             CancellationToken.None);
         var currentParticipants = await CountActiveParticipants(activityId);
-        return Ok(ToApiModel(activity, currentParticipants));
+        if (!TryToApiModel(activity, currentParticipants, false, out var response))
+        {
+            return InvalidActivityStatus(activity.ActivityId, activity.ActivityStatus);
+        }
+
+        return Ok(response);
     }
 
     [HttpGet("{activityId:int}/participations")]
@@ -736,21 +771,46 @@ public class ActivitiesController : ControllerBase
              p.RegisterStatus == RegisterStatusOnsite));
     }
 
-    internal static ApiActivity ToApiModel(
+    internal static bool TryToApiModel(
         Activity activity,
         int currentParticipants,
-        bool isRegistered = false)
+        bool isRegistered,
+        out ApiActivity apiActivity)
     {
-        return ToApiModel(
+        return TryToApiModel(
             activity,
             activity.Club?.ClubName ?? "",
             currentParticipants,
-            isRegistered);
+            isRegistered,
+            out apiActivity);
     }
 
-    private static ApiActivity ToApiModel(
+    private static bool TryToApiModel(
         Activity activity,
         string clubName,
+        int currentParticipants,
+        bool isRegistered,
+        out ApiActivity apiActivity)
+    {
+        if (!TryParseActivityStatus(activity.ActivityStatus, out var status))
+        {
+            apiActivity = null!;
+            return false;
+        }
+
+        apiActivity = BuildApiActivity(
+            activity,
+            clubName,
+            status,
+            currentParticipants,
+            isRegistered);
+        return true;
+    }
+
+    private static ApiActivity BuildApiActivity(
+        Activity activity,
+        string clubName,
+        ApiActivity.StatusEnum status,
         int currentParticipants,
         bool isRegistered)
     {
@@ -766,7 +826,7 @@ public class ActivitiesController : ControllerBase
             StartTime = activity.StartAt,
             EndTime = activity.EndAt,
             Location = activity.Location,
-            Status = ParseActivityStatus(activity.ActivityStatus),
+            Status = status,
             MaxParticipants = activity.Capacity,
             RegistrationDeadline = activity.RegistrationDeadline,
             ReviewerUserId = activity.ReviewerUserId,
@@ -787,29 +847,29 @@ public class ActivitiesController : ControllerBase
         };
     }
 
-    internal static ApiActivity ToApiModel(
+    internal static bool TryToApiModel(
         ActivityPublicCacheEntry activity,
         int currentParticipants,
-        bool isRegistered)
+        bool isRegistered,
+        out ApiActivity apiActivity)
     {
-        return new ApiActivity
+        var entity = new Activity
         {
-            Id = activity.Id,
+            ActivityId = activity.Id,
             Title = activity.Title,
             ActivityType = activity.ActivityType,
             Description = activity.Description,
-            ClubName = activity.ClubName,
             ClubId = activity.ClubId,
             CreatorUserId = activity.CreatorUserId,
-            StartTime = activity.StartTime,
-            EndTime = activity.EndTime,
+            StartAt = activity.StartTime,
+            EndAt = activity.EndTime,
             Location = activity.Location,
-            Status = ParseActivityStatus(activity.Status),
-            MaxParticipants = activity.MaxParticipants,
+            ActivityStatus = activity.Status,
+            Capacity = activity.MaxParticipants,
             RegistrationDeadline = activity.RegistrationDeadline,
             ReviewerUserId = activity.ReviewerUserId,
             ReviewComment = activity.ReviewComment,
-            BudgetAmount = activity.BudgetAmount is { } amount ? decimal.ToDouble(amount) : null,
+            BudgetAmount = activity.BudgetAmount,
             BudgetPurpose = activity.BudgetPurpose,
             BudgetDetail = activity.BudgetDetail,
             BudgetStatus = activity.BudgetStatus,
@@ -819,25 +879,65 @@ public class ActivitiesController : ControllerBase
             CheckinStartAt = activity.CheckinStartAt,
             CheckinEndAt = activity.CheckinEndAt,
             CheckoutStartAt = activity.CheckoutStartAt,
-            CheckoutEndAt = activity.CheckoutEndAt,
-            CurrentParticipants = currentParticipants,
-            IsRegistered = isRegistered
+            CheckoutEndAt = activity.CheckoutEndAt
         };
+
+        return TryToApiModel(
+            entity,
+            activity.ClubName,
+            currentParticipants,
+            isRegistered,
+            out apiActivity);
     }
 
-    internal static ApiActivity.StatusEnum ParseActivityStatus(string? status)
+    internal static bool TryParseActivityStatus(
+        string? status,
+        out ApiActivity.StatusEnum parsedStatus)
     {
-        return status?.Trim().ToLowerInvariant() switch
+        switch (status?.Trim().ToLowerInvariant())
         {
-            "draft" => ApiActivity.StatusEnum.DraftEnum,
-            "pending_review" => ApiActivity.StatusEnum.PendingReviewEnum,
-            "published" => ApiActivity.StatusEnum.PublishedEnum,
-            "rejected" => ApiActivity.StatusEnum.RejectedEnum,
-            "ongoing" => ApiActivity.StatusEnum.OngoingEnum,
-            "finished" => ApiActivity.StatusEnum.FinishedEnum,
-            "cancelled" => ApiActivity.StatusEnum.CancelledEnum,
-            _ => throw new InvalidOperationException($"未知活动状态：{status ?? "<null>"}")
-        };
+            case "draft":
+                parsedStatus = ApiActivity.StatusEnum.DraftEnum;
+                return true;
+            case "pending_review":
+                parsedStatus = ApiActivity.StatusEnum.PendingReviewEnum;
+                return true;
+            case "published":
+                parsedStatus = ApiActivity.StatusEnum.PublishedEnum;
+                return true;
+            case "rejected":
+                parsedStatus = ApiActivity.StatusEnum.RejectedEnum;
+                return true;
+            case "ongoing":
+                parsedStatus = ApiActivity.StatusEnum.OngoingEnum;
+                return true;
+            case "finished":
+                parsedStatus = ApiActivity.StatusEnum.FinishedEnum;
+                return true;
+            case "cancelled":
+                parsedStatus = ApiActivity.StatusEnum.CancelledEnum;
+                return true;
+            default:
+                parsedStatus = default;
+                return false;
+        }
+    }
+
+    private void LogInvalidActivityStatus(int activityId, string? status)
+    {
+        _logger.LogError(
+            "活动 {ActivityId} 包含未知状态 {Status}",
+            activityId,
+            status);
+    }
+
+    private IActionResult InvalidActivityStatus(int activityId, string? status)
+    {
+        LogInvalidActivityStatus(activityId, status);
+        return Error(
+            StatusCodes.Status503ServiceUnavailable,
+            ApiErrorCodes.ServiceUnavailable,
+            "活动状态数据异常，请稍后重试。");
     }
 
     private static ObjectResult Error(int statusCode, string code, string message)


### PR DESCRIPTION
## 改动内容

- 移除 `ActivitiesController` 中手写的 `ActivityDto`，统一返回 OpenAPI 生成的 `Org.OpenAPITools.Models.Activity`。
- 活动列表在数据库分页完成后映射生成模型；详情、创建、审核和签到设置复用统一的 `BuildApiActivity` 映射入口，缓存条目先转换为实体形状，避免两条响应路径发生契约漂移。
- 使用 `TryParseActivityStatus` 集中处理数据库状态字符串到 OpenAPI 枚举的转换，保留前后空白与大小写归一化；活动列表在数据库分页与计数前按 `Trim/ToLower` 归一化语义过滤空值和未知状态，并保留带活动标识及原始状态的日志兜底，详情返回受控的 503 错误；报名、审核、签到设置与签到门禁复用同一归一化函数。
- 集中处理预算金额 `decimal?` 到契约 `double?` 的转换。
- 保持报名接口既有的生成类型 `ActivityRegistrationResult` 不变；旧活动预算入口继续返回标准化 409 错误。
- 新增活动响应模型、全部状态枚举、状态规范化边界、分页响应头、异常状态列表/详情场景、JSON 线格式和手写 DTO 移除的回归测试。

## 改动原因

手写 `ActivityDto` 与 OpenAPI `Activity` schema 重复维护，字段、类型和枚举容易在后续演进中分叉。本次统一复用生成模型和公共映射入口，使编译和测试能够及时暴露契约差异；同时按评审建议将异常活动状态改为可控处理，并在查询层保障分页计数一致，避免脏数据导致列表或详情接口返回未处理的 500，并保持前端 JSON 字段与正常调用行为不变。

---

## 关联 Issue

Closes #119

## 审查关注点

- 数据库活动状态到生成枚举的归一化及异常状态受控处理是否符合现有数据约束。
- 列表在分页前按映射层相同语义归一化并过滤异常状态、分页后映射生成模型的方式是否符合 Oracle 查询与分页预期。
- 实体和缓存条目是否完整复用统一映射入口。
- 预算金额从 Oracle `decimal` 转为 OpenAPI `double` 的契约兼容性。
- 旧预算申请、审批入口已停用，本 PR 不恢复其业务行为。

## UI 改动

不涉及 UI 改动，前端 JSON 字段名、枚举值和正常调用行为保持不变，因此无截图。

## 测试说明

- `.NET 10 Release` 后端构建：通过，0 错误；生成模型既有可空性警告未变。
- `ActivityResponseModelTests`：23/23 通过。
- 本次两个 C# 文件 `dotnet format --verify-no-changes`：通过。
- 前端测试：62 通过、1 跳过（本次未改前端）。
- 前端生产构建：通过（本次未改前端）。
- Windows 本地完整后端测试：208/215 通过；其余 7 项为仓库既有的 Nginx/OpenAPI 文件断言和 Windows Event Log 写权限问题，未涉及本次 Activity 代码，等待 Linux CI 复核。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过（`dotnet build`）
- [x] 前端代码已构建通过（`pnpm build`）
- [x] 已通过活动响应 API 集成测试验证 JSON 线格式、分页响应头和异常状态处理

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`（不适用）
- [ ] 种子数据、视图、索引、触发器、存储过程已同步（不适用）

**文档与部署（仅涉及时勾选）**
- [x] 不涉及课程文档、GitHub Secrets、服务器配置或手动迁移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改进

- 统一活动相关接口的返回格式，提升创建、查询、审核及签到设置等场景的数据一致性。
- 优化活动列表处理，自动规范化活动状态，并确保分页总数统计准确。
- 无法识别状态的活动将被安全跳过或提示服务异常，避免展示错误信息。
- 增强对带有空格及大小写差异的活动状态识别。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
