### PR TITLE
fix(evaluation): 保留评奖记录语义并收敛考核例程

### DIFF
--- a/backend.OracleIntegrationTests/EvaluationRoutineOracleTests.cs
+++ b/backend.OracleIntegrationTests/EvaluationRoutineOracleTests.cs
@@ -128,7 +128,21 @@ public sealed class EvaluationRoutineOracleTests
                 0,
                 90,
                 90,
-                "待提升");
+                "优秀");
+            Assert.Equal(
+                90m,
+                await ScalarDecimalAsync(
+                    connection,
+                    transaction,
+                    "SELECT total_score FROM evaluations WHERE evaluation_id = :evaluationId",
+                    ("evaluationId", AwardEvaluationId)));
+            Assert.Equal(
+                "优秀",
+                await ScalarStringAsync(
+                    connection,
+                    transaction,
+                    "SELECT grade FROM evaluations WHERE evaluation_id = :evaluationId",
+                    ("evaluationId", AwardEvaluationId)));
             await InsertEvaluationAsync(
                 connection,
                 transaction,
@@ -157,10 +171,46 @@ public sealed class EvaluationRoutineOracleTests
                     101, 0, 0, 0, 101, '待提升', 'draft', SYSDATE
                 )
                 """,
-                -20062,
+                -20162,
                 ("evaluationId", InvalidScoreId),
                 ("clubId", ClubId),
                 ("memberId", MemberOneId));
+
+            await ExpectRoutineErrorAsync(
+                connection,
+                transaction,
+                "BEGIN SP_PUBLISH_TERM_EVALUATIONS(:clubId, :termName, :evaluatorId); END;",
+                -20166,
+                ("clubId", 0),
+                ("termName", "2026秋"),
+                ("evaluatorId", EvaluatorId));
+
+            await ExpectRoutineErrorAsync(
+                connection,
+                transaction,
+                "BEGIN SP_PUBLISH_TERM_EVALUATIONS(:clubId, :termName, :evaluatorId); END;",
+                -20167,
+                ("clubId", ClubId),
+                ("termName", ""),
+                ("evaluatorId", EvaluatorId));
+
+            await ExpectRoutineErrorAsync(
+                connection,
+                transaction,
+                "BEGIN SP_PUBLISH_TERM_EVALUATIONS(:clubId, :termName, :evaluatorId); END;",
+                -20168,
+                ("clubId", ClubId),
+                ("termName", "2026秋"),
+                ("evaluatorId", 0));
+
+            await ExpectRoutineErrorAsync(
+                connection,
+                transaction,
+                "BEGIN SP_PUBLISH_TERM_EVALUATIONS(:clubId, :termName, :evaluatorId); END;",
+                -20169,
+                ("clubId", 9999999),
+                ("termName", "2026秋"),
+                ("evaluatorId", EvaluatorId));
 
             await ExpectRoutineErrorAsync(
                 connection,
@@ -170,7 +220,7 @@ public sealed class EvaluationRoutineOracleTests
                     SP_PUBLISH_TERM_EVALUATIONS(:clubId, :termName, :evaluatorId);
                 END;
                 """,
-                -20070,
+                -20170,
                 ("clubId", ClubId),
                 ("termName", "2026秋"),
                 ("evaluatorId", 9999999));
@@ -252,7 +302,7 @@ public sealed class EvaluationRoutineOracleTests
                     SP_PUBLISH_TERM_EVALUATIONS(:clubId, :termName, :evaluatorId);
                 END;
                 """,
-                -20071,
+                -20171,
                 ("clubId", ClubId),
                 ("termName", "2026秋"),
                 ("evaluatorId", EvaluatorId));

--- a/backend.OracleIntegrationTests/EvaluationRoutineOracleTests.cs
+++ b/backend.OracleIntegrationTests/EvaluationRoutineOracleTests.cs
@@ -127,10 +127,10 @@ public sealed class EvaluationRoutineOracleTests
                 0,
                 0,
                 90,
-                90,
+                89,
                 "优秀");
             Assert.Equal(
-                90m,
+                89m,
                 await ScalarDecimalAsync(
                     connection,
                     transaction,

--- a/database/README.md
+++ b/database/README.md
@@ -79,10 +79,11 @@
     过程不自行提交事务，由调用方控制提交或回滚。触发器在语句级检查同一场地已通过预约
     的半开时间区间，应在现有应用层校验之后作为数据库事实约束使用。部署前先运行
     `verify.sql` 中的已通过预约时间核查，记录历史异常后再执行迁移。
-15. `20260903_add_evaluation_consistency_routines.sql`：统一成员考核的总分与等级计算，
+15. `20260903_add_evaluation_consistency_routines.sql`：统一学期成员考核的总分与等级计算，
     拒绝超出 0 至 100 的分项分数，并提供按社团、学期原子公示草稿考核的过程。脚本不改变
-    表结构，但会将已有考核的空分项归零，并按当前规则重新计算总分和等级；执行前必须备份，
-    暂停考核生成、编辑和公示写入，并先确认不存在超出范围的历史分项。
+    表结构，但会将已有学期考核的空分项归零，并按当前规则重新计算总分和等级；`award` 类型
+    的评奖记录保持原有语义。执行前必须备份，暂停考核生成、编辑和公示写入，并先确认不存在
+    超出范围的历史学期考核分项。
 
 迁移完成后执行 `verify.sql`，确认 sequence、唯一索引、列默认值、部门/小组外码、
 经费账户唯一性、审批通过申请流水、幂等台账约束和回填结果均已生效。
@@ -162,8 +163,8 @@
 17. 执行 `migrations/20260831_add_venue_maintenance_until.sql`。执行前备份并暂停场地状态变更，
     执行后运行 `verify.sql` 检查 `VENUES.MAINTENANCE_UNTIL` 和状态一致性约束，再恢复场地状态写入。
 18. 执行 `migrations/20260903_add_evaluation_consistency_routines.sql`。执行前备份并暂停成员考核
-    写入；若脚本报告分项超出范围，先人工核对并修正来源数据。执行后运行 `verify.sql`，确认
-    考核一致性查询返回 0 行、三个新增例程均为 `VALID`，再恢复考核写入。
+    写入；若脚本报告学期考核分项超出范围，先人工核对并修正来源数据。执行后运行 `verify.sql`，
+    确认学期考核一致性查询返回 0 行、三个新增例程均为 `VALID`，再恢复考核写入。
 
 Oracle DDL 会自动提交，迁移脚本不能被视为可事务回滚。执行前应确认连接信息并保留数据库备份；CI 不会自动执行此迁移。
 
@@ -213,13 +214,14 @@ ASP.NET Core 后端通过 EF Core + Oracle 驱动连接远程 Oracle，**不需�
   UPDATE 涉及的预约作为冲突一侧，历史异常由 `verify.sql` 报告并单独治理。
 - `IX_VENUE_RESERVATIONS_VENUE_ID` 支持按场地定位受影响预约；部署触发器前先运行
   `verify.sql` 中的已通过预约时间核查，确认现有数据状态。
-- `FN_EVALUATION_GRADE(total_score)` 统一使用 320/260/200 三个分界计算“优秀”“良好”
+- `FN_EVALUATION_GRADE(total_score)` 为学期考核统一使用 320/260/200 三个分界计算“优秀”“良好”
   “合格”“待提升”，并拒绝 0 至 400 之外的总分。
-- `TRG_EVALUATIONS_DERIVE_SCORE` 在每次写入 `EVALUATIONS` 时将空分项归零，校验四项分数均在
-  0 至 100 之间，并覆盖写入方提供的 `total_score` 和 `grade`，避免 API、导入脚本和人工维护
-  使用不同计算规则。
+- `TRG_EVALUATIONS_DERIVE_SCORE` 只在写入 `evaluation_type=semester` 的 `EVALUATIONS` 时将空分项
+  归零，校验四项分数均在 0 至 100 之间，并覆盖写入方提供的 `total_score` 和 `grade`；`award`
+  类型记录由评奖评优流程维护，不被学期考核规则改写。
 - `SP_PUBLISH_TERM_EVALUATIONS` 仅把指定社团、指定学期的 `semester/draft` 考核批量更新为
-  `published` 并记录考核人；过程锁定社团范围、不自行提交事务，也不涉及评奖申请或考核奖项
-  来源，权限检查和最终提交仍由调用方负责。
+  `published` 并记录考核人；过程锁定社团范围、不自行提交事务，也不涉及评奖申请。评奖申请
+  只有在其归档或公示后，才通过 `EVALUATION_AWARD_SOURCES` 作为学期考核的奖项分来源，权限
+  检查和最终提交仍由调用方负责。
 - 例程的验证必须在隔离 Oracle Schema 中执行 `backend.OracleIntegrationTests`；共享开发库
   只在确认迁移窗口、备份和回滚方案后人工执行迁移。

--- a/database/migrations/20260903_add_evaluation_consistency_routines.sql
+++ b/database/migrations/20260903_add_evaluation_consistency_routines.sql
@@ -6,11 +6,12 @@
 --   3. Run as the CLUBHUB schema owner during a maintenance window.
 --
 -- Impact scope:
---   * Existing EVALUATIONS rows are normalized: null component scores become 0,
---     total_score is recalculated and grade is derived from the current rule.
+--   * Existing semester EVALUATIONS rows are normalized: null component scores
+--     become 0, total_score is recalculated and grade is derived from the
+--     current rule. Award evaluation records keep their award-specific meaning.
 --   * FN_EVALUATION_GRADE provides the shared score-to-grade rule.
 --   * TRG_EVALUATIONS_DERIVE_SCORE rejects out-of-range component scores and
---     derives component defaults, total_score and grade for every future write.
+--     derives component defaults, total_score and grade for future semester writes.
 --   * SP_PUBLISH_TERM_EVALUATIONS publishes one club and term in one statement.
 --   * No tables, columns, constraints or indexes are added or removed.
 --
@@ -35,14 +36,17 @@ BEGIN
   SELECT COUNT(*)
     INTO l_invalid_score_count
     FROM evaluations
-   WHERE NVL(activity_score, 0) NOT BETWEEN 0 AND 100
+   WHERE LOWER(TRIM(NVL(evaluation_type, '#'))) = 'semester'
+     AND (
+            NVL(activity_score, 0) NOT BETWEEN 0 AND 100
       OR NVL(task_score, 0) NOT BETWEEN 0 AND 100
       OR NVL(learning_score, 0) NOT BETWEEN 0 AND 100
-      OR NVL(award_score, 0) NOT BETWEEN 0 AND 100;
+      OR NVL(award_score, 0) NOT BETWEEN 0 AND 100
+         );
 
   IF l_invalid_score_count > 0 THEN
     RAISE_APPLICATION_ERROR(
-      -20060,
+      -20160,
       '存在超出 0 至 100 范围的考核分项，请先完成数据核查。'
     );
   END IF;
@@ -58,7 +62,7 @@ IS
   l_total_score NUMBER := NVL(p_total_score, 0);
 BEGIN
   IF l_total_score < 0 OR l_total_score > 400 THEN
-    RAISE_APPLICATION_ERROR(-20061, '考核总分必须处于 0 至 400 分范围内。');
+    RAISE_APPLICATION_ERROR(-20161, '考核总分必须处于 0 至 400 分范围内。');
   END IF;
 
   IF l_total_score >= 320 THEN
@@ -87,6 +91,23 @@ UPDATE evaluations
          + NVL(task_score, 0)
          + NVL(learning_score, 0)
          + NVL(award_score, 0)
+       )
+ WHERE LOWER(TRIM(NVL(evaluation_type, '#'))) = 'semester'
+   AND (
+         activity_score IS NULL
+      OR task_score IS NULL
+      OR learning_score IS NULL
+      OR award_score IS NULL
+      OR NVL(total_score, -1) <> NVL(activity_score, 0)
+                                      + NVL(task_score, 0)
+                                      + NVL(learning_score, 0)
+                                      + NVL(award_score, 0)
+      OR NVL(TRIM(grade), '#') <> FN_EVALUATION_GRADE(
+           NVL(activity_score, 0)
+           + NVL(task_score, 0)
+           + NVL(learning_score, 0)
+           + NVL(award_score, 0)
+         )
        );
 
 CREATE OR REPLACE TRIGGER TRG_EVALUATIONS_DERIVE_SCORE
@@ -98,36 +119,38 @@ DECLARE
   l_learning_score EVALUATIONS.LEARNING_SCORE%TYPE;
   l_award_score    EVALUATIONS.AWARD_SCORE%TYPE;
 BEGIN
-  l_activity_score := NVL(:NEW.ACTIVITY_SCORE, 0);
-  l_task_score := NVL(:NEW.TASK_SCORE, 0);
-  l_learning_score := NVL(:NEW.LEARNING_SCORE, 0);
-  l_award_score := NVL(:NEW.AWARD_SCORE, 0);
+  IF LOWER(TRIM(NVL(:NEW.EVALUATION_TYPE, '#'))) = 'semester' THEN
+    l_activity_score := NVL(:NEW.ACTIVITY_SCORE, 0);
+    l_task_score := NVL(:NEW.TASK_SCORE, 0);
+    l_learning_score := NVL(:NEW.LEARNING_SCORE, 0);
+    l_award_score := NVL(:NEW.AWARD_SCORE, 0);
 
-  IF l_activity_score NOT BETWEEN 0 AND 100 THEN
-    RAISE_APPLICATION_ERROR(-20062, '活动表现分必须处于 0 至 100 分范围内。');
+    IF l_activity_score NOT BETWEEN 0 AND 100 THEN
+      RAISE_APPLICATION_ERROR(-20162, '活动表现分必须处于 0 至 100 分范围内。');
+    END IF;
+
+    IF l_task_score NOT BETWEEN 0 AND 100 THEN
+      RAISE_APPLICATION_ERROR(-20163, '任务贡献分必须处于 0 至 100 分范围内。');
+    END IF;
+
+    IF l_learning_score NOT BETWEEN 0 AND 100 THEN
+      RAISE_APPLICATION_ERROR(-20164, '学习成长分必须处于 0 至 100 分范围内。');
+    END IF;
+
+    IF l_award_score NOT BETWEEN 0 AND 100 THEN
+      RAISE_APPLICATION_ERROR(-20165, '获奖加分必须处于 0 至 100 分范围内。');
+    END IF;
+
+    :NEW.ACTIVITY_SCORE := l_activity_score;
+    :NEW.TASK_SCORE := l_task_score;
+    :NEW.LEARNING_SCORE := l_learning_score;
+    :NEW.AWARD_SCORE := l_award_score;
+    :NEW.TOTAL_SCORE := l_activity_score
+                      + l_task_score
+                      + l_learning_score
+                      + l_award_score;
+    :NEW.GRADE := FN_EVALUATION_GRADE(:NEW.TOTAL_SCORE);
   END IF;
-
-  IF l_task_score NOT BETWEEN 0 AND 100 THEN
-    RAISE_APPLICATION_ERROR(-20063, '任务贡献分必须处于 0 至 100 分范围内。');
-  END IF;
-
-  IF l_learning_score NOT BETWEEN 0 AND 100 THEN
-    RAISE_APPLICATION_ERROR(-20064, '学习成长分必须处于 0 至 100 分范围内。');
-  END IF;
-
-  IF l_award_score NOT BETWEEN 0 AND 100 THEN
-    RAISE_APPLICATION_ERROR(-20065, '获奖加分必须处于 0 至 100 分范围内。');
-  END IF;
-
-  :NEW.ACTIVITY_SCORE := l_activity_score;
-  :NEW.TASK_SCORE := l_task_score;
-  :NEW.LEARNING_SCORE := l_learning_score;
-  :NEW.AWARD_SCORE := l_award_score;
-  :NEW.TOTAL_SCORE := l_activity_score
-                    + l_task_score
-                    + l_learning_score
-                    + l_award_score;
-  :NEW.GRADE := FN_EVALUATION_GRADE(:NEW.TOTAL_SCORE);
 END TRG_EVALUATIONS_DERIVE_SCORE;
 /
 
@@ -142,15 +165,15 @@ IS
   l_evaluator_count PLS_INTEGER;
 BEGIN
   IF p_club_id IS NULL OR p_club_id <= 0 THEN
-    RAISE_APPLICATION_ERROR(-20066, '社团编号必须为正数。');
+    RAISE_APPLICATION_ERROR(-20166, '社团编号必须为正数。');
   END IF;
 
   IF p_term_name IS NULL OR LENGTH(TRIM(p_term_name)) = 0 THEN
-    RAISE_APPLICATION_ERROR(-20067, '考核学期不能为空。');
+    RAISE_APPLICATION_ERROR(-20167, '考核学期不能为空。');
   END IF;
 
   IF p_evaluator_user_id IS NULL OR p_evaluator_user_id <= 0 THEN
-    RAISE_APPLICATION_ERROR(-20068, '考核人编号必须为正数。');
+    RAISE_APPLICATION_ERROR(-20168, '考核人编号必须为正数。');
   END IF;
 
   BEGIN
@@ -161,7 +184,7 @@ BEGIN
      FOR UPDATE;
   EXCEPTION
     WHEN NO_DATA_FOUND THEN
-      RAISE_APPLICATION_ERROR(-20069, '待公示考核所属社团不存在。');
+      RAISE_APPLICATION_ERROR(-20169, '待公示考核所属社团不存在。');
   END;
 
   SELECT COUNT(*)
@@ -170,7 +193,7 @@ BEGIN
    WHERE user_id = p_evaluator_user_id;
 
   IF l_evaluator_count = 0 THEN
-    RAISE_APPLICATION_ERROR(-20070, '考核人不存在。');
+    RAISE_APPLICATION_ERROR(-20170, '考核人不存在。');
   END IF;
 
   UPDATE evaluations
@@ -182,7 +205,7 @@ BEGIN
      AND LOWER(TRIM(NVL(public_status, '#'))) = 'draft';
 
   IF SQL%ROWCOUNT = 0 THEN
-    RAISE_APPLICATION_ERROR(-20071, '指定社团和学期没有可公示的草稿考核。');
+    RAISE_APPLICATION_ERROR(-20171, '指定社团和学期没有可公示的草稿考核。');
   END IF;
 END SP_PUBLISH_TERM_EVALUATIONS;
 /

--- a/database/verify.sql
+++ b/database/verify.sql
@@ -674,35 +674,38 @@ SELECT evaluation_id,
        total_score,
        grade
 FROM evaluations
-WHERE activity_score IS NULL
-   OR task_score IS NULL
-   OR learning_score IS NULL
-   OR award_score IS NULL
-   OR total_score IS NULL
-   OR NVL(activity_score, 0) NOT BETWEEN 0 AND 100
-   OR NVL(task_score, 0) NOT BETWEEN 0 AND 100
-   OR NVL(learning_score, 0) NOT BETWEEN 0 AND 100
-   OR NVL(award_score, 0) NOT BETWEEN 0 AND 100
-   OR total_score <> NVL(activity_score, 0)
-                    + NVL(task_score, 0)
-                    + NVL(learning_score, 0)
-                    + NVL(award_score, 0)
-   OR NVL(TRIM(grade), '#') <>
-      CASE
-        WHEN NVL(activity_score, 0)
-           + NVL(task_score, 0)
-           + NVL(learning_score, 0)
-           + NVL(award_score, 0) >= 320 THEN '优秀'
-        WHEN NVL(activity_score, 0)
-           + NVL(task_score, 0)
-           + NVL(learning_score, 0)
-           + NVL(award_score, 0) >= 260 THEN '良好'
-        WHEN NVL(activity_score, 0)
-           + NVL(task_score, 0)
-           + NVL(learning_score, 0)
-           + NVL(award_score, 0) >= 200 THEN '合格'
-        ELSE '待提升'
-      END;
+WHERE LOWER(TRIM(NVL(evaluation_type, '#'))) = 'semester'
+  AND (
+       activity_score IS NULL
+    OR task_score IS NULL
+    OR learning_score IS NULL
+    OR award_score IS NULL
+    OR total_score IS NULL
+    OR NVL(activity_score, 0) NOT BETWEEN 0 AND 100
+    OR NVL(task_score, 0) NOT BETWEEN 0 AND 100
+    OR NVL(learning_score, 0) NOT BETWEEN 0 AND 100
+    OR NVL(award_score, 0) NOT BETWEEN 0 AND 100
+    OR total_score <> NVL(activity_score, 0)
+                         + NVL(task_score, 0)
+                         + NVL(learning_score, 0)
+                         + NVL(award_score, 0)
+    OR NVL(TRIM(grade), '#') <>
+       CASE
+         WHEN NVL(activity_score, 0)
+            + NVL(task_score, 0)
+            + NVL(learning_score, 0)
+            + NVL(award_score, 0) >= 320 THEN '优秀'
+         WHEN NVL(activity_score, 0)
+            + NVL(task_score, 0)
+            + NVL(learning_score, 0)
+            + NVL(award_score, 0) >= 260 THEN '良好'
+         WHEN NVL(activity_score, 0)
+            + NVL(task_score, 0)
+            + NVL(learning_score, 0)
+            + NVL(award_score, 0) >= 200 THEN '合格'
+         ELSE '待提升'
+       END
+      );
 
 -- 以下查询应返回 1 行：触发器按场地筛选预约，使用该索引减少历史记录扫描。
 SELECT index_name, table_name, uniqueness, status


### PR DESCRIPTION
## 改动内容

- 将评估一致性迁移、触发器和校验查询限制在 `evaluation_type=semester` 的成员学期考核。
- 保留 `award` 类型评奖记录的原有分数、等级和业务语义；评奖结果只通过 `EVALUATION_AWARD_SOURCES` 作为学期考核的奖项分来源。
- 为本迁移分配独立的 Oracle 错误码 `-20160` 至 `-20171`，避免与已有迁移复用 `-20061` 至 `-20063`。
- 仅更新真正不一致的历史学期考核行，并补充批量公示四个参数校验分支和评奖记录不被改写的 Oracle 回归断言。
- 同步 `database/README.md` 与 `database/verify.sql` 的适用范围和验证说明。

## 改动原因

PR #218 的原实现会把 `EVALUATIONS` 中的评奖记录也套用学期考核的 0—400 分等级规则，可能改变评奖记录原有含义。CodeRabbit 还指出迁移错误码与既有脚本重复、历史规范化 UPDATE 会重写所有行、批量公示参数校验覆盖不足。本 PR 在不改变表结构的前提下收敛这些边界。

---

## 关联 Issue

Part of #217

## 审查关注点

- 触发器是否只派生 `semester` 类型记录，并保留 `award` 类型记录。
- 历史校正的 `WHERE` 条件是否只命中真正不一致的学期考核。
- 新错误码是否与数据库现有迁移不冲突。
- 批量公示参数错误是否均在修改数据前返回。

## UI 改动

无前端改动。

## 测试说明

- `dotnet build backend.OracleIntegrationTests/ClubHub.Api.OracleIntegrationTests.csproj --configuration Release --no-restore`：通过；仅有仓库已有生成模型 nullable 警告。
- `dotnet test backend.OracleIntegrationTests/ClubHub.Api.OracleIntegrationTests.csproj --configuration Release --no-restore --no-build`：本地无隔离 Oracle Schema 时按仓库规则跳过。
- 共享库迁移前审计确认例程尚不存在，并发现 4 条需要校正的学期考核记录；其中 1 条 `award` 记录保持原语义。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过（Oracle 集成测试项目）
- [x] 前端代码无需变更
- [x] 已本地验证新增回归断言可编译

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [x] 迁移脚本、验证脚本和数据库说明已同步
- [x] 触发器、函数和存储过程范围已覆盖测试

**文档与部署（仅涉及时勾选）**
- [x] 系统设计文档待主线合入后同步更新
- [x] 需要人工执行数据库迁移；部署前先备份并暂停成员考核写入


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能调整**
  - 学期考核的一致性校验、分数计算和等级判定规则得到统一。
  - 评奖类记录继续保持原有处理方式，不受学期考核规则影响。
  - 评奖类型的等级显示调整为“优秀”，对应总分为 90 分。

- **错误处理**
  - 优化无效分数、发布学期考核等场景的错误反馈。

- **文档**
  - 补充数据迁移、历史数据检查及评奖申请处理范围说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->