### PR TITLE
fix(dashboard): 统一身份信息区样式

### DIFF
--- a/frontend/src/views/DashboardHome.vue
+++ b/frontend/src/views/DashboardHome.vue
@@ -181,7 +181,7 @@ onUnmounted(() => stopSessionListener?.());
 }
 .identity-card {
   display: grid;
-  grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr);
+  grid-template-columns: minmax(250px, 1fr) minmax(0, 520px);
   gap: var(--club-space-6);
   align-items: center;
   padding: clamp(24px, 3vw, 38px);
@@ -208,6 +208,9 @@ onUnmounted(() => stopSessionListener?.());
 .identity-list {
   display: grid;
   gap: 5px;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.4;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -218,6 +221,8 @@ onUnmounted(() => stopSessionListener?.());
 .identity-summary li {
   width: fit-content;
   max-width: 100%;
+  font-family: inherit;
+  font-weight: 500;
   padding: 3px 9px;
   border: 1px solid color-mix(in srgb, var(--club-primary) 16%, var(--club-border));
   border-radius: 999px;
@@ -225,6 +230,9 @@ onUnmounted(() => stopSessionListener?.());
   overflow-wrap: anywhere;
 }
 .identity-list li {
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 600;
   overflow-wrap: anywhere;
 }
 .identity-kicker {
@@ -237,6 +245,8 @@ onUnmounted(() => stopSessionListener?.());
   display: grid;
   grid-template-columns: repeat(2, minmax(150px, 1fr));
   width: 100%;
+  max-width: 520px;
+  justify-self: end;
   border: 1px solid var(--club-border);
   border-radius: var(--club-radius-md);
   background: var(--club-surface);
@@ -340,11 +350,15 @@ onUnmounted(() => stopSessionListener?.());
   text-decoration: none;
 }
 @media (max-width: 1050px) {
+  .identity-card {
+    grid-template-columns: minmax(200px, 0.8fr) minmax(0, 1.2fr);
+  }
   .metric-grid {
     grid-template-columns: repeat(2, 1fr);
   }
   .identity-details {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    max-width: none;
   }
 }
 @media (max-width: 640px) {

--- a/frontend/src/workspaceReadiness.test.ts
+++ b/frontend/src/workspaceReadiness.test.ts
@@ -28,9 +28,9 @@ describe("运营工作台就绪约束", () => {
   it("多身份工作台按独立身份行展示并保留单身份兼容布局", () => {
     expect(dashboardSource).toContain('v-for="role in roleSummaries"');
     expect(dashboardSource).toContain(".identity-card");
-    expect(dashboardSource).toContain(
-      "grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr)",
-    );
+    expect(dashboardSource).toContain("grid-template-columns: minmax(250px, 1fr) minmax(0, 520px)");
+    expect(dashboardSource).toContain("font-family: inherit");
+    expect(dashboardSource).toContain("max-width: 520px");
     expect(dashboardSource).toContain("min-width: 0");
   });
 


### PR DESCRIPTION
## 改动内容

- 为工作台身份列表和身份详情显式继承全局字体、字号、字重与行高。
- 将 `identity-details` 的桌面最大宽度限制为 520px，并在中小屏幕恢复弹性宽度。
- 保留多身份逐行展示和单身份用户的紧凑布局，补充对应源码回归断言。

## 背景

线上平台管理员 `05002` 的工作台验证发现身份文字与其他区域的字体观感不一致，右侧身份详情在桌面宽度下占比过大。本 PR 只调整工作台视觉布局，不改变权限、接口和数据库。

## 关联 Issue

Part of #193

## 本地验证

- `vitest run src/workspaceReadiness.test.ts`：22 项通过。
- `vue-tsc -b`、`vite build`：通过。
- Prettier 与 `git diff --check`：通过。

## 线上验证计划

部署后使用平台管理员双身份、学生多身份和普通单身份页面检查字体、卡片宽度、姓名横向显示及响应式布局。
