### PR TITLE
fix(auth): 垂直居中登录注册页面内容

### DIFF
--- a/frontend/src/authLayout.test.ts
+++ b/frontend/src/authLayout.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import authFlowSource from "./views/AuthFlow.vue?raw";
+
+describe("登录注册页面布局", () => {
+  it("使用完整视口高度垂直居中认证内容", () => {
+    const authShellRule = authFlowSource.match(/\.auth-shell\s*\{([\s\S]*?)\}/)?.[1];
+
+    expect(authShellRule).toBeDefined();
+    expect(authShellRule).toContain("min-height: 100vh");
+    expect(authShellRule).toContain("align-items: center");
+    expect(authShellRule).toContain("padding-block: 24px");
+    expect(authShellRule).not.toContain("padding-top");
+  });
+});

--- a/frontend/src/views/AuthFlow.vue
+++ b/frontend/src/views/AuthFlow.vue
@@ -630,12 +630,12 @@ if (!auth.value) void loadCaptcha(false);
 }
 
 .auth-shell {
-  min-height: 520px;
+  min-height: 100vh;
   display: grid;
   grid-template-columns: minmax(260px, 1fr) minmax(320px, 420px);
   gap: 28px;
   align-items: center;
-  padding-top: 24px;
+  padding-block: 24px;
 }
 
 .register-shell {


### PR DESCRIPTION
## 改动内容

- 登录和注册认证容器使用完整视口高度。
- 将单侧顶部留白改为对称上下留白，使文字和表单面板垂直居中。
- 补充认证页布局回归测试，不修改任何文案、表单或交互。

## 改动原因

登录和注册页面内容原先受固定 520px 最小高度限制，整体靠近页面顶部。

---

## 关联 Issue

Closes #210

## 审查关注点

请确认登录和注册两种状态下仅垂直位置发生变化，其他布局和交互保持不变。

## UI 改动

在 1280×720 视口实测：认证容器、左侧文字与右侧面板中心均为 y=360；注册面板完整显示且无额外滚动。

## 测试说明

- `pnpm exec vitest run src/authLayout.test.ts`：通过。
- `pnpm run lint`：通过。
- `pnpm run build`：通过。
- `pnpm test`：新增测试通过；整套测试有 11 个既有 Node 26 localStorage 环境失败，其余 103 个通过或跳过。

---

### 检查清单

**代码质量**
- [x] 前端代码已构建通过（`pnpm build`）
- [x] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 优化认证页面布局，使内容区域适配完整视口高度。
  * 调整上下内边距并实现垂直居中，提升不同屏幕尺寸下的显示效果。
* **测试**
  * 新增认证页面布局测试，确保高度、居中方式及内边距符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->