### PR TITLE
chore(release): 发布场地维护截止时间持久化修复

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10642,7 +10642,8 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义返回，空值表示未设置。
+          description: 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义、秒精度返回，空值表示未设置。
+          example: 2026-09-15T12:00:00Z
       required:
         - id
         - name
@@ -10723,7 +10724,8 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
+          description: status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义、秒精度持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
+          example: 2026-09-15T12:00:00Z
         cancelConflictingReservations:
           type: boolean
           nullable: true

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10642,7 +10642,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: 维护结束时间。为空表示维护结束时间未知。
+          description: 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义返回，空值表示未设置。
       required:
         - id
         - name
@@ -10723,7 +10723,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: status 为 maintenance 时可选填写的维护结束时间。
+          description: status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
         cancelConflictingReservations:
           type: boolean
           nullable: true

--- a/backend.Tests/PublicQueryCacheTests.cs
+++ b/backend.Tests/PublicQueryCacheTests.cs
@@ -114,6 +114,68 @@ public sealed class PublicQueryCacheTests
     }
 
     [Fact]
+    public async Task VenueCacheRebuildsPersistedMaintenanceDeadline()
+    {
+        var redis = new InMemoryRedisDatabase();
+        await using var factory = CreateFactory(redis);
+        await SeedAsync(factory.Services);
+        using var client = factory.CreateClient();
+
+        var firstDeadline = new DateTime(2026, 9, 15, 4, 0, 0, DateTimeKind.Utc);
+        var secondDeadline = firstDeadline.AddDays(2);
+
+        using var firstResponse = await client.GetAsync("/api/venues/21");
+        var first = await ReadJsonAsync(firstResponse);
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.Equal("maintenance", first.GetProperty("status").GetString());
+        Assert.Equal(firstDeadline, first.GetProperty("maintenanceUntil").GetDateTime());
+
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+            var venue = await db.Venues.FindAsync(21);
+            venue!.MaintenanceUntil = secondDeadline;
+            await db.SaveChangesAsync();
+        }
+
+        using var cachedResponse = await client.GetAsync("/api/venues/21");
+        var cached = await ReadJsonAsync(cachedResponse);
+        Assert.Equal(firstDeadline, cached.GetProperty("maintenanceUntil").GetDateTime());
+
+        redis.Unavailable = true;
+        using var fallbackResponse = await client.GetAsync("/api/venues/21");
+        var fallback = await ReadJsonAsync(fallbackResponse);
+        Assert.Equal(secondDeadline, fallback.GetProperty("maintenanceUntil").GetDateTime());
+        redis.Unavailable = false;
+
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var cache = scope.ServiceProvider.GetRequiredService<PublicQueryCacheService>();
+            await cache.InvalidateVenueAsync(21);
+        }
+
+        using var refreshedResponse = await client.GetAsync("/api/venues/21");
+        var refreshed = await ReadJsonAsync(refreshedResponse);
+        Assert.Equal(secondDeadline, refreshed.GetProperty("maintenanceUntil").GetDateTime());
+
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+            var venue = await db.Venues.FindAsync(21);
+            venue!.VenueStatus = "available";
+            venue.MaintenanceUntil = null;
+            await db.SaveChangesAsync();
+            var cache = scope.ServiceProvider.GetRequiredService<PublicQueryCacheService>();
+            await cache.InvalidateVenueAsync(21);
+        }
+
+        using var clearedResponse = await client.GetAsync("/api/venues/21");
+        var cleared = await ReadJsonAsync(clearedResponse);
+        Assert.Equal("available", cleared.GetProperty("status").GetString());
+        Assert.Equal(JsonValueKind.Null, cleared.GetProperty("maintenanceUntil").ValueKind);
+    }
+
+    [Fact]
     public async Task RedisOutageFallsBackAndRecoveryNaturallyRebuilds()
     {
         var redis = new InMemoryRedisDatabase { Unavailable = true };
@@ -202,6 +264,15 @@ public sealed class PublicQueryCacheTests
             VenueName = "Lecture hall",
             Capacity = 100,
             VenueStatus = "available",
+            CreatedAt = DateTime.UtcNow
+        });
+        db.Venues.Add(new Venue
+        {
+            VenueId = 21,
+            VenueName = "Maintenance hall",
+            Capacity = 80,
+            VenueStatus = "maintenance",
+            MaintenanceUntil = new DateTime(2026, 9, 15, 4, 0, 0, DateTimeKind.Utc),
             CreatedAt = DateTime.UtcNow
         });
         await db.SaveChangesAsync();

--- a/backend.Tests/VenuesAuthorizationTests.cs
+++ b/backend.Tests/VenuesAuthorizationTests.cs
@@ -33,7 +33,15 @@ public sealed class VenuesAuthorizationTests : IClassFixture<ClubHubWebApplicati
     public async Task MaintenanceDeadlineIsPersistedAndClearedWithStatus()
     {
         var (client, userId, venueId) = await SeedVenueAdminAsync();
-        var deadline = DateTime.UtcNow.AddDays(3).AddSeconds(30);
+        var requestedDeadline = DateTime.UtcNow.AddDays(3).AddSeconds(30);
+        var deadline = new DateTime(
+            requestedDeadline.Year,
+            requestedDeadline.Month,
+            requestedDeadline.Day,
+            requestedDeadline.Hour,
+            requestedDeadline.Minute,
+            requestedDeadline.Second,
+            DateTimeKind.Utc);
 
         using var maintenanceResponse = await client.PatchAsJsonAsync(
             $"/api/v1/venues/{venueId}/status",
@@ -41,7 +49,7 @@ public sealed class VenuesAuthorizationTests : IClassFixture<ClubHubWebApplicati
             {
                 operatorUserId = userId,
                 status = "maintenance",
-                maintenanceUntil = deadline,
+                maintenanceUntil = requestedDeadline,
                 cancelConflictingReservations = false
             });
         var maintenanceBody = await ReadJsonAsync(maintenanceResponse);
@@ -97,6 +105,36 @@ public sealed class VenuesAuthorizationTests : IClassFixture<ClubHubWebApplicati
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Equal(ApiErrorCodes.ValidationError, body.GetProperty("code").GetString());
         Assert.Equal("维护结束时间必须晚于当前时间。", body.GetProperty("message").GetString());
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        var venue = await db.Venues.FindAsync(venueId);
+        Assert.Equal("available", venue!.VenueStatus);
+        Assert.Null(venue.MaintenanceUntil);
+    }
+
+    [Fact]
+    public async Task UnzonedMaintenanceDeadlineIsRejectedBeforeStateChange()
+    {
+        var (client, userId, venueId) = await SeedVenueAdminAsync();
+        var unzonedDeadline = DateTime.SpecifyKind(
+            DateTime.UtcNow.AddDays(3),
+            DateTimeKind.Unspecified);
+
+        using var response = await client.PatchAsJsonAsync(
+            $"/api/v1/venues/{venueId}/status",
+            new
+            {
+                operatorUserId = userId,
+                status = "maintenance",
+                maintenanceUntil = unzonedDeadline,
+                cancelConflictingReservations = false
+            });
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(ApiErrorCodes.ValidationError, body.GetProperty("code").GetString());
+        Assert.Equal("维护结束时间必须包含时区信息。", body.GetProperty("message").GetString());
 
         await using var scope = _factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();

--- a/backend.Tests/VenuesAuthorizationTests.cs
+++ b/backend.Tests/VenuesAuthorizationTests.cs
@@ -1,11 +1,18 @@
 using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text.Json;
+using ClubHub.Api.Data;
+using ClubHub.Api.Data.Entities;
 using ClubHub.Api.Infrastructure.Rest;
+using ClubHub.Api.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ClubHub.Api.Tests;
 
 public sealed class VenuesAuthorizationTests : IClassFixture<ClubHubWebApplicationFactory>
 {
+    private static int _sequence;
     private readonly ClubHubWebApplicationFactory _factory;
 
     public VenuesAuthorizationTests(ClubHubWebApplicationFactory factory) => _factory = factory;
@@ -20,5 +27,139 @@ public sealed class VenuesAuthorizationTests : IClassFixture<ClubHubWebApplicati
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.Equal(ApiErrorCodes.Unauthorized, body.RootElement.GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public async Task MaintenanceDeadlineIsPersistedAndClearedWithStatus()
+    {
+        var (client, userId, venueId) = await SeedVenueAdminAsync();
+        var deadline = DateTime.UtcNow.AddDays(3).AddSeconds(30);
+
+        using var maintenanceResponse = await client.PatchAsJsonAsync(
+            $"/api/v1/venues/{venueId}/status",
+            new
+            {
+                operatorUserId = userId,
+                status = "maintenance",
+                maintenanceUntil = deadline,
+                cancelConflictingReservations = false
+            });
+        var maintenanceBody = await ReadJsonAsync(maintenanceResponse);
+
+        Assert.Equal(HttpStatusCode.OK, maintenanceResponse.StatusCode);
+        Assert.Equal("maintenance", maintenanceBody.GetProperty("status").GetString());
+        Assert.Equal(deadline, maintenanceBody.GetProperty("maintenanceUntil").GetDateTime());
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+            var venue = await db.Venues.FindAsync(venueId);
+            Assert.Equal(deadline, venue!.MaintenanceUntil);
+        }
+
+        using var availableResponse = await client.PatchAsJsonAsync(
+            $"/api/v1/venues/{venueId}/status",
+            new
+            {
+                operatorUserId = userId,
+                status = "available",
+                maintenanceUntil = (DateTime?)null,
+                cancelConflictingReservations = false
+            });
+        var availableBody = await ReadJsonAsync(availableResponse);
+
+        Assert.Equal(HttpStatusCode.OK, availableResponse.StatusCode);
+        Assert.Equal("available", availableBody.GetProperty("status").GetString());
+        Assert.Equal(JsonValueKind.Null, availableBody.GetProperty("maintenanceUntil").ValueKind);
+
+        await using var finalScope = _factory.Services.CreateAsyncScope();
+        var finalDb = finalScope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        var finalVenue = await finalDb.Venues.FindAsync(venueId);
+        Assert.Null(finalVenue!.MaintenanceUntil);
+    }
+
+    [Fact]
+    public async Task PastMaintenanceDeadlineIsRejectedBeforeStateChange()
+    {
+        var (client, userId, venueId) = await SeedVenueAdminAsync();
+
+        using var response = await client.PatchAsJsonAsync(
+            $"/api/v1/venues/{venueId}/status",
+            new
+            {
+                operatorUserId = userId,
+                status = "maintenance",
+                maintenanceUntil = DateTime.UtcNow.AddMinutes(-1),
+                cancelConflictingReservations = false
+            });
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(ApiErrorCodes.ValidationError, body.GetProperty("code").GetString());
+        Assert.Equal("维护结束时间必须晚于当前时间。", body.GetProperty("message").GetString());
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        var venue = await db.Venues.FindAsync(venueId);
+        Assert.Equal("available", venue!.VenueStatus);
+        Assert.Null(venue.MaintenanceUntil);
+    }
+
+    private async Task<(HttpClient Client, int UserId, int VenueId)> SeedVenueAdminAsync()
+    {
+        var baseId = 780_000 + Interlocked.Increment(ref _sequence) * 10;
+        var now = DateTime.UtcNow;
+        var userId = baseId;
+        var roleId = baseId + 1;
+        var venueId = baseId + 2;
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        db.Users.Add(new User
+        {
+            UserId = userId,
+            Username = $"venue-admin-{baseId}",
+            PasswordHash = "unused",
+            RealName = "场地测试管理员",
+            AccountStatus = "normal",
+            CreatedAt = now
+        });
+        db.Roles.Add(new Role
+        {
+            RoleId = roleId,
+            RoleCode = "VENUE_ADMIN",
+            RoleName = "场地管理员",
+            RoleScope = "system",
+            CreatedAt = now
+        });
+        db.UserRoles.Add(new UserRole
+        {
+            UserRoleId = baseId + 3,
+            UserId = userId,
+            RoleId = roleId,
+            ClubId = null,
+            AssignedAt = now
+        });
+        db.Venues.Add(new Venue
+        {
+            VenueId = venueId,
+            VenueName = "持久化测试场地",
+            Capacity = 60,
+            VenueStatus = "available",
+            CreatedAt = now
+        });
+        await db.SaveChangesAsync();
+
+        var token = scope.ServiceProvider.GetRequiredService<AuthTokenService>().CreateToken(
+            new User { UserId = userId, Username = $"venue-admin-{baseId}" });
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return (client, userId, venueId);
+    }
+
+    private static async Task<JsonElement> ReadJsonAsync(HttpResponseMessage response)
+    {
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return document.RootElement.Clone();
     }
 }

--- a/backend/Controllers/VenuesController.cs
+++ b/backend/Controllers/VenuesController.cs
@@ -277,7 +277,15 @@ public class VenuesController : ControllerBase
             return null;
         }
 
-        var normalized = RequestTimeToUtc(maintenanceUntil.Value);
+        if (maintenanceUntil.Value.Kind == DateTimeKind.Unspecified)
+        {
+            error = new BadRequestObjectResult(Error(
+                "venue_maintenance_until_timezone_required",
+                "维护结束时间必须包含时区信息。"));
+            return null;
+        }
+
+        var normalized = TruncateToSecond(RequestTimeToUtc(maintenanceUntil.Value));
         if (normalized == default || normalized <= DateTime.UtcNow)
         {
             error = new BadRequestObjectResult(Error(
@@ -288,6 +296,9 @@ public class VenuesController : ControllerBase
 
         return normalized;
     }
+
+    private static DateTime TruncateToSecond(DateTime value) =>
+        new(value.Year, value.Month, value.Day, value.Hour, value.Minute, value.Second, DateTimeKind.Utc);
 
     private static DateTime RequestTimeToUtc(DateTime value)
     {

--- a/backend/Controllers/VenuesController.cs
+++ b/backend/Controllers/VenuesController.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
 using ClubHub.Api.Infrastructure.Rest;
@@ -21,7 +20,6 @@ public class VenuesController : ControllerBase
     private const string ReservationStatusApproved = "approved";
     private const string ReservationStatusCancelled = "cancelled";
     private static readonly TimeZoneInfo BeijingTimeZone = ResolveBeijingTimeZone();
-    private static readonly ConcurrentDictionary<int, DateTime> MaintenanceUntilByVenueId = new();
 
     private static readonly HashSet<string> AllowedStatuses = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -159,10 +157,16 @@ public class VenuesController : ControllerBase
             return BadRequest(Error("venue_status_invalid", "场地状态参数不合法。"));
         }
 
+        var normalizedMaintenanceUntil = NormalizeMaintenanceUntil(
+            normalizedStatus,
+            req.MaintenanceUntil,
+            out var maintenanceError);
+        if (maintenanceError is not null) return maintenanceError;
+
         var venue = await _db.Venues.FindAsync(venueId);
         if (venue is null) return NotFound(Error("venue_not_found", "场地不存在。"));
 
-        var conflicts = await StatusConflictQuery(venueId, normalizedStatus, req.MaintenanceUntil)
+        var conflicts = await StatusConflictQuery(venueId, normalizedStatus, normalizedMaintenanceUntil)
             .ToListAsync();
         if (conflicts.Count > 0 && req.CancelConflictingReservations != true)
         {
@@ -179,7 +183,9 @@ public class VenuesController : ControllerBase
         }
 
         venue.VenueStatus = normalizedStatus;
-        UpdateMaintenanceUntil(venueId, normalizedStatus, req.MaintenanceUntil);
+        // EF Core wraps the single SaveChanges call in one Oracle transaction,
+        // so status, maintenance deadline and reservation cancellations commit together.
+        venue.MaintenanceUntil = normalizedMaintenanceUntil;
         await _db.SaveChangesAsync();
         await _publicQueryCache.InvalidateVenueAsync(
             venueId,
@@ -214,7 +220,6 @@ public class VenuesController : ControllerBase
             .ToListAsync();
         _db.VenueReservations.RemoveRange(reservations);
         _db.Venues.Remove(venue);
-        MaintenanceUntilByVenueId.TryRemove(venueId, out _);
         await _db.SaveChangesAsync();
         await _publicQueryCache.InvalidateVenueAsync(
             venueId,
@@ -261,15 +266,27 @@ public class VenuesController : ControllerBase
         return query;
     }
 
-    private static void UpdateMaintenanceUntil(int venueId, string status, DateTime? maintenanceUntil)
+    private static DateTime? NormalizeMaintenanceUntil(
+        string status,
+        DateTime? maintenanceUntil,
+        out IActionResult? error)
     {
+        error = null;
         if (status != "maintenance" || maintenanceUntil is null)
         {
-            MaintenanceUntilByVenueId.TryRemove(venueId, out _);
-            return;
+            return null;
         }
 
-        MaintenanceUntilByVenueId[venueId] = RequestTimeToUtc(maintenanceUntil.Value);
+        var normalized = RequestTimeToUtc(maintenanceUntil.Value);
+        if (normalized == default || normalized <= DateTime.UtcNow)
+        {
+            error = new BadRequestObjectResult(Error(
+                "venue_maintenance_until_invalid",
+                "维护结束时间必须晚于当前时间。"));
+            return null;
+        }
+
+        return normalized;
     }
 
     private static DateTime RequestTimeToUtc(DateTime value)
@@ -367,9 +384,7 @@ public class VenuesController : ControllerBase
             status,
             venue.ManagerUserId,
             venue.CreatedAt ?? DateTime.MinValue,
-            status == "maintenance" && MaintenanceUntilByVenueId.TryGetValue(venue.VenueId, out var maintenanceUntil)
-                ? maintenanceUntil
-                : null);
+            status == "maintenance" ? LearningWorkflow.AsUtc(venue.MaintenanceUntil) : null);
     }
 
     private static VenueDto ToDto(VenuePublicCacheEntry venue)
@@ -384,9 +399,7 @@ public class VenuesController : ControllerBase
             status,
             venue.ManagerUserId,
             venue.CreatedAt,
-            status == "maintenance" && MaintenanceUntilByVenueId.TryGetValue(venue.Id, out var maintenanceUntil)
-                ? maintenanceUntil
-                : null);
+            status == "maintenance" ? LearningWorkflow.AsUtc(venue.MaintenanceUntil) : null);
     }
 
     private static string? NullIfBlank(string? value)

--- a/backend/Data/ClubHubDbContext.cs
+++ b/backend/Data/ClubHubDbContext.cs
@@ -787,6 +787,9 @@ public class ClubHubDbContext : DbContext
             e.Property(v => v.VenueId)
              .ValueGeneratedOnAdd()
              .HasDefaultValueSql("SEQ_VENUES.NEXTVAL");
+            e.Property(v => v.MaintenanceUntil)
+             .HasColumnName("MAINTENANCE_UNTIL")
+             .HasColumnType("DATE");
             e.HasMany(v => v.Reservations)
              .WithOne(r => r.Venue)
              .HasForeignKey(r => r.VenueId)

--- a/backend/Data/Entities/Venue.cs
+++ b/backend/Data/Entities/Venue.cs
@@ -26,6 +26,9 @@ public class Venue
     [Column("VENUE_STATUS")]
     public string? VenueStatus { get; set; }
 
+    [Column("MAINTENANCE_UNTIL")]
+    public DateTime? MaintenanceUntil { get; set; }
+
     [Column("CREATED_AT")]
     public DateTime? CreatedAt { get; set; }
 

--- a/backend/Models/UpdateVenueStatusRequest.cs
+++ b/backend/Models/UpdateVenueStatusRequest.cs
@@ -68,9 +68,9 @@ namespace Org.OpenAPITools.Models
         public StatusEnum Status { get; set; }
 
         /// <summary>
-        /// status 为 maintenance 时可选填写的维护结束时间。
+        /// status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
         /// </summary>
-        /// <value>status 为 maintenance 时可选填写的维护结束时间。</value>
+        /// <value>status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。</value>
         [DataMember(Name="maintenanceUntil", EmitDefaultValue=true)]
         public DateTime? MaintenanceUntil { get; set; }
 

--- a/backend/Models/UpdateVenueStatusRequest.cs
+++ b/backend/Models/UpdateVenueStatusRequest.cs
@@ -68,9 +68,10 @@ namespace Org.OpenAPITools.Models
         public StatusEnum Status { get; set; }
 
         /// <summary>
-        /// status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
+        /// status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义、秒精度持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
         /// </summary>
-        /// <value>status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。</value>
+        /// <value>status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义、秒精度持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。</value>
+        /* <example>2026-09-15T12:00Z</example> */
         [DataMember(Name="maintenanceUntil", EmitDefaultValue=true)]
         public DateTime? MaintenanceUntil { get; set; }
 

--- a/backend/Models/Venue.cs
+++ b/backend/Models/Venue.cs
@@ -106,9 +106,10 @@ namespace Org.OpenAPITools.Models
         public DateTime CreatedAt { get; set; }
 
         /// <summary>
-        /// 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义返回，空值表示未设置。
+        /// 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义、秒精度返回，空值表示未设置。
         /// </summary>
-        /// <value>维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义返回，空值表示未设置。</value>
+        /// <value>维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义、秒精度返回，空值表示未设置。</value>
+        /* <example>2026-09-15T12:00Z</example> */
         [DataMember(Name="maintenanceUntil", EmitDefaultValue=true)]
         public DateTime? MaintenanceUntil { get; set; }
 

--- a/backend/Models/Venue.cs
+++ b/backend/Models/Venue.cs
@@ -106,9 +106,9 @@ namespace Org.OpenAPITools.Models
         public DateTime CreatedAt { get; set; }
 
         /// <summary>
-        /// 维护结束时间。为空表示维护结束时间未知。
+        /// 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义返回，空值表示未设置。
         /// </summary>
-        /// <value>维护结束时间。为空表示维护结束时间未知。</value>
+        /// <value>维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义返回，空值表示未设置。</value>
         [DataMember(Name="maintenanceUntil", EmitDefaultValue=true)]
         public DateTime? MaintenanceUntil { get; set; }
 

--- a/backend/Services/PublicQueryCacheService.cs
+++ b/backend/Services/PublicQueryCacheService.cs
@@ -7,6 +7,8 @@ namespace ClubHub.Api.Services;
 
 public sealed class PublicQueryCacheService
 {
+    private const string VenueCacheVersion = "v2";
+
     private static readonly RedisCachePolicy ActivityDetailPolicy = new(
         "activity-detail",
         TimeSpan.FromMinutes(2),
@@ -63,7 +65,8 @@ public sealed class PublicQueryCacheService
         _keyBuilder.Build("activity", "detail", activityId);
 
     private RedisKey VenueKey(int venueId) =>
-        _keyBuilder.Build("venue", "detail", venueId);
+        // The version separates pre-#166 payloads that do not contain MaintenanceUntil.
+        _keyBuilder.Build("venue", "detail", VenueCacheVersion, venueId);
 
     private Task<ActivityPublicCacheEntry?> LoadActivityAsync(
         int activityId,

--- a/backend/Services/PublicQueryCacheService.cs
+++ b/backend/Services/PublicQueryCacheService.cs
@@ -114,7 +114,8 @@ public sealed class PublicQueryCacheService
                 venue.Capacity ?? 0,
                 venue.VenueStatus,
                 venue.ManagerUserId,
-                venue.CreatedAt ?? DateTime.MinValue))
+                venue.CreatedAt ?? DateTime.MinValue,
+                venue.MaintenanceUntil))
             .FirstOrDefaultAsync(cancellationToken);
 }
 
@@ -154,4 +155,5 @@ public sealed record VenuePublicCacheEntry(
     int Capacity,
     string? Status,
     int? ManagerUserId,
-    DateTime CreatedAt);
+    DateTime CreatedAt,
+    DateTime? MaintenanceUntil);

--- a/database/README.md
+++ b/database/README.md
@@ -3,7 +3,7 @@
 本目录保存 ClubHub 的 Oracle 数据库脚本。
 
 - `schema.sql`：当前权威全量建表脚本，用于全新的本地开发库或明确测试库。
-- `verify.sql`：验证当前用户、41 张核心表、40 个核心主键 Sequence 及其列默认值和推进位置，并检查项目成员、任务执行人、进度记录、社团部门和小组约束、评奖评优申请审批、公示细则、经费闭环和幂等台账约束。
+- `verify.sql`：验证当前用户、41 张核心表、40 个核心主键 Sequence 及其列默认值和推进位置，并检查场地维护截止时间、项目成员、任务执行人、进度记录、社团部门和小组约束、评奖评优申请审批、公示细则、经费闭环和幂等台账约束。
 - `seeds/`：隔离开发或测试环境使用的样例数据。
 - `views/`：后续放统计视图。
 - `migrations/`：已有数据库的增量迁移脚本；项目成员关系依次包含 `001_add_project_members.sql` 与 `002_harden_project_members_constraints.sql`。
@@ -70,6 +70,10 @@
     发现某个现有 Sequence 未超过对应表最大主键时执行。脚本不创建表、不删除或
     更新业务数据，也明确排除当前未部署的幂等台账 Sequence。当前共享库的 39 个
     在用 Sequence 已全部通过审计，无需执行本脚本。
+13. `20260831_add_venue_maintenance_until.sql`：为 `VENUES` 增加可空的
+    `MAINTENANCE_UNTIL`，约定以 UTC 语义保存维护截止时间，并增加状态一致性检查约束。
+    执行前备份数据库并暂停场地状态写入；脚本不会替已有数据推测维护截止时间，历史维护记录
+    的空值由管理员按实际情况确认。
 
 迁移完成后执行 `verify.sql`，确认 sequence、唯一索引、列默认值、部门/小组外码、
 经费账户唯一性、审批通过申请流水、幂等台账约束和回填结果均已生效。
@@ -146,6 +150,8 @@
 14. 当前 production Redis 关闭，因此不要执行 `migrations/20260726_add_idempotency_records.sql`；只有未来正式恢复 Redis 幂等能力时，才在维护窗口重新评估并迁移。
 15. 导入显式主键数据后先只读比较 39 个在用 Sequence 与对应表最大主键；仅在发现落后时执行 `migrations/20260828_align_primary_key_sequences.sql`。截至 2026-08-28，当前共享库全部正常，无需执行。
 16. 当前共享库执行 `009_data_quality_audit.sql` 做业务数据巡检，各查询应返回 0 行。`verify.sql` 面向包含幂等台账的 41 表完整结构；在本迁移仍被跳过时，不要将其中缺失 `IDEMPOTENCY_RECORDS` 的结果误判为其他结构故障。
+17. 执行 `migrations/20260831_add_venue_maintenance_until.sql`。执行前备份并暂停场地状态变更，
+    执行后运行 `verify.sql` 检查 `VENUES.MAINTENANCE_UNTIL` 和状态一致性约束，再恢复场地状态写入。
 
 Oracle DDL 会自动提交，迁移脚本不能被视为可事务回滚。执行前应确认连接信息并保留数据库备份；CI 不会自动执行此迁移。
 

--- a/database/migrations/20260831_add_venue_maintenance_until.sql
+++ b/database/migrations/20260831_add_venue_maintenance_until.sql
@@ -6,7 +6,7 @@
 --   3. Run as the CLUBHUB schema owner, then execute database/verify.sql.
 --
 -- Semantics:
---   - MAINTENANCE_UNTIL is nullable and stores UTC wall-clock time in Oracle DATE.
+--   - MAINTENANCE_UNTIL is nullable and stores UTC wall-clock time to whole-second precision in Oracle DATE.
 --   - A null value means that the maintenance end time is not set.
 --   - The application clears the value when VENUE_STATUS leaves maintenance.
 --

--- a/database/migrations/20260831_add_venue_maintenance_until.sql
+++ b/database/migrations/20260831_add_venue_maintenance_until.sql
@@ -1,0 +1,70 @@
+-- Issue #166: persist venue maintenance deadlines in Oracle.
+--
+-- Execution prerequisites:
+--   1. Back up the target CLUBHUB schema.
+--   2. Stop venue status writes during the migration.
+--   3. Run as the CLUBHUB schema owner, then execute database/verify.sql.
+--
+-- Semantics:
+--   - MAINTENANCE_UNTIL is nullable and stores UTC wall-clock time in Oracle DATE.
+--   - A null value means that the maintenance end time is not set.
+--   - The application clears the value when VENUE_STATUS leaves maintenance.
+--
+-- Rollback outline for a non-production test database:
+--   ALTER TABLE VENUES DROP CONSTRAINT CK_VENUES_MAINTENANCE_UNTIL;
+--   ALTER TABLE VENUES DROP COLUMN MAINTENANCE_UNTIL;
+-- Oracle DDL commits implicitly; take a backup before attempting rollback.
+
+WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK;
+SET DEFINE OFF;
+
+DECLARE
+  table_count NUMBER;
+  column_count NUMBER;
+  date_column_count NUMBER;
+  constraint_count NUMBER;
+BEGIN
+  SELECT COUNT(*) INTO table_count
+  FROM user_tables
+  WHERE table_name = 'VENUES';
+
+  IF table_count = 0 THEN
+    RAISE_APPLICATION_ERROR(-20061, 'VENUES does not exist; run the base schema first.');
+  END IF;
+
+  SELECT COUNT(*) INTO column_count
+  FROM user_tab_columns
+  WHERE table_name = 'VENUES'
+    AND column_name = 'MAINTENANCE_UNTIL';
+
+  IF column_count = 0 THEN
+    EXECUTE IMMEDIATE 'ALTER TABLE VENUES ADD (maintenance_until DATE)';
+  ELSE
+    SELECT COUNT(*) INTO date_column_count
+    FROM user_tab_columns
+    WHERE table_name = 'VENUES'
+      AND column_name = 'MAINTENANCE_UNTIL'
+      AND data_type = 'DATE';
+
+    IF date_column_count = 0 THEN
+      RAISE_APPLICATION_ERROR(-20062, 'VENUES.MAINTENANCE_UNTIL exists with an unexpected type.');
+    END IF;
+  END IF;
+
+  SELECT COUNT(*) INTO constraint_count
+  FROM user_constraints
+  WHERE table_name = 'VENUES'
+    AND constraint_name = 'CK_VENUES_MAINTENANCE_UNTIL';
+
+  IF constraint_count = 0 THEN
+    EXECUTE IMMEDIATE q'[
+      ALTER TABLE VENUES ADD CONSTRAINT CK_VENUES_MAINTENANCE_UNTIL CHECK (
+        maintenance_until IS NULL OR
+        NVL(LOWER(TRIM(venue_status)), '#') = 'maintenance'
+      )
+    ]';
+  END IF;
+END;
+/
+
+COMMIT;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -305,6 +305,11 @@ CREATE TABLE VENUES (
   room_no varchar2(255),
   capacity number,
   venue_status varchar2(255),
+  maintenance_until date,
+  CONSTRAINT CK_VENUES_MAINTENANCE_UNTIL CHECK (
+    maintenance_until IS NULL OR
+    NVL(LOWER(TRIM(venue_status)), '#') = 'maintenance'
+  ),
   created_at date
 );
 

--- a/database/verify.sql
+++ b/database/verify.sql
@@ -114,6 +114,16 @@ WHERE (table_name, column_name) IN (
 )
 ORDER BY table_name, column_name;
 
+SELECT column_id, column_name, data_type, nullable, data_default
+FROM user_tab_columns
+WHERE table_name = 'VENUES'
+  AND column_name = 'MAINTENANCE_UNTIL';
+
+SELECT constraint_name, constraint_type, status, deferrable, deferred
+FROM user_constraints
+WHERE table_name = 'VENUES'
+  AND constraint_name = 'CK_VENUES_MAINTENANCE_UNTIL';
+
 -- 以下查询应返回 0 行：每个主键 sequence 必须存在，且下一个值必须大于当前最大主键。
 WITH sequence_targets AS (
   SELECT 'SEQ_USERS' AS sequence_name, NVL(MAX(user_id), 0) AS max_id FROM users
@@ -248,6 +258,11 @@ SELECT transaction_id, transaction_type, amount
 FROM budget_transactions
 WHERE transaction_type NOT IN ('commitment', 'expense', 'refund', 'adjustment')
    OR amount = 0;
+
+SELECT venue_id, venue_status, maintenance_until
+FROM venues
+WHERE maintenance_until IS NOT NULL
+  AND NVL(LOWER(TRIM(venue_status)), '#') <> 'maintenance';
 
 SELECT account.account_id,
        account.club_id,

--- a/frontend/src/api/models/UpdateVenueStatusRequest.ts
+++ b/frontend/src/api/models/UpdateVenueStatusRequest.ts
@@ -29,7 +29,7 @@ export interface UpdateVenueStatusRequest {
    */
   status: UpdateVenueStatusRequestStatusEnum;
   /**
-   * status 为 maintenance 时可选填写的维护结束时间。
+   * status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
    */
   maintenanceUntil?: Date | null;
   /**

--- a/frontend/src/api/models/UpdateVenueStatusRequest.ts
+++ b/frontend/src/api/models/UpdateVenueStatusRequest.ts
@@ -29,7 +29,7 @@ export interface UpdateVenueStatusRequest {
    */
   status: UpdateVenueStatusRequestStatusEnum;
   /**
-   * status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
+   * status 为 maintenance 时可选填写的维护结束时间；客户端使用带时区的 ISO 8601 时间，服务端按 UTC 语义、秒精度持久化。未填写表示维护期限未知，切换到其他状态时该值会被清除。
    */
   maintenanceUntil?: Date | null;
   /**

--- a/frontend/src/api/models/Venue.ts
+++ b/frontend/src/api/models/Venue.ts
@@ -53,7 +53,7 @@ export interface Venue {
    */
   createdAt: Date;
   /**
-   * 维护结束时间。为空表示维护结束时间未知。
+   * 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义返回，空值表示未设置。
    */
   maintenanceUntil?: Date | null;
 }

--- a/frontend/src/api/models/Venue.ts
+++ b/frontend/src/api/models/Venue.ts
@@ -53,7 +53,7 @@ export interface Venue {
    */
   createdAt: Date;
   /**
-   * 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义返回，空值表示未设置。
+   * 维护结束时间。仅在 maintenance 状态下有业务含义；接口按 UTC 语义、秒精度返回，空值表示未设置。
    */
   maintenanceUntil?: Date | null;
 }


### PR DESCRIPTION
## 改动内容

- 发布 PR #208 的场地维护截止时间持久化修复。
- 让 `VENUES.MAINTENANCE_UNTIL` 成为场地维护截止时间的 Oracle 业务事实来源。
- 同步发布实体映射、缓存键 v2、UTC 秒精度校验、数据库迁移与回归测试。

## 改动原因

`dev` 已完成 Issue #166 的代码实现和门禁验证。共享开发库已在发布前执行增量迁移，场地状态写入与新版本 API 可以在同一数据库结构上运行。

---

## 关联 Issue

Closes #166

## 审查关注点

- `dev` 与 `main` 的发布内容只包含已验证的场地维护持久化修复。
- 迁移先于新代码部署，`VENUES.MAINTENANCE_UNTIL` 列和状态约束已在共享开发库验证。
- 现有场地预约、缓存回源和状态清理行为保持兼容。

## UI 改动

无新的前端代码改动；现有场地维护界面继续使用 `maintenanceUntil`。

## 测试说明

- PR #208 CI、代码质量门禁和 CodeRabbit 已完成。
- 本地后端全量测试 239 项通过，Oracle 集成测试按规则跳过 4 项。
- 前端 Vitest 112 项通过、1 项按既有环境配置跳过；类型检查和生产构建通过。
- 共享开发库迁移验证：`MAINTENANCE_UNTIL` 为 Oracle `DATE`、约束已启用、违规记录为 0。
