### PR TITLE
feat(database): add Oracle budget and venue routines

### DIFF
--- a/backend.OracleIntegrationTests/DatabaseRoutineOracleTests.cs
+++ b/backend.OracleIntegrationTests/DatabaseRoutineOracleTests.cs
@@ -1,0 +1,291 @@
+using System.Data;
+using Oracle.ManagedDataAccess.Client;
+
+namespace ClubHub.Api.OracleIntegrationTests;
+
+public sealed class DatabaseRoutineOracleTests
+{
+    private const int UserId = 9215001;
+    private const int ReviewerId = 9215002;
+    private const int ClubId = 9215001;
+    private const int AccountId = 9215001;
+    private const int ApplicationId = 9215001;
+    private const int InsufficientApplicationId = 9215002;
+    private const int VenueId = 9215001;
+    private const int ReservationId = 9215001;
+    private const int OverlapReservationId = 9215002;
+    private const int AdjacentReservationId = 9215003;
+    private const int UpdateReservationId = 9215004;
+
+    [OracleIntegrationFact]
+    public async Task BudgetRoutines_ReviewAndVenueTrigger_ProtectOracleInvariants()
+    {
+        await using var connection = new OracleConnection(OracleIntegrationEnvironment.ConnectionString);
+        await connection.OpenAsync();
+        await using var transaction = (OracleTransaction)await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+
+        try
+        {
+            Assert.Equal(
+                3,
+                await ScalarIntAsync(
+                    connection,
+                    transaction,
+                    """
+                    SELECT COUNT(*)
+                    FROM user_objects
+                    WHERE object_name IN (
+                        'FN_BUDGET_AVAILABLE_AMOUNT',
+                        'SP_REVIEW_BUDGET_APPLICATION',
+                        'TRG_VENUE_RESERVATION_OVERLAP'
+                    )
+                      AND status = 'VALID'
+                    """));
+
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO users (user_id, username, real_name, account_status, created_at) VALUES (:userId, 'routine_applicant_215', '例程申请人', 'normal', SYSDATE)",
+                ("userId", UserId));
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO users (user_id, username, real_name, account_status, created_at) VALUES (:reviewerId, 'routine_reviewer_215', '例程审核人', 'normal', SYSDATE)",
+                ("reviewerId", ReviewerId));
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO clubs (club_id, club_name, club_status, created_at) VALUES (:clubId, '数据库例程测试社', 'active', SYSDATE)",
+                ("clubId", ClubId));
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO budget_accounts (account_id, club_id, fiscal_year, account_name, initial_amount, account_status) VALUES (:accountId, :clubId, '2150', '例程测试账户', 100, 'active')",
+                ("accountId", AccountId),
+                ("clubId", ClubId));
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO budget_applications (application_id, account_id, club_id, applicant_user_id, application_type, title, amount, purpose, application_status) VALUES (:applicationId, :accountId, :clubId, :userId, 'purchase', '例程测试采购', 40, '测试经费审批过程', 'pending')",
+                ("applicationId", ApplicationId),
+                ("accountId", AccountId),
+                ("clubId", ClubId),
+                ("userId", UserId));
+
+            Assert.Equal(
+                100m,
+                await ScalarDecimalAsync(
+                    connection,
+                    transaction,
+                    "SELECT FN_BUDGET_AVAILABLE_AMOUNT(:accountId) FROM dual",
+                    ("accountId", AccountId)));
+
+            await ExecuteAsync(
+                connection,
+                transaction,
+                """
+                BEGIN
+                    SP_REVIEW_BUDGET_APPLICATION(:applicationId, :reviewerId, 1, '审批通过');
+                END;
+                """,
+                ("applicationId", ApplicationId),
+                ("reviewerId", ReviewerId));
+
+            Assert.Equal(
+                "approved",
+                await ScalarStringAsync(
+                    connection,
+                    transaction,
+                    "SELECT application_status FROM budget_applications WHERE application_id = :applicationId",
+                    ("applicationId", ApplicationId)));
+            Assert.Equal(
+                1,
+                await ScalarIntAsync(
+                    connection,
+                    transaction,
+                    "SELECT COUNT(*) FROM budget_review_records WHERE application_id = :applicationId AND approved = 1",
+                    ("applicationId", ApplicationId)));
+            Assert.Equal(
+                -40m,
+                await ScalarDecimalAsync(
+                    connection,
+                    transaction,
+                    "SELECT amount FROM budget_transactions WHERE application_id = :applicationId AND transaction_type = 'commitment'",
+                    ("applicationId", ApplicationId)));
+            Assert.Equal(
+                60m,
+                await ScalarDecimalAsync(
+                    connection,
+                    transaction,
+                    "SELECT FN_BUDGET_AVAILABLE_AMOUNT(:accountId) FROM dual",
+                    ("accountId", AccountId)));
+
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO budget_applications (application_id, account_id, club_id, applicant_user_id, application_type, title, amount, purpose, application_status) VALUES (:applicationId, :accountId, :clubId, :userId, 'purchase', '余额不足测试', 1000, '应被过程拒绝', 'pending')",
+                ("applicationId", InsufficientApplicationId),
+                ("accountId", AccountId),
+                ("clubId", ClubId),
+                ("userId", UserId));
+            await ExpectRoutineErrorAsync(
+                connection,
+                transaction,
+                """
+                BEGIN
+                    SP_REVIEW_BUDGET_APPLICATION(:applicationId, :reviewerId, 1, '不应通过');
+                END;
+                """,
+                -20049,
+                ("applicationId", InsufficientApplicationId),
+                ("reviewerId", ReviewerId));
+            Assert.Equal(
+                "pending",
+                await ScalarStringAsync(
+                    connection,
+                    transaction,
+                    "SELECT application_status FROM budget_applications WHERE application_id = :applicationId",
+                    ("applicationId", InsufficientApplicationId)));
+
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO venues (venue_id, venue_name, venue_status, created_at) VALUES (:venueId, '例程测试教室', 'available', SYSDATE)",
+                ("venueId", VenueId));
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO venue_reservations (reservation_id, venue_id, club_id, applicant_user_id, start_at, end_at, purpose, reservation_status, reviewer_user_id, created_at) VALUES (:reservationId, :venueId, :clubId, :userId, DATE '2026-09-01', DATE '2026-09-01' + 1/24, '首段预约', 'approved', :reviewerId, SYSDATE)",
+                ("reservationId", ReservationId),
+                ("venueId", VenueId),
+                ("clubId", ClubId),
+                ("userId", UserId),
+                ("reviewerId", ReviewerId));
+            await ExpectRoutineErrorAsync(
+                connection,
+                transaction,
+                "INSERT INTO venue_reservations (reservation_id, venue_id, club_id, applicant_user_id, start_at, end_at, purpose, reservation_status, reviewer_user_id, created_at) VALUES (:reservationId, :venueId, :clubId, :userId, DATE '2026-09-01' + 1/48, DATE '2026-09-01' + 1/16, '重叠预约', 'approved', :reviewerId, SYSDATE)",
+                -20054,
+                ("reservationId", OverlapReservationId),
+                ("venueId", VenueId),
+                ("clubId", ClubId),
+                ("userId", UserId),
+                ("reviewerId", ReviewerId));
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO venue_reservations (reservation_id, venue_id, club_id, applicant_user_id, start_at, end_at, purpose, reservation_status, reviewer_user_id, created_at) VALUES (:reservationId, :venueId, :clubId, :userId, DATE '2026-09-01' + 1/24, DATE '2026-09-01' + 1/12, '首尾相接预约', 'approved', :reviewerId, SYSDATE)",
+                ("reservationId", AdjacentReservationId),
+                ("venueId", VenueId),
+                ("clubId", ClubId),
+                ("userId", UserId),
+                ("reviewerId", ReviewerId));
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "INSERT INTO venue_reservations (reservation_id, venue_id, club_id, applicant_user_id, start_at, end_at, purpose, reservation_status, reviewer_user_id, created_at) VALUES (:reservationId, :venueId, :clubId, :userId, DATE '2026-09-01' + 1/48, DATE '2026-09-01' + 1/16, '状态变更预约', 'pending', :reviewerId, SYSDATE)",
+                ("reservationId", UpdateReservationId),
+                ("venueId", VenueId),
+                ("clubId", ClubId),
+                ("userId", UserId),
+                ("reviewerId", ReviewerId));
+            await ExpectRoutineErrorAsync(
+                connection,
+                transaction,
+                "UPDATE venue_reservations SET reservation_status = 'approved' WHERE reservation_id = :reservationId",
+                -20054,
+                ("reservationId", UpdateReservationId));
+            Assert.Equal(
+                "pending",
+                await ScalarStringAsync(
+                    connection,
+                    transaction,
+                    "SELECT reservation_status FROM venue_reservations WHERE reservation_id = :reservationId",
+                    ("reservationId", UpdateReservationId)));
+            await ExecuteAsync(
+                connection,
+                transaction,
+                "UPDATE venue_reservations SET start_at = DATE '2026-09-01' + 1/12, end_at = DATE '2026-09-01' + 1/8, reservation_status = 'approved' WHERE reservation_id = :reservationId",
+                ("reservationId", UpdateReservationId));
+        }
+        finally
+        {
+            await transaction.RollbackAsync();
+        }
+    }
+
+    private static async Task ExpectRoutineErrorAsync(
+        OracleConnection connection,
+        OracleTransaction transaction,
+        string sql,
+        int expectedNumber,
+        params (string Name, object Value)[] parameters)
+    {
+        var exception = await Record.ExceptionAsync(() => ExecuteAsync(connection, transaction, sql, parameters));
+        var oracleException = Assert.IsType<OracleException>(exception);
+        Assert.True(
+            oracleException.Number == Math.Abs(expectedNumber) ||
+            oracleException.Message.Contains($"ORA-{Math.Abs(expectedNumber)}", StringComparison.Ordinal),
+            $"Expected ORA-{Math.Abs(expectedNumber)}, got {oracleException.Message}");
+    }
+
+    private static async Task ExecuteAsync(
+        OracleConnection connection,
+        OracleTransaction transaction,
+        string sql,
+        params (string Name, object Value)[] parameters)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = sql;
+        AddParameters(command, parameters);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<int> ScalarIntAsync(
+        OracleConnection connection,
+        OracleTransaction transaction,
+        string sql,
+        params (string Name, object Value)[] parameters) =>
+        Convert.ToInt32(await ScalarAsync(connection, transaction, sql, parameters));
+
+    private static async Task<decimal> ScalarDecimalAsync(
+        OracleConnection connection,
+        OracleTransaction transaction,
+        string sql,
+        params (string Name, object Value)[] parameters) =>
+        Convert.ToDecimal(await ScalarAsync(connection, transaction, sql, parameters));
+
+    private static async Task<string> ScalarStringAsync(
+        OracleConnection connection,
+        OracleTransaction transaction,
+        string sql,
+        params (string Name, object Value)[] parameters) =>
+        Convert.ToString(await ScalarAsync(connection, transaction, sql, parameters))!;
+
+    private static async Task<object?> ScalarAsync(
+        OracleConnection connection,
+        OracleTransaction transaction,
+        string sql,
+        params (string Name, object Value)[] parameters)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = sql;
+        AddParameters(command, parameters);
+        return await command.ExecuteScalarAsync();
+    }
+
+    private static void AddParameters(
+        OracleCommand command,
+        IEnumerable<(string Name, object Value)> parameters)
+    {
+        foreach (var (name, value) in parameters)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value;
+            command.Parameters.Add(parameter);
+        }
+    }
+}

--- a/backend.OracleIntegrationTests/DatabaseRoutineOracleTests.cs
+++ b/backend.OracleIntegrationTests/DatabaseRoutineOracleTests.cs
@@ -41,6 +41,17 @@ public sealed class DatabaseRoutineOracleTests
                     )
                       AND status = 'VALID'
                     """));
+            Assert.Equal(
+                1,
+                await ScalarIntAsync(
+                    connection,
+                    transaction,
+                    """
+                    SELECT COUNT(*)
+                    FROM user_indexes
+                    WHERE index_name = 'IX_VENUE_RESERVATIONS_VENUE_ID'
+                      AND table_name = 'VENUE_RESERVATIONS'
+                    """));
 
             await ExecuteAsync(
                 connection,

--- a/backend.OracleIntegrationTests/DatabaseRoutineOracleTests.cs
+++ b/backend.OracleIntegrationTests/DatabaseRoutineOracleTests.cs
@@ -15,7 +15,7 @@ public sealed class DatabaseRoutineOracleTests
     private const int ReservationId = 9215001;
     private const int OverlapReservationId = 9215002;
     private const int AdjacentReservationId = 9215003;
-    private const int UpdateReservationId = 9215004;
+    private const long HighReservationId = 2147483648L;
 
     [OracleIntegrationFact]
     public async Task BudgetRoutines_ReviewAndVenueTrigger_ProtectOracleInvariants()
@@ -195,7 +195,7 @@ public sealed class DatabaseRoutineOracleTests
                 connection,
                 transaction,
                 "INSERT INTO venue_reservations (reservation_id, venue_id, club_id, applicant_user_id, start_at, end_at, purpose, reservation_status, reviewer_user_id, created_at) VALUES (:reservationId, :venueId, :clubId, :userId, DATE '2026-09-01' + 1/48, DATE '2026-09-01' + 1/16, '状态变更预约', 'pending', :reviewerId, SYSDATE)",
-                ("reservationId", UpdateReservationId),
+                ("reservationId", HighReservationId),
                 ("venueId", VenueId),
                 ("clubId", ClubId),
                 ("userId", UserId),
@@ -205,19 +205,19 @@ public sealed class DatabaseRoutineOracleTests
                 transaction,
                 "UPDATE venue_reservations SET reservation_status = 'approved' WHERE reservation_id = :reservationId",
                 -20054,
-                ("reservationId", UpdateReservationId));
+                ("reservationId", HighReservationId));
             Assert.Equal(
                 "pending",
                 await ScalarStringAsync(
                     connection,
                     transaction,
                     "SELECT reservation_status FROM venue_reservations WHERE reservation_id = :reservationId",
-                    ("reservationId", UpdateReservationId)));
+                    ("reservationId", HighReservationId)));
             await ExecuteAsync(
                 connection,
                 transaction,
                 "UPDATE venue_reservations SET start_at = DATE '2026-09-01' + 1/12, end_at = DATE '2026-09-01' + 1/8, reservation_status = 'approved' WHERE reservation_id = :reservationId",
-                ("reservationId", UpdateReservationId));
+                ("reservationId", HighReservationId));
         }
         finally
         {

--- a/backend/Controllers/VenueReservationsController.cs
+++ b/backend/Controllers/VenueReservationsController.cs
@@ -347,6 +347,10 @@ public class VenueReservationsController : ControllerBase
         {
             return Conflict(Error("venue_reservation_conflict", "审批通过失败：该场地在所选时间段已有已通过预约。"));
         }
+        catch (DbUpdateException ex) when (IsVenueDataViolation(ex))
+        {
+            return Conflict(Error("venue_reservation_data_invalid", "审批通过失败：场地预约数据不一致，请联系管理员核对。"));
+        }
 
         return Ok(ToDto(reservation));
     }
@@ -566,6 +570,26 @@ public class VenueReservationsController : ControllerBase
             }
 
             if (current.Message.Contains("ORA-20054", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsVenueDataViolation(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is OracleException oracleException &&
+                (oracleException.Number == 20052 || oracleException.Number == 20053))
+            {
+                return true;
+            }
+
+            if (current.Message.Contains("ORA-20052", StringComparison.OrdinalIgnoreCase) ||
+                current.Message.Contains("ORA-20053", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/backend/Controllers/VenueReservationsController.cs
+++ b/backend/Controllers/VenueReservationsController.cs
@@ -6,6 +6,7 @@ using ClubHub.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Oracle.ManagedDataAccess.Client;
 using Org.OpenAPITools.Models;
 using ApiError = Org.OpenAPITools.Models.ApiError;
 using VenueReservationEntity = ClubHub.Api.Data.Entities.VenueReservation;
@@ -338,7 +339,14 @@ public class VenueReservationsController : ControllerBase
             ? null
             : req.ReviewComment.Trim();
 
-        await _db.SaveChangesAsync();
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsVenueOverlapViolation(ex))
+        {
+            return Conflict(Error("venue_reservation_conflict", "审批通过失败：该场地在所选时间段已有已通过预约。"));
+        }
 
         return Ok(ToDto(reservation));
     }
@@ -546,6 +554,24 @@ public class VenueReservationsController : ControllerBase
 
         var now = DateTime.UtcNow;
         return StoredTimeToUtc(reservation.StartAt.Value) <= now && StoredTimeToUtc(reservation.EndAt.Value) > now;
+    }
+
+    private static bool IsVenueOverlapViolation(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is OracleException oracleException && oracleException.Number == 20054)
+            {
+                return true;
+            }
+
+            if (current.Message.Contains("ORA-20054", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async Task<(IActionResult? Error, bool CanReview, IReadOnlyList<int> ClubIds)> GetReservationAccessAsync(int userId)

--- a/database/README.md
+++ b/database/README.md
@@ -74,6 +74,10 @@
     `MAINTENANCE_UNTIL`，约定以 UTC 语义保存维护截止时间，并增加状态一致性检查约束。
     执行前备份数据库并暂停场地状态写入；脚本不会替已有数据推测维护截止时间，历史维护记录
     的空值由管理员按实际情况确认。
+14. `20260901_add_budget_and_venue_routines.sql`：新增经费可用余额函数、经费申请审批
+    过程和场地预约时间冲突 compound trigger。该脚本不改变表结构；过程不自行提交事务，
+    由调用方控制提交或回滚。触发器在语句级检查同一场地已通过预约的半开时间区间，
+    应在现有应用层校验之后作为数据库事实约束使用。
 
 迁移完成后执行 `verify.sql`，确认 sequence、唯一索引、列默认值、部门/小组外码、
 经费账户唯一性、审批通过申请流水、幂等台账约束和回填结果均已生效。
@@ -184,5 +188,19 @@ ASP.NET Core 后端通过 EF Core + Oracle 驱动连接远程 Oracle，**不需�
 - 使用 Oracle 语法。
 - 表结构变更必须同步 `schema.sql` 和数据库设计文档。
 - 新增种子数据、视图、迁移脚本时放入对应子目录。
+- 数据库函数、存储过程和触发器随 `migrations/20260901_add_budget_and_venue_routines.sql`
+  增量部署，并同步到 `schema.sql` 与 `verify.sql`；禁止只在共享数据库中手工创建而不留脚本。
 - `schema.sql` 中核心 sequence 从 `1000000` 起步，用于避开 seeds 保留的显式样例 ID；
   已有数据库的迁移脚本使用 `GREATEST(实时最大主键 + 1, 1000000)` 作为安全下限。
+
+### 数据库例程边界
+
+- `FN_BUDGET_AVAILABLE_AMOUNT(account_id)` 只读汇总 `BUDGET_ACCOUNTS.initial_amount` 与
+  `BUDGET_TRANSACTIONS.amount`，流水的负数占用、正数退款/调整语义与后端保持一致。
+- `SP_REVIEW_BUDGET_APPLICATION` 锁定待审核申请和对应账户，执行额度判断、申请状态更新、
+  审核记录写入和批准占用流水写入；过程不包含权限判断，也不提交事务，权限仍由 API 层负责。
+- `TRG_VENUE_RESERVATION_OVERLAP` 使用 `AFTER STATEMENT` 检查 `[start_at, end_at)` 区间，
+  同一场地首尾相接允许通过，重叠则抛出 `ORA-20054`；采用父行锁避免并发审批绕过检查，
+  同时避免普通行级触发器查询变更表产生 mutating table 错误。
+- 例程的验证必须在隔离 Oracle Schema 中执行 `backend.OracleIntegrationTests`；共享开发库
+  只在确认迁移窗口、备份和回滚方案后人工执行迁移。

--- a/database/README.md
+++ b/database/README.md
@@ -75,9 +75,10 @@
     执行前备份数据库并暂停场地状态写入；脚本不会替已有数据推测维护截止时间，历史维护记录
     的空值由管理员按实际情况确认。
 14. `20260901_add_budget_and_venue_routines.sql`：新增经费可用余额函数、经费申请审批
-    过程和场地预约时间冲突 compound trigger。该脚本不改变表结构；过程不自行提交事务，
-    由调用方控制提交或回滚。触发器在语句级检查同一场地已通过预约的半开时间区间，
-    应在现有应用层校验之后作为数据库事实约束使用。
+    过程、场地预约时间冲突 compound trigger 和 `VENUE_ID` 索引。该脚本不改变表结构；
+    过程不自行提交事务，由调用方控制提交或回滚。触发器在语句级检查同一场地已通过预约
+    的半开时间区间，应在现有应用层校验之后作为数据库事实约束使用。部署前先运行
+    `verify.sql` 中的已通过预约时间核查，记录历史异常后再执行迁移。
 
 迁移完成后执行 `verify.sql`，确认 sequence、唯一索引、列默认值、部门/小组外码、
 经费账户唯一性、审批通过申请流水、幂等台账约束和回填结果均已生效。
@@ -188,8 +189,9 @@ ASP.NET Core 后端通过 EF Core + Oracle 驱动连接远程 Oracle，**不需�
 - 使用 Oracle 语法。
 - 表结构变更必须同步 `schema.sql` 和数据库设计文档。
 - 新增种子数据、视图、迁移脚本时放入对应子目录。
-- 数据库函数、存储过程和触发器随 `migrations/20260901_add_budget_and_venue_routines.sql`
-  增量部署，并同步到 `schema.sql` 与 `verify.sql`；禁止只在共享数据库中手工创建而不留脚本。
+- 数据库函数、存储过程、触发器和 `VENUE_ID` 索引随
+  `migrations/20260901_add_budget_and_venue_routines.sql` 增量部署，并同步到
+  `schema.sql` 与 `verify.sql`；禁止只在共享数据库中手工创建而不留脚本。
 - `schema.sql` 中核心 sequence 从 `1000000` 起步，用于避开 seeds 保留的显式样例 ID；
   已有数据库的迁移脚本使用 `GREATEST(实时最大主键 + 1, 1000000)` 作为安全下限。
 
@@ -201,6 +203,9 @@ ASP.NET Core 后端通过 EF Core + Oracle 驱动连接远程 Oracle，**不需�
   审核记录写入和批准占用流水写入；过程不包含权限判断，也不提交事务，权限仍由 API 层负责。
 - `TRG_VENUE_RESERVATION_OVERLAP` 使用 `AFTER STATEMENT` 检查 `[start_at, end_at)` 区间，
   同一场地首尾相接允许通过，重叠则抛出 `ORA-20054`；采用父行锁避免并发审批绕过检查，
-  同时避免普通行级触发器查询变更表产生 mutating table 错误。
+  同时避免普通行级触发器查询变更表产生 mutating table 错误。校验只把本次 INSERT/
+  UPDATE 涉及的预约作为冲突一侧，历史异常由 `verify.sql` 报告并单独治理。
+- `IX_VENUE_RESERVATIONS_VENUE_ID` 支持按场地定位受影响预约；部署触发器前先运行
+  `verify.sql` 中的已通过预约时间核查，确认现有数据状态。
 - 例程的验证必须在隔离 Oracle Schema 中执行 `backend.OracleIntegrationTests`；共享开发库
   只在确认迁移窗口、备份和回滚方案后人工执行迁移。

--- a/database/migrations/20260901_add_budget_and_venue_routines.sql
+++ b/database/migrations/20260901_add_budget_and_venue_routines.sql
@@ -201,7 +201,7 @@ FOR INSERT OR UPDATE OF VENUE_ID, START_AT, END_AT, RESERVATION_STATUS
 ON VENUE_RESERVATIONS
 COMPOUND TRIGGER
   TYPE venue_id_set IS TABLE OF BOOLEAN INDEX BY PLS_INTEGER;
-  TYPE reservation_id_set IS TABLE OF BOOLEAN INDEX BY PLS_INTEGER;
+  TYPE reservation_id_set IS TABLE OF VENUE_RESERVATIONS.RESERVATION_ID%TYPE INDEX BY VARCHAR2(100);
   g_venue_ids venue_id_set;
   g_changed_ids reservation_id_set;
 
@@ -218,17 +218,18 @@ COMPOUND TRIGGER
     END IF;
 
     IF :NEW.RESERVATION_ID IS NOT NULL THEN
-      g_changed_ids(:NEW.RESERVATION_ID) := TRUE;
+      g_changed_ids(TO_CHAR(:NEW.RESERVATION_ID)) := :NEW.RESERVATION_ID;
     END IF;
 
     IF UPDATING AND :OLD.RESERVATION_ID IS NOT NULL THEN
-      g_changed_ids(:OLD.RESERVATION_ID) := TRUE;
+      g_changed_ids(TO_CHAR(:OLD.RESERVATION_ID)) := :OLD.RESERVATION_ID;
     END IF;
   END AFTER EACH ROW;
 
   AFTER STATEMENT IS
     l_venue_id          PLS_INTEGER;
-    l_reservation_id    PLS_INTEGER;
+    l_reservation_key   VARCHAR2(100);
+    l_reservation_id    VENUE_RESERVATIONS.RESERVATION_ID%TYPE;
     l_locked_venue_id   VENUES.VENUE_ID%TYPE;
     l_invalid_count     PLS_INTEGER;
     l_conflict_count    PLS_INTEGER;
@@ -254,8 +255,9 @@ COMPOUND TRIGGER
     -- Only rows changed by this statement participate in the validation. This
     -- keeps historical APPROVED anomalies from blocking unrelated approvals,
     -- while still checking every new or updated row against current data.
-    l_reservation_id := g_changed_ids.FIRST;
-    WHILE l_reservation_id IS NOT NULL LOOP
+    l_reservation_key := g_changed_ids.FIRST;
+    WHILE l_reservation_key IS NOT NULL LOOP
+      l_reservation_id := g_changed_ids(l_reservation_key);
       SELECT COUNT(*)
         INTO l_invalid_count
         FROM venue_reservations reservation
@@ -286,7 +288,7 @@ COMPOUND TRIGGER
         RAISE_APPLICATION_ERROR(-20054, '同一场地的已通过预约时间区间不能重叠。');
       END IF;
 
-      l_reservation_id := g_changed_ids.NEXT(l_reservation_id);
+      l_reservation_key := g_changed_ids.NEXT(l_reservation_key);
     END LOOP;
   END AFTER STATEMENT;
 END TRG_VENUE_RESERVATION_OVERLAP;

--- a/database/migrations/20260901_add_budget_and_venue_routines.sql
+++ b/database/migrations/20260901_add_budget_and_venue_routines.sql
@@ -7,8 +7,44 @@
 --
 -- This migration creates no tables or columns. CREATE OR REPLACE is used so the
 -- script can be rerun after a review fix. Oracle DDL commits implicitly.
+--
+-- Impact scope:
+--   * FN_BUDGET_AVAILABLE_AMOUNT reads budget account and transaction rows.
+--   * SP_REVIEW_BUDGET_APPLICATION updates a pending application and its review
+--     record; an approval also writes one commitment transaction.
+--   * TRG_VENUE_RESERVATION_OVERLAP checks INSERT/UPDATE statements that affect
+--     approved venue reservations and may raise ORA-20052/20053/20054.
+--   * IX_VENUE_RESERVATIONS_VENUE_ID adds an index for the trigger's venue scan.
+--   * Existing business rows are not rewritten by this migration.
+--
+-- Preflight:
+--   Run the approved-reservation interval checks in database/verify.sql before
+--   deployment and record any historical anomalies for separate data cleanup.
+--
+-- Rollback (run as the schema owner after stopping related writes):
+--   DROP INDEX IX_VENUE_RESERVATIONS_VENUE_ID;
+--   DROP TRIGGER TRG_VENUE_RESERVATION_OVERLAP;
+--   DROP PROCEDURE SP_REVIEW_BUDGET_APPLICATION;
+--   DROP FUNCTION FN_BUDGET_AVAILABLE_AMOUNT;
+--   Dropping these objects restores the previous application-only venue
+--   reservation behavior. Restore backed-up definitions instead when the
+--   target schema already had objects with these names.
 
 WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK;
+
+DECLARE
+  l_index_count PLS_INTEGER;
+BEGIN
+  SELECT COUNT(*)
+    INTO l_index_count
+    FROM user_indexes
+   WHERE index_name = 'IX_VENUE_RESERVATIONS_VENUE_ID';
+
+  IF l_index_count = 0 THEN
+    EXECUTE IMMEDIATE 'CREATE INDEX IX_VENUE_RESERVATIONS_VENUE_ID ON VENUE_RESERVATIONS (VENUE_ID)';
+  END IF;
+END;
+/
 
 CREATE OR REPLACE FUNCTION FN_BUDGET_AVAILABLE_AMOUNT (
   p_account_id IN BUDGET_ACCOUNTS.ACCOUNT_ID%TYPE
@@ -53,7 +89,6 @@ IS
   l_amount             BUDGET_APPLICATIONS.AMOUNT%TYPE;
   l_title              BUDGET_APPLICATIONS.TITLE%TYPE;
   l_account_status     BUDGET_ACCOUNTS.ACCOUNT_STATUS%TYPE;
-  l_initial_amount     BUDGET_ACCOUNTS.INITIAL_AMOUNT%TYPE;
   l_available_amount   NUMBER;
   l_user_count         PLS_INTEGER;
 BEGIN
@@ -93,8 +128,8 @@ BEGIN
   END IF;
 
   IF p_approved = 1 THEN
-    SELECT account_status, initial_amount
-      INTO l_account_status, l_initial_amount
+    SELECT account_status
+      INTO l_account_status
       FROM budget_accounts
      WHERE account_id = l_account_id
        AND club_id = l_club_id
@@ -166,7 +201,9 @@ FOR INSERT OR UPDATE OF VENUE_ID, START_AT, END_AT, RESERVATION_STATUS
 ON VENUE_RESERVATIONS
 COMPOUND TRIGGER
   TYPE venue_id_set IS TABLE OF BOOLEAN INDEX BY PLS_INTEGER;
+  TYPE reservation_id_set IS TABLE OF BOOLEAN INDEX BY PLS_INTEGER;
   g_venue_ids venue_id_set;
+  g_changed_ids reservation_id_set;
 
   AFTER EACH ROW IS
   BEGIN
@@ -179,13 +216,22 @@ COMPOUND TRIGGER
        AND UPPER(TRIM(NVL(:OLD.RESERVATION_STATUS, '#'))) = 'APPROVED' THEN
       g_venue_ids(:OLD.VENUE_ID) := TRUE;
     END IF;
+
+    IF :NEW.RESERVATION_ID IS NOT NULL THEN
+      g_changed_ids(:NEW.RESERVATION_ID) := TRUE;
+    END IF;
+
+    IF UPDATING AND :OLD.RESERVATION_ID IS NOT NULL THEN
+      g_changed_ids(:OLD.RESERVATION_ID) := TRUE;
+    END IF;
   END AFTER EACH ROW;
 
   AFTER STATEMENT IS
-    l_venue_id        PLS_INTEGER;
-    l_locked_venue_id VENUES.VENUE_ID%TYPE;
-    l_invalid_count   PLS_INTEGER;
-    l_conflict_count  PLS_INTEGER;
+    l_venue_id          PLS_INTEGER;
+    l_reservation_id    PLS_INTEGER;
+    l_locked_venue_id   VENUES.VENUE_ID%TYPE;
+    l_invalid_count     PLS_INTEGER;
+    l_conflict_count    PLS_INTEGER;
   BEGIN
     l_venue_id := g_venue_ids.FIRST;
     WHILE l_venue_id IS NOT NULL LOOP
@@ -202,10 +248,18 @@ COMPOUND TRIGGER
           RAISE_APPLICATION_ERROR(-20052, '预约引用的场地不存在。');
       END;
 
+      l_venue_id := g_venue_ids.NEXT(l_venue_id);
+    END LOOP;
+
+    -- Only rows changed by this statement participate in the validation. This
+    -- keeps historical APPROVED anomalies from blocking unrelated approvals,
+    -- while still checking every new or updated row against current data.
+    l_reservation_id := g_changed_ids.FIRST;
+    WHILE l_reservation_id IS NOT NULL LOOP
       SELECT COUNT(*)
         INTO l_invalid_count
         FROM venue_reservations reservation
-       WHERE reservation.venue_id = l_venue_id
+       WHERE reservation.reservation_id = l_reservation_id
          AND UPPER(TRIM(NVL(reservation.reservation_status, '#'))) = 'APPROVED'
          AND (reservation.start_at IS NULL
               OR reservation.end_at IS NULL
@@ -221,7 +275,8 @@ COMPOUND TRIGGER
         JOIN venue_reservations right_reservation
           ON right_reservation.venue_id = left_reservation.venue_id
          AND right_reservation.reservation_id > left_reservation.reservation_id
-       WHERE left_reservation.venue_id = l_venue_id
+       WHERE (left_reservation.reservation_id = l_reservation_id
+              OR right_reservation.reservation_id = l_reservation_id)
          AND UPPER(TRIM(NVL(left_reservation.reservation_status, '#'))) = 'APPROVED'
          AND UPPER(TRIM(NVL(right_reservation.reservation_status, '#'))) = 'APPROVED'
          AND left_reservation.start_at < right_reservation.end_at
@@ -231,7 +286,7 @@ COMPOUND TRIGGER
         RAISE_APPLICATION_ERROR(-20054, '同一场地的已通过预约时间区间不能重叠。');
       END IF;
 
-      l_venue_id := g_venue_ids.NEXT(l_venue_id);
+      l_reservation_id := g_changed_ids.NEXT(l_reservation_id);
     END LOOP;
   END AFTER STATEMENT;
 END TRG_VENUE_RESERVATION_OVERLAP;

--- a/database/migrations/20260901_add_budget_and_venue_routines.sql
+++ b/database/migrations/20260901_add_budget_and_venue_routines.sql
@@ -1,0 +1,238 @@
+-- Issue #215: add Oracle routines for budget and venue invariants.
+--
+-- Execution prerequisites:
+--   1. Back up the target CLUBHUB schema.
+--   2. Run as the CLUBHUB schema owner during a maintenance window.
+--   3. Keep the existing application-level budget and venue checks enabled.
+--
+-- This migration creates no tables or columns. CREATE OR REPLACE is used so the
+-- script can be rerun after a review fix. Oracle DDL commits implicitly.
+
+WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK;
+
+CREATE OR REPLACE FUNCTION FN_BUDGET_AVAILABLE_AMOUNT (
+  p_account_id IN BUDGET_ACCOUNTS.ACCOUNT_ID%TYPE
+) RETURN NUMBER
+AUTHID DEFINER
+IS
+  l_initial_amount BUDGET_ACCOUNTS.INITIAL_AMOUNT%TYPE;
+  l_transaction_amount NUMBER;
+BEGIN
+  IF p_account_id IS NULL OR p_account_id <= 0 THEN
+    RAISE_APPLICATION_ERROR(-20040, '经费账户编号必须为正数。');
+  END IF;
+
+  SELECT initial_amount
+    INTO l_initial_amount
+    FROM budget_accounts
+   WHERE account_id = p_account_id;
+
+  SELECT NVL(SUM(amount), 0)
+    INTO l_transaction_amount
+    FROM budget_transactions
+   WHERE account_id = p_account_id;
+
+  RETURN l_initial_amount + l_transaction_amount;
+EXCEPTION
+  WHEN NO_DATA_FOUND THEN
+    RAISE_APPLICATION_ERROR(-20041, '经费账户不存在。');
+END FN_BUDGET_AVAILABLE_AMOUNT;
+/
+
+CREATE OR REPLACE PROCEDURE SP_REVIEW_BUDGET_APPLICATION (
+  p_application_id   IN BUDGET_APPLICATIONS.APPLICATION_ID%TYPE,
+  p_reviewer_user_id IN BUDGET_APPLICATIONS.REVIEWER_USER_ID%TYPE,
+  p_approved         IN NUMBER,
+  p_comment          IN BUDGET_APPLICATIONS.REVIEW_COMMENT%TYPE
+)
+AUTHID DEFINER
+IS
+  l_application_status BUDGET_APPLICATIONS.APPLICATION_STATUS%TYPE;
+  l_account_id         BUDGET_APPLICATIONS.ACCOUNT_ID%TYPE;
+  l_club_id            BUDGET_APPLICATIONS.CLUB_ID%TYPE;
+  l_amount             BUDGET_APPLICATIONS.AMOUNT%TYPE;
+  l_title              BUDGET_APPLICATIONS.TITLE%TYPE;
+  l_account_status     BUDGET_ACCOUNTS.ACCOUNT_STATUS%TYPE;
+  l_initial_amount     BUDGET_ACCOUNTS.INITIAL_AMOUNT%TYPE;
+  l_available_amount   NUMBER;
+  l_user_count         PLS_INTEGER;
+BEGIN
+  IF p_application_id IS NULL OR p_application_id <= 0 THEN
+    RAISE_APPLICATION_ERROR(-20042, '经费申请编号必须为正数。');
+  END IF;
+
+  IF p_reviewer_user_id IS NULL OR p_reviewer_user_id <= 0 THEN
+    RAISE_APPLICATION_ERROR(-20043, '审核人编号必须为正数。');
+  END IF;
+
+  IF p_approved IS NULL OR p_approved NOT IN (0, 1) THEN
+    RAISE_APPLICATION_ERROR(-20044, '审核结果必须为 0 或 1。');
+  END IF;
+
+  IF p_comment IS NOT NULL AND LENGTH(p_comment) > 255 THEN
+    RAISE_APPLICATION_ERROR(-20045, '审批意见不能超过 255 个字符。');
+  END IF;
+
+  SELECT application_status, account_id, club_id, amount, title
+    INTO l_application_status, l_account_id, l_club_id, l_amount, l_title
+    FROM budget_applications
+   WHERE application_id = p_application_id
+   FOR UPDATE;
+
+  IF LOWER(TRIM(l_application_status)) <> 'pending' THEN
+    RAISE_APPLICATION_ERROR(-20046, '只有待审核的经费申请才能审核。');
+  END IF;
+
+  SELECT COUNT(*)
+    INTO l_user_count
+    FROM users
+   WHERE user_id = p_reviewer_user_id;
+
+  IF l_user_count = 0 THEN
+    RAISE_APPLICATION_ERROR(-20047, '审核人不存在。');
+  END IF;
+
+  IF p_approved = 1 THEN
+    SELECT account_status, initial_amount
+      INTO l_account_status, l_initial_amount
+      FROM budget_accounts
+     WHERE account_id = l_account_id
+       AND club_id = l_club_id
+     FOR UPDATE;
+
+    IF LOWER(TRIM(l_account_status)) <> 'active' THEN
+      RAISE_APPLICATION_ERROR(-20048, '经费账户已关闭，不能审批通过新的经费申请。');
+    END IF;
+
+    l_available_amount := FN_BUDGET_AVAILABLE_AMOUNT(l_account_id);
+    IF l_amount > l_available_amount THEN
+      RAISE_APPLICATION_ERROR(-20049, '经费账户余额不足，不能审批通过该申请。');
+    END IF;
+  END IF;
+
+  UPDATE budget_applications
+     SET application_status = CASE WHEN p_approved = 1 THEN 'approved' ELSE 'rejected' END,
+         reviewer_user_id = p_reviewer_user_id,
+         review_comment = p_comment,
+         reviewed_at = SYSDATE,
+         updated_at = SYSDATE
+   WHERE application_id = p_application_id;
+
+  INSERT INTO budget_review_records (
+    application_id,
+    reviewer_user_id,
+    approved,
+    comment_text,
+    reviewed_at
+  ) VALUES (
+    p_application_id,
+    p_reviewer_user_id,
+    p_approved,
+    p_comment,
+    SYSDATE
+  );
+
+  IF p_approved = 1 THEN
+    INSERT INTO budget_transactions (
+      account_id,
+      application_id,
+      club_id,
+      transaction_type,
+      amount,
+      description,
+      occurred_at,
+      created_at
+    ) VALUES (
+      l_account_id,
+      p_application_id,
+      l_club_id,
+      'commitment',
+      -l_amount,
+      '经费申请通过：' || l_title,
+      SYSDATE,
+      SYSDATE
+    );
+  END IF;
+EXCEPTION
+  WHEN NO_DATA_FOUND THEN
+    RAISE_APPLICATION_ERROR(-20050, '经费申请或对应账户不存在。');
+  WHEN DUP_VAL_ON_INDEX THEN
+    RAISE_APPLICATION_ERROR(-20051, '该经费申请已经生成占用流水。');
+END SP_REVIEW_BUDGET_APPLICATION;
+/
+
+CREATE OR REPLACE TRIGGER TRG_VENUE_RESERVATION_OVERLAP
+FOR INSERT OR UPDATE OF VENUE_ID, START_AT, END_AT, RESERVATION_STATUS
+ON VENUE_RESERVATIONS
+COMPOUND TRIGGER
+  TYPE venue_id_set IS TABLE OF BOOLEAN INDEX BY PLS_INTEGER;
+  g_venue_ids venue_id_set;
+
+  AFTER EACH ROW IS
+  BEGIN
+    IF :NEW.VENUE_ID IS NOT NULL
+       AND UPPER(TRIM(NVL(:NEW.RESERVATION_STATUS, '#'))) = 'APPROVED' THEN
+      g_venue_ids(:NEW.VENUE_ID) := TRUE;
+    END IF;
+
+    IF UPDATING AND :OLD.VENUE_ID IS NOT NULL
+       AND UPPER(TRIM(NVL(:OLD.RESERVATION_STATUS, '#'))) = 'APPROVED' THEN
+      g_venue_ids(:OLD.VENUE_ID) := TRUE;
+    END IF;
+  END AFTER EACH ROW;
+
+  AFTER STATEMENT IS
+    l_venue_id        PLS_INTEGER;
+    l_locked_venue_id VENUES.VENUE_ID%TYPE;
+    l_invalid_count   PLS_INTEGER;
+    l_conflict_count  PLS_INTEGER;
+  BEGIN
+    l_venue_id := g_venue_ids.FIRST;
+    WHILE l_venue_id IS NOT NULL LOOP
+      -- Lock the parent row in ascending venue order. This serializes approvals
+      -- for the same venue without querying the mutating child table per row.
+      BEGIN
+        SELECT venue_id
+          INTO l_locked_venue_id
+          FROM venues
+         WHERE venue_id = l_venue_id
+         FOR UPDATE;
+      EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+          RAISE_APPLICATION_ERROR(-20052, '预约引用的场地不存在。');
+      END;
+
+      SELECT COUNT(*)
+        INTO l_invalid_count
+        FROM venue_reservations reservation
+       WHERE reservation.venue_id = l_venue_id
+         AND UPPER(TRIM(NVL(reservation.reservation_status, '#'))) = 'APPROVED'
+         AND (reservation.start_at IS NULL
+              OR reservation.end_at IS NULL
+              OR reservation.start_at >= reservation.end_at);
+
+      IF l_invalid_count > 0 THEN
+        RAISE_APPLICATION_ERROR(-20053, '已通过预约的时间区间无效。');
+      END IF;
+
+      SELECT COUNT(*)
+        INTO l_conflict_count
+        FROM venue_reservations left_reservation
+        JOIN venue_reservations right_reservation
+          ON right_reservation.venue_id = left_reservation.venue_id
+         AND right_reservation.reservation_id > left_reservation.reservation_id
+       WHERE left_reservation.venue_id = l_venue_id
+         AND UPPER(TRIM(NVL(left_reservation.reservation_status, '#'))) = 'APPROVED'
+         AND UPPER(TRIM(NVL(right_reservation.reservation_status, '#'))) = 'APPROVED'
+         AND left_reservation.start_at < right_reservation.end_at
+         AND right_reservation.start_at < left_reservation.end_at;
+
+      IF l_conflict_count > 0 THEN
+        RAISE_APPLICATION_ERROR(-20054, '同一场地的已通过预约时间区间不能重叠。');
+      END IF;
+
+      l_venue_id := g_venue_ids.NEXT(l_venue_id);
+    END LOOP;
+  END AFTER STATEMENT;
+END TRG_VENUE_RESERVATION_OVERLAP;
+/

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -961,3 +961,7 @@ ALTER TABLE FORUM_POSTS ADD FOREIGN KEY (user_id) REFERENCES USERS (user_id) DEF
 ALTER TABLE FORUM_POSTS ADD FOREIGN KEY (parent_post_id) REFERENCES FORUM_POSTS (post_id) DEFERRABLE INITIALLY IMMEDIATE;
 
 ALTER TABLE OPERATION_LOGS ADD FOREIGN KEY (user_id) REFERENCES USERS (user_id) DEFERRABLE INITIALLY IMMEDIATE;
+
+-- Oracle routines for derived budget balance, budget approval and venue overlap.
+-- The included migration is also safe to rerun on an existing database.
+@@migrations/20260901_add_budget_and_venue_routines.sql

--- a/database/verify.sql
+++ b/database/verify.sql
@@ -259,6 +259,24 @@ FROM budget_transactions
 WHERE transaction_type NOT IN ('commitment', 'expense', 'refund', 'adjustment')
    OR amount = 0;
 
+-- 以下查询应返回 0 行：已通过场地预约不得存在无效时间区间或跨记录重叠。
+SELECT reservation_id, venue_id, start_at, end_at, reservation_status
+FROM venue_reservations
+WHERE UPPER(TRIM(NVL(reservation_status, '#'))) = 'APPROVED'
+  AND (start_at IS NULL OR end_at IS NULL OR start_at >= end_at);
+
+SELECT left_reservation.reservation_id AS left_reservation_id,
+       right_reservation.reservation_id AS right_reservation_id,
+       left_reservation.venue_id
+FROM venue_reservations left_reservation
+JOIN venue_reservations right_reservation
+  ON right_reservation.venue_id = left_reservation.venue_id
+ AND right_reservation.reservation_id > left_reservation.reservation_id
+WHERE UPPER(TRIM(NVL(left_reservation.reservation_status, '#'))) = 'APPROVED'
+  AND UPPER(TRIM(NVL(right_reservation.reservation_status, '#'))) = 'APPROVED'
+  AND left_reservation.start_at < right_reservation.end_at
+  AND right_reservation.start_at < left_reservation.end_at;
+
 SELECT venue_id, venue_status, maintenance_until
 FROM venues
 WHERE maintenance_until IS NOT NULL
@@ -646,3 +664,23 @@ WHERE document.published_by_user_id IS NOT NULL
     FROM users publisher
     WHERE publisher.user_id = document.published_by_user_id
   );
+
+-- 以下查询应返回 3 行，且三个数据库例程的状态均为 VALID。
+SELECT object_name, object_type, status
+FROM user_objects
+WHERE object_name IN (
+  'FN_BUDGET_AVAILABLE_AMOUNT',
+  'SP_REVIEW_BUDGET_APPLICATION',
+  'TRG_VENUE_RESERVATION_OVERLAP'
+)
+ORDER BY object_type, object_name;
+
+-- 以下查询应返回 0 行：例程编译错误需要先修复，再进入业务验收。
+SELECT name, type, line, position, text
+FROM user_errors
+WHERE name IN (
+  'FN_BUDGET_AVAILABLE_AMOUNT',
+  'SP_REVIEW_BUDGET_APPLICATION',
+  'TRG_VENUE_RESERVATION_OVERLAP'
+)
+ORDER BY name, sequence;

--- a/database/verify.sql
+++ b/database/verify.sql
@@ -665,6 +665,12 @@ WHERE document.published_by_user_id IS NOT NULL
     WHERE publisher.user_id = document.published_by_user_id
   );
 
+-- 以下查询应返回 1 行：触发器按场地筛选预约，使用该索引减少历史记录扫描。
+SELECT index_name, table_name, uniqueness, status
+FROM user_indexes
+WHERE index_name = 'IX_VENUE_RESERVATIONS_VENUE_ID'
+  AND table_name = 'VENUE_RESERVATIONS';
+
 -- 以下查询应返回 3 行，且三个数据库例程的状态均为 VALID。
 SELECT object_name, object_type, status
 FROM user_objects


### PR DESCRIPTION
## 改动内容

- 新增 FN_BUDGET_AVAILABLE_AMOUNT，按账户初始额度和经费流水汇总计算可用余额。
- 新增 SP_REVIEW_BUDGET_APPLICATION，在调用方事务中完成待审核申请锁定、额度校验、状态更新、审核记录和批准占用流水写入。
- 新增 TRG_VENUE_RESERVATION_OVERLAP，使用 Oracle compound trigger 在语句级阻止同一场地已通过预约的时间区间重叠，并允许首尾相接的半开区间。
- 新增 VENUE_ID 索引；触发器只以本次 INSERT/UPDATE 涉及的预约作为冲突校验一侧，历史异常由 verify.sql 单独报告。
- 保留现有 API 层权限与预检查，并将数据库冲突错误映射为统一的场地预约冲突响应。
- 同步 schema.sql、增量 migration、verify.sql、Oracle 集成测试和数据库说明。

## 改动原因

当前经费余额和场地预约冲突主要由应用层处理。新增例程把经费闭环的派生余额、审批原子性和场地跨行时间约束落实到 Oracle 事实层，降低绕过应用写入时的数据一致性风险，也为课程设计验收提供可复核的数据库对象。

## 关联 Issue

Closes #215

## 风险与回滚

- 不新增或修改表、字段和外键；迁移创建或替换三个数据库例程，并幂等创建 VENUE_ID 索引。
- Oracle DDL 会自动提交，部署前按数据库说明备份并在维护窗口执行；如需回滚，可恢复例程定义或撤销本次 migration 中的对象。
- 回滚顺序为删除 VENUE_ID 索引、触发器、存储过程和函数；若目标库原有同名对象，应优先恢复备份定义。
- 触发器与现有服务层冲突检查保持同一套 [start_at, end_at) 语义。

## 测试说明

- dotnet build backend/ClubHub.Api.csproj --configuration Release --no-restore
- dotnet test backend.Tests/ClubHub.Api.Tests.csproj --configuration Release --no-restore --no-build（249 项通过）
- dotnet test backend.OracleIntegrationTests/ClubHub.Api.OracleIntegrationTests.csproj --configuration Release --no-restore（未配置隔离 Schema 时 5 项按约定跳过）
- 共享开发库只做了受控事务冒烟测试：函数余额 100→60、审批流水 -40、余额不足 ORA-20049、预约重叠 ORA-20054、状态更新重叠 ORA-20054、首尾相接通过，全部测试数据已回滚。
- 线上 /budgets 与 /venue-reservations 页面回归通过，截图和说明已整理在提交目录的测试记录中。

## UI 改动

无前端代码改动；现有经费管理和场地预约页面保持可用。

## 检查清单

- [x] 已阅读并遵循仓库贡献规范。
- [x] 未修改配置密钥或提交敏感信息。
- [x] 数据库脚本、验证脚本与迁移说明已同步。
- [x] 新增 Oracle 专属行为测试，且自动化测试仅面向隔离 Schema。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增预算余额计算与审批流程，支持余额不足等校验。
  - 新增场地预约时间有效性及重叠检测，防止冲突预约通过审批。
- **问题修复**
  - 场地预约冲突或数据无效时，审批接口返回明确提示。
- **数据库与部署**
  - 增强预约数据核查、索引验证及数据库例程部署检查，提升一致性与可靠性。
- **测试**
  - 增加预算审批、余额校验、预约冲突及边界场景的集成测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->