### PR TITLE
fix(test): 修复 contract 和 nginx 配置测试正则匹配

### DIFF
--- a/backend.Tests/NginxUploadLimitTests.cs
+++ b/backend.Tests/NginxUploadLimitTests.cs
@@ -12,7 +12,7 @@ public sealed class NginxUploadLimitTests
 
         var apiLocation = Regex.Match(
             configuration,
-            @"(?mi)^[ \t]*location[ \t]+/api/[ \t]*\{(?<body>[^}]*)^[ \t]*\}");
+            @"(?mi)^[ \t]*location[ \t]+/api/[ \t]*\{(?<body>[\s\S]*)^[ \t]*\}");
         Assert.True(apiLocation.Success, "Cannot locate the /api/ location.");
         Assert.Matches(
             new Regex(

--- a/backend.Tests/NginxUploadLimitTests.cs
+++ b/backend.Tests/NginxUploadLimitTests.cs
@@ -12,11 +12,13 @@ public sealed class NginxUploadLimitTests
 
         var apiLocation = Regex.Match(
             configuration,
-            @"(?mi)^[ \t]*location[ \t]+/api/[ \t]*\{(?<body>[\s\S]*)^[ \t]*\}");
+            @"(?mi)location\s+/api/\s*\{(?<body>.*?)\n\s*\}",
+            RegexOptions.Singleline);
         Assert.True(apiLocation.Success, "Cannot locate the /api/ location.");
         Assert.Matches(
             new Regex(
-                @"(?mi)^[ \t]*client_max_body_size[ \t]+51m[ \t]*;[ \t]*(?:#.*)?$"),
+                @"(?mi)^\s*client_max_body_size\s+51m\s*;",
+                RegexOptions.Multiline),
             apiLocation.Groups["body"].Value);
     }
 

--- a/backend.Tests/OpenApiRestContractTests.cs
+++ b/backend.Tests/OpenApiRestContractTests.cs
@@ -32,7 +32,7 @@ public class OpenApiRestContractTests
     public void EveryDocumentedApiPathUsesV1Prefix()
     {
         var document = ReadDocument();
-        var paths = Regex.Matches(document, @"(?m)^  (?<path>/api/[^:]+):$")
+        var paths = Regex.Matches(document, @"(?m)^  (?<path>/api/[^:]+):\s*$")
             .Select(match => match.Groups["path"].Value)
             .ToArray();
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## 改动内容

修复两个后端测试中的正则表达式问题：

1. **OpenApiRestContractTests**：已修复 ✅
   - 改进正则以处理 CRLF 换行符
   - 将  改为  以处理行尾空白

2. **NginxUploadLimitTests**：已修复 ✅  
   - 改进第一个正则，使用非贪心匹配  和 Singleline 模式
   - 改进第二个正则，添加显式 RegexOptions.Multiline
   - 使用 \s 替代 [ \t] 以提高灵活性

## 改动原因

由于我们的项目是跨平台合作的，部分同学设备上的 openapi.yaml 和 nginx.conf 使用 CRLF 换行符（Windows 风格），导致原有的正则表达式无法正确匹配多行内容和行边界。

---

## 关联 Issue

Closes #190
Closes #191

## 测试说明

两个测试均已通过本地验证。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过
- [x] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化

**文档与部署（仅涉及时勾选）**
- [x] 无需文档或配置变更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试改进**
  * 增强上传请求限制测试对 Nginx 配置格式的兼容性。
  * 改进 OpenAPI 路径验证，支持冒号后的尾随空白。
  * 不影响面向终端用户的功能或界面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->