### PR TITLE
fix(dashboard): 优化多身份工作台布局

### DIFF
--- a/frontend/src/views/DashboardHome.vue
+++ b/frontend/src/views/DashboardHome.vue
@@ -14,11 +14,9 @@ const notices = ref<number | null>(null);
 const recruitments = ref<number | null>(null);
 let dashboardRequestId = 0;
 
-const roleSummary = computed(() => {
+const roleSummaries = computed(() => {
   const roles = auth.value?.roles ?? [];
-  return roles.length
-    ? roles.map((role) => role.displayName || role.name).join(" · ")
-    : "暂无业务角色";
+  return roles.length ? roles.map((role) => role.displayName || role.name) : ["暂无业务角色"];
 });
 
 const attentionItems = computed(() => {
@@ -95,14 +93,19 @@ onUnmounted(() => stopSessionListener?.());
       <div class="identity-primary">
         <span class="identity-kicker">CURRENT IDENTITY</span>
         <h3>{{ auth?.user.realName || "当前用户" }}</h3>
-        <p>{{ roleSummary }}</p>
+        <ul class="identity-summary" aria-label="当前身份列表">
+          <li v-for="role in roleSummaries" :key="role">{{ role }}</li>
+        </ul>
       </div>
       <div class="identity-details" aria-label="账号基本信息">
         <div>
           <span>学号</span><strong>{{ auth?.user.studentNo || "未填写" }}</strong>
         </div>
         <div>
-          <span>身份</span><strong>{{ roleSummary }}</strong>
+          <span>身份</span>
+          <ul class="identity-list">
+            <li v-for="role in roleSummaries" :key="role">{{ role }}</li>
+          </ul>
         </div>
         <div>
           <span>学院</span><strong>{{ auth?.user.college || "未填写" }}</strong>
@@ -178,7 +181,7 @@ onUnmounted(() => stopSessionListener?.());
 }
 .identity-card {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr);
   gap: var(--club-space-6);
   align-items: center;
   padding: clamp(24px, 3vw, 38px);
@@ -193,13 +196,36 @@ onUnmounted(() => stopSessionListener?.());
   );
   box-shadow: var(--club-shadow-sm);
 }
+.identity-primary,
+.identity-details {
+  min-width: 0;
+}
 .identity-card h3 {
   margin: 7px 0;
   font-size: clamp(24px, 3vw, 38px);
 }
-.identity-card p {
+.identity-summary,
+.identity-list {
+  display: grid;
+  gap: 5px;
   margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.identity-summary {
   color: var(--club-text-secondary);
+}
+.identity-summary li {
+  width: fit-content;
+  max-width: 100%;
+  padding: 3px 9px;
+  border: 1px solid color-mix(in srgb, var(--club-primary) 16%, var(--club-border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--club-bg-elevated) 78%, transparent);
+  overflow-wrap: anywhere;
+}
+.identity-list li {
+  overflow-wrap: anywhere;
 }
 .identity-kicker {
   color: var(--club-primary-strong);
@@ -210,7 +236,7 @@ onUnmounted(() => stopSessionListener?.());
 .identity-details {
   display: grid;
   grid-template-columns: repeat(2, minmax(150px, 1fr));
-  min-width: min(520px, 52%);
+  width: 100%;
   border: 1px solid var(--club-border);
   border-radius: var(--club-radius-md);
   background: var(--club-surface);
@@ -318,7 +344,7 @@ onUnmounted(() => stopSessionListener?.());
     grid-template-columns: repeat(2, 1fr);
   }
   .identity-details {
-    min-width: min(480px, 58%);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 @media (max-width: 640px) {

--- a/frontend/src/workspaceReadiness.test.ts
+++ b/frontend/src/workspaceReadiness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import appShellSource from "./components/shell/AppShell.vue?raw";
 import routerSource from "./router/index.ts?raw";
+import dashboardSource from "./views/DashboardHome.vue?raw";
 
 const viewSources = import.meta.glob("./views/*.vue", {
   eager: true,
@@ -22,6 +23,15 @@ describe("运营工作台就绪约束", () => {
     expect(routerSource).toContain('path: "/dashboard"');
     expect(routerSource).toContain('redirect: "/dashboard"');
     expect(routerSource).toContain('title: "运营工作台"');
+  });
+
+  it("多身份工作台按独立身份行展示并保留单身份兼容布局", () => {
+    expect(dashboardSource).toContain('v-for="role in roleSummaries"');
+    expect(dashboardSource).toContain(".identity-card");
+    expect(dashboardSource).toContain(
+      "grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr)",
+    );
+    expect(dashboardSource).toContain("min-width: 0");
   });
 
   it("页面眉标由路由语义提供，不再硬编码通用 Workspace", () => {


### PR DESCRIPTION
## 改动内容

- 将运营工作台的多身份摘要改为逐行身份项，并在信息卡片中复用同一身份列表。
- 为身份卡片的两栏网格补充 `min-width: 0` 和可换行约束，保证姓名、身份名称和学院专业在常规桌面宽度下不会被压缩成竖排。
- 保留单身份用户的紧凑呈现，并补充工作台源码回归约束。

## 改动原因

线上 `2450001` 同时拥有学生、计算机协会成员、红楼梦文化社成员和负责人身份，原布局将左侧姓名压缩为竖排，身份摘要也挤压信息卡片。该修复只调整内容组织和网格约束，不改变权限和业务数据。

## 关联 Issue

Part of #193

## 本地验证

- `vitest run src/workspaceReadiness.test.ts`：22 项通过。
- `vue-tsc -b`：通过。
- `vite build`：通过。
- Prettier 与 `git diff --check`：通过。

## 线上验证计划

部署后使用多身份学生账号和普通单身份账号分别在桌面与窄屏宽度检查工作台，并保存回归截图。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 身份信息现支持展示多个角色，并以独立列表项呈现。
  * 新增角色胶囊样式，提升身份信息的可读性。
  * 优化身份卡片与工作台布局，兼容单身份和多身份场景。

* **测试**
  * 增加多身份展示及单身份布局兼容性的自动化验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->