### PR TITLE
chore(release): 发布身份信息区样式修复

### DIFF
--- a/frontend/src/views/DashboardHome.vue
+++ b/frontend/src/views/DashboardHome.vue
@@ -181,7 +181,7 @@ onUnmounted(() => stopSessionListener?.());
 }
 .identity-card {
   display: grid;
-  grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr);
+  grid-template-columns: minmax(250px, 1fr) minmax(0, 520px);
   gap: var(--club-space-6);
   align-items: center;
   padding: clamp(24px, 3vw, 38px);
@@ -208,6 +208,9 @@ onUnmounted(() => stopSessionListener?.());
 .identity-list {
   display: grid;
   gap: 5px;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.4;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -218,6 +221,8 @@ onUnmounted(() => stopSessionListener?.());
 .identity-summary li {
   width: fit-content;
   max-width: 100%;
+  font-family: inherit;
+  font-weight: 500;
   padding: 3px 9px;
   border: 1px solid color-mix(in srgb, var(--club-primary) 16%, var(--club-border));
   border-radius: 999px;
@@ -225,6 +230,9 @@ onUnmounted(() => stopSessionListener?.());
   overflow-wrap: anywhere;
 }
 .identity-list li {
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 600;
   overflow-wrap: anywhere;
 }
 .identity-kicker {
@@ -237,6 +245,8 @@ onUnmounted(() => stopSessionListener?.());
   display: grid;
   grid-template-columns: repeat(2, minmax(150px, 1fr));
   width: 100%;
+  max-width: 520px;
+  justify-self: end;
   border: 1px solid var(--club-border);
   border-radius: var(--club-radius-md);
   background: var(--club-surface);
@@ -340,11 +350,15 @@ onUnmounted(() => stopSessionListener?.());
   text-decoration: none;
 }
 @media (max-width: 1050px) {
+  .identity-card {
+    grid-template-columns: minmax(200px, 0.8fr) minmax(0, 1.2fr);
+  }
   .metric-grid {
     grid-template-columns: repeat(2, 1fr);
   }
   .identity-details {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    max-width: none;
   }
 }
 @media (max-width: 640px) {

--- a/frontend/src/workspaceReadiness.test.ts
+++ b/frontend/src/workspaceReadiness.test.ts
@@ -28,9 +28,9 @@ describe("运营工作台就绪约束", () => {
   it("多身份工作台按独立身份行展示并保留单身份兼容布局", () => {
     expect(dashboardSource).toContain('v-for="role in roleSummaries"');
     expect(dashboardSource).toContain(".identity-card");
-    expect(dashboardSource).toContain(
-      "grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr)",
-    );
+    expect(dashboardSource).toContain("grid-template-columns: minmax(250px, 1fr) minmax(0, 520px)");
+    expect(dashboardSource).toContain("font-family: inherit");
+    expect(dashboardSource).toContain("max-width: 520px");
     expect(dashboardSource).toContain("min-width: 0");
   });
 


### PR DESCRIPTION
## 发布内容

本次将 `dev` 中已经通过 CI 的终极答辩回归修复发布到 `main`：

- 兼容旧浏览器幂等键生成，恢复项目、学习、活动和经费写操作。
- 修复学习资源预览 Cookie 路径与 HTTP 预览会话。
- 修复 Oracle 经费审核行锁 SQL，补充预算并发回归断言。
- 增加活动待审核直接入口，统一答辩页面的 UTC+8 展示和输入。
- 兼容历史成员考核学期名称，保护考核编辑表单分数。
- 优化多身份工作台布局，将身份逐行呈现并保留单身份用户的紧凑展示。
- 统一身份信息区字体、字号和行高，并限制桌面宽度，避免信息卡片过宽。
- 升级 `Microsoft.OpenApi` 到 2.7.5，修复测试环境 EventLog 权限对故障注入测试的干扰。

## 验证

- 前端 Vitest：111 项通过，1 项按既有条件跳过。
- 后端测试：234 项通过，Oracle 隔离测试 4 项按仓库约定跳过。
- 前端类型检查、构建和后端 Release 构建通过。
- PR #199 已合并到 `dev`，本 PR 仅发布 `dev` 到 `main`。
- PR #201 已合并到 `dev`，本 PR 同步发布该布局修复。
- PR #203 已合并到 `dev`，本 PR 同步发布身份信息区细节样式修复。

## 数据说明

未修改数据库表结构。共享开发库中的答辩演示记录已按授权完成名称、时间窗口和历史考核学期维护；部署后需按清单进行线上回归。
