### PR TITLE
chore(release): 发布多身份工作台布局修复

### DIFF
--- a/frontend/src/views/DashboardHome.vue
+++ b/frontend/src/views/DashboardHome.vue
@@ -14,11 +14,9 @@ const notices = ref<number | null>(null);
 const recruitments = ref<number | null>(null);
 let dashboardRequestId = 0;
 
-const roleSummary = computed(() => {
+const roleSummaries = computed(() => {
   const roles = auth.value?.roles ?? [];
-  return roles.length
-    ? roles.map((role) => role.displayName || role.name).join(" · ")
-    : "暂无业务角色";
+  return roles.length ? roles.map((role) => role.displayName || role.name) : ["暂无业务角色"];
 });
 
 const attentionItems = computed(() => {
@@ -95,14 +93,19 @@ onUnmounted(() => stopSessionListener?.());
       <div class="identity-primary">
         <span class="identity-kicker">CURRENT IDENTITY</span>
         <h3>{{ auth?.user.realName || "当前用户" }}</h3>
-        <p>{{ roleSummary }}</p>
+        <ul class="identity-summary" aria-label="当前身份列表">
+          <li v-for="role in roleSummaries" :key="role">{{ role }}</li>
+        </ul>
       </div>
       <div class="identity-details" aria-label="账号基本信息">
         <div>
           <span>学号</span><strong>{{ auth?.user.studentNo || "未填写" }}</strong>
         </div>
         <div>
-          <span>身份</span><strong>{{ roleSummary }}</strong>
+          <span>身份</span>
+          <ul class="identity-list">
+            <li v-for="role in roleSummaries" :key="role">{{ role }}</li>
+          </ul>
         </div>
         <div>
           <span>学院</span><strong>{{ auth?.user.college || "未填写" }}</strong>
@@ -178,7 +181,7 @@ onUnmounted(() => stopSessionListener?.());
 }
 .identity-card {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr);
   gap: var(--club-space-6);
   align-items: center;
   padding: clamp(24px, 3vw, 38px);
@@ -193,13 +196,36 @@ onUnmounted(() => stopSessionListener?.());
   );
   box-shadow: var(--club-shadow-sm);
 }
+.identity-primary,
+.identity-details {
+  min-width: 0;
+}
 .identity-card h3 {
   margin: 7px 0;
   font-size: clamp(24px, 3vw, 38px);
 }
-.identity-card p {
+.identity-summary,
+.identity-list {
+  display: grid;
+  gap: 5px;
   margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.identity-summary {
   color: var(--club-text-secondary);
+}
+.identity-summary li {
+  width: fit-content;
+  max-width: 100%;
+  padding: 3px 9px;
+  border: 1px solid color-mix(in srgb, var(--club-primary) 16%, var(--club-border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--club-bg-elevated) 78%, transparent);
+  overflow-wrap: anywhere;
+}
+.identity-list li {
+  overflow-wrap: anywhere;
 }
 .identity-kicker {
   color: var(--club-primary-strong);
@@ -210,7 +236,7 @@ onUnmounted(() => stopSessionListener?.());
 .identity-details {
   display: grid;
   grid-template-columns: repeat(2, minmax(150px, 1fr));
-  min-width: min(520px, 52%);
+  width: 100%;
   border: 1px solid var(--club-border);
   border-radius: var(--club-radius-md);
   background: var(--club-surface);
@@ -318,7 +344,7 @@ onUnmounted(() => stopSessionListener?.());
     grid-template-columns: repeat(2, 1fr);
   }
   .identity-details {
-    min-width: min(480px, 58%);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 @media (max-width: 640px) {

--- a/frontend/src/workspaceReadiness.test.ts
+++ b/frontend/src/workspaceReadiness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import appShellSource from "./components/shell/AppShell.vue?raw";
 import routerSource from "./router/index.ts?raw";
+import dashboardSource from "./views/DashboardHome.vue?raw";
 
 const viewSources = import.meta.glob("./views/*.vue", {
   eager: true,
@@ -22,6 +23,15 @@ describe("运营工作台就绪约束", () => {
     expect(routerSource).toContain('path: "/dashboard"');
     expect(routerSource).toContain('redirect: "/dashboard"');
     expect(routerSource).toContain('title: "运营工作台"');
+  });
+
+  it("多身份工作台按独立身份行展示并保留单身份兼容布局", () => {
+    expect(dashboardSource).toContain('v-for="role in roleSummaries"');
+    expect(dashboardSource).toContain(".identity-card");
+    expect(dashboardSource).toContain(
+      "grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr)",
+    );
+    expect(dashboardSource).toContain("min-width: 0");
   });
 
   it("页面眉标由路由语义提供，不再硬编码通用 Workspace", () => {


### PR DESCRIPTION
## 发布内容

本次将 `dev` 中已经通过 CI 的终极答辩回归修复发布到 `main`：

- 兼容旧浏览器幂等键生成，恢复项目、学习、活动和经费写操作。
- 修复学习资源预览 Cookie 路径与 HTTP 预览会话。
- 修复 Oracle 经费审核行锁 SQL，补充预算并发回归断言。
- 增加活动待审核直接入口，统一答辩页面的 UTC+8 展示和输入。
- 兼容历史成员考核学期名称，保护考核编辑表单分数。
- 优化多身份工作台布局，将身份逐行呈现并保留单身份用户的紧凑展示。
- 升级 `Microsoft.OpenApi` 到 2.7.5，修复测试环境 EventLog 权限对故障注入测试的干扰。

## 验证

- 前端 Vitest：111 项通过，1 项按既有条件跳过。
- 后端测试：234 项通过，Oracle 隔离测试 4 项按仓库约定跳过。
- 前端类型检查、构建和后端 Release 构建通过。
- PR #199 已合并到 `dev`，本 PR 仅发布 `dev` 到 `main`。
- PR #201 已合并到 `dev`，本 PR 同步发布该布局修复。

## 数据说明

未修改数据库表结构。共享开发库中的答辩演示记录已按授权完成名称、时间窗口和历史考核学期维护；部署后需按清单进行线上回归。
