### PR TITLE
release: 将论坛私有图片修复带入 main

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7278,7 +7278,7 @@ components:
         imageUrl:
           type: string
           description: 短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。
-          example: https://clubhub-oss.aliyuncs.com/forum/2026/08/19/abc123.png
+          example: https://clubhub-oss.aliyuncs.com/forum/2026/08/19/abc123.png?x-oss-signature=short-lived
         fileName:
           type: string
           description: 图片文件名。

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7278,7 +7278,7 @@ components:
         imageUrl:
           type: string
           description: 短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。
-          example: https://clubhub-oss.aliyuncs.com/forum/2026/08/19/abc123.png?x-oss-signature=short-lived
+          example: https://clubhub-oss.aliyuncs.com/clubs/1/forum/2026/08/19/abc123.png?x-oss-signature=short-lived
         fileName:
           type: string
           description: 图片文件名。

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7277,7 +7277,7 @@ components:
       properties:
         imageUrl:
           type: string
-          description: 上传后的图片 OSS URL，可直接在 Markdown 中使用。
+          description: 短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。
           example: https://clubhub-oss.aliyuncs.com/forum/2026/08/19/abc123.png
         fileName:
           type: string

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -5,6 +5,8 @@ using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
 using ClubHub.Api.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace ClubHub.Api.Tests;
 
@@ -283,12 +285,23 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     public async Task DeleteImage_WithValidStorageKey_ReturnsServerError()
     {
         var (client, clubId) = await SeedAsync(member: true, moderate: false);
-        const string testStorageKey = "clubs/1/forum/2026/08/19/test.png";
+        var testStorageKey = $"clubs/{clubId}/forum/2026/08/19/test.png";
 
         using var response = await client.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/delete-image?storageKey={Uri.EscapeDataString(testStorageKey)}");
 
-        // OSS not configured in tests, so deletion fails with 500; verifies endpoint exists and accepts storageKey
+        // OSS not configured in tests, so deletion fails with 500 after the ownership and permission checks.
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteImage_CrossClubStorageKey_ReturnsBadRequest()
+    {
+        var (client, clubId) = await SeedAsync(member: true, moderate: false);
+        var testStorageKey = $"clubs/{clubId + 1}/forum/2026/08/19/test.png";
+
+        using var response = await client.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/delete-image?storageKey={Uri.EscapeDataString(testStorageKey)}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
@@ -305,10 +318,55 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     public async Task DeleteImage_NonMember_IsForbidden()
     {
         var (client, clubId) = await SeedAsync(member: false, moderate: false);
-        const string testStorageKey = "clubs/1/forum/2026/08/19/test.png";
+        var testStorageKey = $"clubs/{clubId}/forum/2026/08/19/test.png";
 
         using var response = await client.DeleteAsync($"/api/v1/clubs/{clubId}/forum-posts/delete-image?storageKey={Uri.EscapeDataString(testStorageKey)}");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
+
+    [Theory]
+    [InlineData(1, "clubs/1/forum/2026/09/03/image.png", true)]
+    [InlineData(1, "clubs/2/forum/2026/09/03/image.png", false)]
+    [InlineData(1, "clubs/1/forum/../private/image.png", false)]
+    [InlineData(1, "clubs/1/forum/2026/09/03/", false)]
+    [InlineData(1, "clubs/1/forum/2026/09/03\\image.png", false)]
+    [InlineData(1, "clubs/1/forum/2026/09/03/image.png?other-club=2", false)]
+    public void ForumStorageKeyPolicy_ValidatesClubPrefix(int clubId, string storageKey, bool expected)
+    {
+        Assert.Equal(expected, ForumImageUploadService.IsForumStorageKey(clubId, storageKey));
+    }
+
+    [Fact]
+    public void CanonicalizeMarkdownImageUrls_RemovesTemporarySignature()
+    {
+        using var service = CreateImageService();
+        const string content = "封面：![活动海报](https://clubhub.example.oss-cn-shanghai-internal.aliyuncs.com/clubs/42/forum/2026/09/03/image.png?x-oss-signature=temporary)";
+
+        var canonicalized = service.CanonicalizeMarkdownImageUrls(42, content);
+
+        Assert.Equal("封面：![活动海报](https://clubhub.example.oss-cn-shanghai.aliyuncs.com/clubs/42/forum/2026/09/03/image.png)", canonicalized);
+    }
+
+    [Fact]
+    public void CanonicalizeMarkdownImageUrls_LeavesExternalAndOtherClubImagesUnchanged()
+    {
+        using var service = CreateImageService();
+        const string content = "![外部](https://example.com/image.png) ![其他社团](https://clubhub.example.oss-cn-shanghai.aliyuncs.com/clubs/43/forum/2026/09/03/image.png)";
+
+        var canonicalized = service.CanonicalizeMarkdownImageUrls(42, content);
+
+        Assert.Equal(content, canonicalized);
+    }
+
+    private static ForumImageUploadService CreateImageService() => new(
+        Options.Create(new OssStorageOptions
+        {
+            Region = "cn-shanghai",
+            Endpoint = "oss-cn-shanghai-internal.aliyuncs.com",
+            PublicEndpoint = "oss-cn-shanghai.aliyuncs.com",
+            Bucket = "clubhub.example",
+            RoleName = string.Empty
+        }),
+        NullLogger<ForumImageUploadService>.Instance);
 }

--- a/backend.Tests/ForumPostsAuthorizationTests.cs
+++ b/backend.Tests/ForumPostsAuthorizationTests.cs
@@ -341,18 +341,18 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
     public void CanonicalizeMarkdownImageUrls_RemovesTemporarySignature()
     {
         using var service = CreateImageService();
-        const string content = "封面：![活动海报](https://clubhub.example.oss-cn-shanghai-internal.aliyuncs.com/clubs/42/forum/2026/09/03/image.png?x-oss-signature=temporary)";
+        const string content = "封面：![活动海报](https://clubhub-test.oss-cn-shanghai-internal.aliyuncs.com/clubs/42/forum/2026/09/03/image.png?x-oss-signature=temporary)";
 
         var canonicalized = service.CanonicalizeMarkdownImageUrls(42, content);
 
-        Assert.Equal("封面：![活动海报](https://clubhub.example.oss-cn-shanghai.aliyuncs.com/clubs/42/forum/2026/09/03/image.png)", canonicalized);
+        Assert.Equal("封面：![活动海报](https://clubhub-test.oss-cn-shanghai.aliyuncs.com/clubs/42/forum/2026/09/03/image.png)", canonicalized);
     }
 
     [Fact]
     public void CanonicalizeMarkdownImageUrls_LeavesExternalAndOtherClubImagesUnchanged()
     {
         using var service = CreateImageService();
-        const string content = "![外部](https://example.com/image.png) ![其他社团](https://clubhub.example.oss-cn-shanghai.aliyuncs.com/clubs/43/forum/2026/09/03/image.png)";
+        const string content = "![外部](https://example.com/image.png) ![其他社团](https://clubhub-test.oss-cn-shanghai.aliyuncs.com/clubs/43/forum/2026/09/03/image.png)";
 
         var canonicalized = service.CanonicalizeMarkdownImageUrls(42, content);
 
@@ -365,7 +365,7 @@ public sealed class ForumPostsAuthorizationTests : IClassFixture<ClubHubWebAppli
             Region = "cn-shanghai",
             Endpoint = "oss-cn-shanghai-internal.aliyuncs.com",
             PublicEndpoint = "oss-cn-shanghai.aliyuncs.com",
-            Bucket = "clubhub.example",
+            Bucket = "clubhub-test",
             RoleName = string.Empty
         }),
         NullLogger<ForumImageUploadService>.Instance);

--- a/backend/Controllers/ForumPostsController.cs
+++ b/backend/Controllers/ForumPostsController.cs
@@ -95,7 +95,8 @@ public sealed class ForumPostsController : ControllerBase
             return BadRequest(new { message = "\u6807\u9898\u9577\u5ea6\u5fc5\u9808\u4e3a 1-120 \u5b57\u7b26\u3002" });
 
         var now = DateTime.UtcNow;
-        var post = new ForumPost { ClubId = clubId, UserId = context.User!.UserId, ParentPostId = parent?.PostId, Title = isReply ? null : title, Content = content, IsTop = 0, PostStatus = Published, CreatedAt = now, UpdatedAt = now };
+        var persistedContent = _imageUploadService.CanonicalizeMarkdownImageUrls(clubId, content);
+        var post = new ForumPost { ClubId = clubId, UserId = context.User!.UserId, ParentPostId = parent?.PostId, Title = isReply ? null : title, Content = persistedContent, IsTop = 0, PostStatus = Published, CreatedAt = now, UpdatedAt = now };
         _db.ForumPosts.Add(post);
         await _db.SaveChangesAsync();
         post.User = context.User;
@@ -228,6 +229,7 @@ public sealed class ForumPostsController : ControllerBase
         {
             ImageUrl = result.ImageUrl,
             FileName = result.FileName,
+            StorageKey = result.StorageKey,
             UploadedAt = DateTime.UtcNow
         };
 
@@ -235,15 +237,20 @@ public sealed class ForumPostsController : ControllerBase
     }
 
     [HttpDelete("delete-image")]
-    public async Task<IActionResult> DeleteImage(int clubId, [FromQuery] string storageKey)
+    public async Task<IActionResult> DeleteImage(int clubId, [FromQuery] string? storageKey)
     {
         var context = await GetUserContextAsync(clubId);
         if (context.Result is not null) return context.Result;
 
+        if (!Allows(context.Roles!, ForumPostPermission, clubId) && !Allows(context.Roles!, ForumModeratePermission, clubId))
+            return StatusCode(403, new { message = "当前用户没有删除论坛图片的权限。" });
+
         if (string.IsNullOrWhiteSpace(storageKey))
             return BadRequest(new { message = "storageKey 参数不能为空" });
+        if (!ForumImageUploadService.IsForumStorageKey(clubId, storageKey))
+            return BadRequest(new { message = "storageKey 不属于当前社团的论坛图片目录。" });
 
-        var success = await _imageUploadService.DeleteAsync(storageKey, HttpContext.RequestAborted);
+        var success = await _imageUploadService.DeleteAsync(clubId, storageKey, HttpContext.RequestAborted);
         return success ? Ok() : StatusCode(500, new { message = "删除失败" });
     }
 
@@ -266,7 +273,7 @@ public sealed class ForumPostsController : ControllerBase
         AuthService.RolesAllow(roles, permission, clubId);
     private static bool IsPublished(ForumPost post) => string.Equals(post.PostStatus, Published, StringComparison.OrdinalIgnoreCase) || string.IsNullOrWhiteSpace(post.PostStatus);
 
-    private static List<ApiForumPost> BuildNestedReplies(List<ForumPost> allPosts, int? parentPostId, bool includeHidden)
+    private List<ApiForumPost> BuildNestedReplies(List<ForumPost> allPosts, int? parentPostId, bool includeHidden)
     {
         var directReplies = allPosts.Where(r => r.ParentPostId == parentPostId)
             .OrderBy(r => r.CreatedAt).ThenBy(r => r.PostId).ToList();
@@ -280,6 +287,6 @@ public sealed class ForumPostsController : ControllerBase
         return result;
     }
 
-    private static ApiForumPost ToApiPost(ForumPost post, List<ApiForumPost> replies) => new() { Id = post.PostId, ClubId = post.ClubId, UserId = post.UserId, UserName = post.User is null ? null : (string.IsNullOrWhiteSpace(post.User.RealName) ? post.User.Username : post.User.RealName), ParentPostId = post.ParentPostId, Title = post.Title, Content = post.Content, IsTop = post.IsTop != 0, PostStatus = IsPublished(post) ? ApiForumPost.PostStatusEnum.PublishedEnum : ApiForumPost.PostStatusEnum.HiddenEnum, CreatedAt = LearningWorkflow.AsUtc(post.CreatedAt), UpdatedAt = LearningWorkflow.AsUtc(post.UpdatedAt), Replies = replies };
+    private ApiForumPost ToApiPost(ForumPost post, List<ApiForumPost> replies) => new() { Id = post.PostId, ClubId = post.ClubId, UserId = post.UserId, UserName = post.User is null ? null : (string.IsNullOrWhiteSpace(post.User.RealName) ? post.User.Username : post.User.RealName), ParentPostId = post.ParentPostId, Title = post.Title, Content = _imageUploadService.RefreshMarkdownImageUrls(post.ClubId, post.Content), IsTop = post.IsTop != 0, PostStatus = IsPublished(post) ? ApiForumPost.PostStatusEnum.PublishedEnum : ApiForumPost.PostStatusEnum.HiddenEnum, CreatedAt = LearningWorkflow.AsUtc(post.CreatedAt), UpdatedAt = LearningWorkflow.AsUtc(post.UpdatedAt), Replies = replies };
     private sealed record UserContext(IActionResult? Result, User? User, IReadOnlyList<PermissionRole>? Roles);
 }

--- a/backend/Models/ForumImageUploadResponse.cs
+++ b/backend/Models/ForumImageUploadResponse.cs
@@ -26,9 +26,9 @@ namespace Org.OpenAPITools.Models
     public partial class ForumImageUploadResponse 
     {
         /// <summary>
-        /// 上传后的图片 OSS URL，可直接在 Markdown 中使用。
+        /// 短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。
         /// </summary>
-        /// <value>上传后的图片 OSS URL，可直接在 Markdown 中使用。</value>
+        /// <value>短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。</value>
         /* <example>https://clubhub-oss.aliyuncs.com/forum/2026/08/19/abc123.png</example> */
         [Required]
         [DataMember(Name="imageUrl", EmitDefaultValue=false)]

--- a/backend/Models/ForumImageUploadResponse.cs
+++ b/backend/Models/ForumImageUploadResponse.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Models
         /// 短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。
         /// </summary>
         /// <value>短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。</value>
-        /* <example>https://clubhub-oss.aliyuncs.com/forum/2026/08/19/abc123.png</example> */
+        /* <example>https://clubhub-oss.aliyuncs.com/forum/2026/08/19/abc123.png?x-oss-signature&#x3D;short-lived</example> */
         [Required]
         [DataMember(Name="imageUrl", EmitDefaultValue=false)]
         public string ImageUrl { get; set; }

--- a/backend/Models/ForumImageUploadResponse.cs
+++ b/backend/Models/ForumImageUploadResponse.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Models
         /// 短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。
         /// </summary>
         /// <value>短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。</value>
-        /* <example>https://clubhub-oss.aliyuncs.com/forum/2026/08/19/abc123.png?x-oss-signature&#x3D;short-lived</example> */
+        /* <example>https://clubhub-oss.aliyuncs.com/clubs/1/forum/2026/08/19/abc123.png?x-oss-signature&#x3D;short-lived</example> */
         [Required]
         [DataMember(Name="imageUrl", EmitDefaultValue=false)]
         public string ImageUrl { get; set; }

--- a/backend/Services/ForumImageUploadService.cs
+++ b/backend/Services/ForumImageUploadService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Options;
 using OSS = AlibabaCloud.OSS.V2;
 
@@ -30,11 +31,15 @@ public sealed class ForumImageUploadService : IDisposable
         ".webp"
     );
 
+    private static readonly Regex MarkdownImagePattern = new(
+        @"!\[[^\]]*\]\((?<url><[^>\r\n]+>|[^)\s]+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private const long MaxFileSizeBytes = 5 * 1024 * 1024; // 5 MB
-    private const string LegacyReferenceScheme = "oss";
+    private static readonly TimeSpan SignedUrlLifetime = TimeSpan.FromHours(2);
     private readonly OssStorageOptions _options;
     private readonly OSS.Client? _client;
-    private readonly Exception? _configurationError;
+    private readonly OSS.Client? _publicUrlClient;
     private readonly ILogger<ForumImageUploadService> _logger;
 
     public ForumImageUploadService(IOptions<OssStorageOptions> options, ILogger<ForumImageUploadService> logger)
@@ -43,6 +48,8 @@ public sealed class ForumImageUploadService : IDisposable
         _logger = logger;
         if (!IsConfigured()) return;
 
+        OSS.Client? uploadClient = null;
+        OSS.Client? publicUrlClient = null;
         try
         {
             var credentialClient = new Aliyun.Credentials.Client(
@@ -60,21 +67,22 @@ public sealed class ForumImageUploadService : IDisposable
                     credential.SecurityToken);
             });
 
-            var configuration = OSS.Configuration.LoadDefault();
-            configuration.Region = _options.Region.Trim();
-            configuration.Endpoint = NormalizeEndpoint(_options.Endpoint);
-            configuration.CredentialsProvider = credentialsProvider;
-            configuration.ConnectTimeout = TimeSpan.FromSeconds(10);
-            configuration.ReadWriteTimeout = TimeSpan.FromMinutes(5);
-            _client = new OSS.Client(configuration);
+            uploadClient = CreateClient(_options.Region, _options.Endpoint, credentialsProvider);
+            publicUrlClient = CreateClient(_options.Region, GetPublicEndpoint(), credentialsProvider);
+            _client = uploadClient;
+            _publicUrlClient = publicUrlClient;
         }
         catch (InvalidOperationException)
         {
+            uploadClient?.Dispose();
+            publicUrlClient?.Dispose();
             throw;
         }
         catch (Exception exception)
         {
-            _configurationError = exception;
+            uploadClient?.Dispose();
+            publicUrlClient?.Dispose();
+            _logger.LogError(exception, "Forum image OSS client initialization failed");
         }
     }
 
@@ -105,7 +113,7 @@ public sealed class ForumImageUploadService : IDisposable
     }
 
     /// <summary>
-    /// 上传图片到 OSS
+    /// 上传图片到 OSS。对象保持私有，返回的图片地址为短期签名 URL。
     /// </summary>
     public async Task<UploadResult> UploadAsync(
         int clubId,
@@ -116,12 +124,13 @@ public sealed class ForumImageUploadService : IDisposable
         if (!isValid)
             return new(false, null, null, null, failureKind, errorMessage);
 
-        if (_client == null)
+        if (_client == null || _publicUrlClient == null)
             return new(false, null, null, null, UploadFailureKind.Storage, "OSS 服务未正确配置");
 
         var fileName = file.FileName ?? "image.jpg";
         var extension = Path.GetExtension(fileName).ToLowerInvariant();
         var objectName = $"clubs/{clubId}/forum/{DateTime.UtcNow:yyyy/MM/dd}/{Guid.NewGuid():N}{extension}";
+        var objectUploaded = false;
 
         try
         {
@@ -136,8 +145,9 @@ public sealed class ForumImageUploadService : IDisposable
                     ContentDisposition = $"inline; filename*=UTF-8''{Uri.EscapeDataString(fileName)}"
                 },
                 cancellationToken: cancellationToken);
+            objectUploaded = true;
 
-            var imageUrl = BuildImageUrl(objectName);
+            var imageUrl = BuildSignedImageUrl(objectName);
             return new(true, imageUrl, Path.GetFileName(objectName), objectName, null, null);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -146,17 +156,36 @@ public sealed class ForumImageUploadService : IDisposable
         }
         catch (Exception exception)
         {
+            if (objectUploaded)
+            {
+                try
+                {
+                    await _client.DeleteObjectAsync(
+                        new OSS.Models.DeleteObjectRequest
+                        {
+                            Bucket = _options.Bucket,
+                            Key = objectName
+                        },
+                        cancellationToken: CancellationToken.None);
+                }
+                catch (Exception cleanupException)
+                {
+                    _logger.LogWarning(cleanupException, "Failed to clean up forum image after signing failure for key {StorageKey}", objectName);
+                }
+            }
+
             _logger.LogError(exception, "OSS upload failed for club {ClubId} file {FileName}", clubId, fileName);
             return new(false, null, null, null, UploadFailureKind.Storage, "上传失败");
         }
     }
 
     /// <summary>
-    /// 删除已上传的图片
+    /// 删除已上传的图片。对象键必须属于当前社团的论坛目录。
     /// </summary>
-    public async Task<bool> DeleteAsync(string storageKey, CancellationToken cancellationToken = default)
+    public async Task<bool> DeleteAsync(int clubId, string? storageKey, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(storageKey) || _client == null)
+        var normalizedStorageKey = storageKey?.Trim();
+        if (!IsForumStorageKey(clubId, normalizedStorageKey) || _client == null)
             return false;
 
         try
@@ -165,7 +194,7 @@ public sealed class ForumImageUploadService : IDisposable
                 new OSS.Models.DeleteObjectRequest
                 {
                     Bucket = _options.Bucket,
-                    Key = storageKey
+                    Key = normalizedStorageKey!
                 },
                 cancellationToken: cancellationToken);
             return true;
@@ -177,9 +206,59 @@ public sealed class ForumImageUploadService : IDisposable
         }
     }
 
-    public void Dispose() => _client?.Dispose();
+    /// <summary>
+    /// 将帖子正文中的论坛图片地址规范化为不含签名参数的稳定对象地址，避免把临时凭证写入数据库。
+    /// </summary>
+    public string CanonicalizeMarkdownImageUrls(int clubId, string content) =>
+        ReplaceMarkdownImageUrls(clubId, content, BuildUnsignedImageUrl);
 
-    private OSS.Client? GetClient() => _client;
+    /// <summary>
+    /// 为帖子正文中的论坛图片重新生成短期签名地址。每次读取帖子时调用，兼容旧的未签名地址。
+    /// </summary>
+    public string RefreshMarkdownImageUrls(int clubId, string content) =>
+        ReplaceMarkdownImageUrls(clubId, content, BuildSignedImageUrl);
+
+    /// <summary>
+    /// 判断对象键是否严格位于指定社团的论坛图片目录下。
+    /// </summary>
+    internal static bool IsForumStorageKey(int clubId, string? storageKey)
+    {
+        if (clubId <= 0 || string.IsNullOrWhiteSpace(storageKey)) return false;
+
+        var normalized = storageKey.Trim();
+        string decoded;
+        try
+        {
+            decoded = Uri.UnescapeDataString(normalized);
+        }
+        catch (UriFormatException)
+        {
+            return false;
+        }
+        var prefix = $"clubs/{clubId}/forum/";
+        if (!decoded.StartsWith(prefix, StringComparison.Ordinal)) return false;
+        if (decoded.Length == prefix.Length || decoded.Contains('\\') || decoded.Contains('?') || decoded.Contains('#')) return false;
+
+        var segments = decoded.Split('/');
+        return segments.All(segment => segment.Length > 0 && segment is not "." and not "..");
+    }
+
+    public void Dispose()
+    {
+        _publicUrlClient?.Dispose();
+        _client?.Dispose();
+    }
+
+    private static OSS.Client CreateClient(string region, string endpoint, OSS.Credentials.ICredentialsProvider credentialsProvider)
+    {
+        var configuration = OSS.Configuration.LoadDefault();
+        configuration.Region = region.Trim();
+        configuration.Endpoint = NormalizeEndpoint(endpoint);
+        configuration.CredentialsProvider = credentialsProvider;
+        configuration.ConnectTimeout = TimeSpan.FromSeconds(10);
+        configuration.ReadWriteTimeout = TimeSpan.FromMinutes(5);
+        return new OSS.Client(configuration);
+    }
 
     private bool IsConfigured() =>
         !string.IsNullOrWhiteSpace(_options.Region) &&
@@ -187,21 +266,91 @@ public sealed class ForumImageUploadService : IDisposable
         !string.IsNullOrWhiteSpace(_options.Bucket) &&
         !string.IsNullOrWhiteSpace(_options.RoleName);
 
-    private string BuildImageUrl(string objectName)
+    private string GetPublicEndpoint()
     {
-        var normalizedEndpoint = NormalizeEndpoint(_options.Endpoint);
-        var endpointWithoutScheme = normalizedEndpoint["https://".Length..];
+        var endpoint = string.IsNullOrWhiteSpace(_options.PublicEndpoint)
+            ? _options.Endpoint.Trim()
+            : _options.PublicEndpoint.Trim();
+        return endpoint.Replace("-internal.", ".", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string BuildSignedImageUrl(string objectName)
+    {
+        var client = _publicUrlClient ?? throw new InvalidOperationException("Forum image OSS signing client is not configured.");
+        var result = client.Presign(
+            new OSS.Models.GetObjectRequest
+            {
+                Bucket = _options.Bucket,
+                Key = objectName
+            },
+            DateTime.UtcNow.Add(SignedUrlLifetime));
+        return result.Url ?? throw new InvalidOperationException("Forum image OSS signing returned an empty URL.");
+    }
+
+    private string BuildUnsignedImageUrl(string objectName)
+    {
+        var endpointHost = new Uri(NormalizeEndpoint(GetPublicEndpoint())).Host;
+        return $"https://{_options.Bucket.Trim()}.{endpointHost}/{objectName}";
+    }
+
+    private string ReplaceMarkdownImageUrls(int clubId, string content, Func<string, string> transform)
+    {
+        if (string.IsNullOrEmpty(content)) return content;
+
+        return MarkdownImagePattern.Replace(content, match =>
+        {
+            var urlToken = match.Groups["url"].Value;
+            var imageUrl = urlToken.Trim('<', '>');
+            if (!TryGetForumStorageKey(clubId, imageUrl, out var storageKey)) return match.Value;
+
+            try
+            {
+                var transformedUrl = transform(storageKey);
+                var replacement = urlToken.StartsWith('<') && urlToken.EndsWith('>')
+                    ? $"<{transformedUrl}>"
+                    : transformedUrl;
+                var prefixLength = match.Groups["url"].Index - match.Index;
+                return match.Value[..prefixLength] + replacement;
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(exception, "Failed to refresh forum image URL for key {StorageKey}", storageKey);
+                return match.Value;
+            }
+        });
+    }
+
+    private bool TryGetForumStorageKey(int clubId, string imageUrl, out string storageKey)
+    {
+        storageKey = string.Empty;
+        if (string.IsNullOrWhiteSpace(_options.Endpoint) || string.IsNullOrWhiteSpace(_options.Bucket))
+            return false;
+        if (!Uri.TryCreate(imageUrl, UriKind.Absolute, out var uri) ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+            uri.Port != 443)
+            return false;
+
         var bucket = _options.Bucket.Trim();
-        return $"https://{bucket}.{endpointWithoutScheme}/{objectName}";
+        if (string.IsNullOrWhiteSpace(bucket)) return false;
+
+        var configuredHost = new Uri(NormalizeEndpoint(_options.Endpoint)).Host;
+        var publicHost = new Uri(NormalizeEndpoint(GetPublicEndpoint())).Host;
+        var isOssHost = string.Equals(uri.Host, $"{bucket}.{configuredHost}", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(uri.Host, $"{bucket}.{publicHost}", StringComparison.OrdinalIgnoreCase);
+        if (!isOssHost) return false;
+
+        var key = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped).TrimStart('/');
+        if (!IsForumStorageKey(clubId, key)) return false;
+
+        storageKey = key;
+        return true;
     }
 
     private static string NormalizeEndpoint(string endpoint)
     {
         var normalized = endpoint.Trim().TrimEnd('/');
         if (normalized.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
-        {
             throw new InvalidOperationException("Forum image OSS endpoint must use HTTPS or omit the scheme.");
-        }
 
         return normalized.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
             ? normalized

--- a/backend/Services/OssStorageOptions.cs
+++ b/backend/Services/OssStorageOptions.cs
@@ -8,6 +8,11 @@ public sealed class OssStorageOptions
 
     public string Endpoint { get; init; } = string.Empty;
 
+    /// <summary>
+    /// 用于生成浏览器直连签名 URL 的公网 Endpoint；为空时由 Endpoint 自动推导。
+    /// </summary>
+    public string PublicEndpoint { get; init; } = string.Empty;
+
     public string Bucket { get; init; } = string.Empty;
 
     public string RoleName { get; init; } = string.Empty;

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -5,6 +5,7 @@
   "Oss": {
     "Region": "cn-shanghai",
     "Endpoint": "oss-cn-shanghai-internal.aliyuncs.com",
+    "PublicEndpoint": "oss-cn-shanghai.aliyuncs.com",
     "Bucket": "clubhub-learning-prod-2026-c7h2",
     "RoleName": "ClubHubOssProdRole"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       Authentication__Sessions__MaxSessionsPerUser: ${AUTH_SESSION_MAX_PER_USER:-10}
       Oss__Region: ${OSS_REGION:-cn-shanghai}
       Oss__Endpoint: ${OSS_ENDPOINT:-oss-cn-shanghai-internal.aliyuncs.com}
+      Oss__PublicEndpoint: ${OSS_PUBLIC_ENDPOINT:-oss-cn-shanghai.aliyuncs.com}
       Oss__Bucket: ${OSS_BUCKET:-clubhub-learning-prod-2026-c7h2}
       Oss__RoleName: ${OSS_ROLE_NAME:-ClubHubOssProdRole}
       LearningPreview__MaxConcurrentConversions: ${LEARNING_PREVIEW_MAX_CONCURRENT_CONVERSIONS:-2}

--- a/frontend/src/api/models/ForumImageUploadResponse.ts
+++ b/frontend/src/api/models/ForumImageUploadResponse.ts
@@ -21,7 +21,7 @@ import { mapValues, parseDate, parseDateTime, serializeDate, serializeDateTime }
  */
 export interface ForumImageUploadResponse {
   /**
-   * 上传后的图片 OSS URL，可直接在 Markdown 中使用。
+   * 短期签名的 OSS URL，可在有效期内直接在 Markdown 中使用；帖子读取时由后端刷新。
    */
   imageUrl: string;
   /**


### PR DESCRIPTION
## 改动内容

将已在 `dev` 验证并合并的论坛私有 OSS 图片修复带入 `main`，内容与 PR #221 保持一致：

- 返回短期签名图片 URL，帖子读取时刷新历史地址。
- 上传响应补齐 `storageKey`。
- 收紧论坛图片删除的权限、社团对象前缀和路径校验。
- OpenAPI 示例与自动生成模型同步更新。

## 改动原因

论坛图片继续使用私有 Bucket，并通过签名 URL 保持浏览器直连 OSS 的加载方式，避免公开整个共享 Bucket。

## 关联 Issue

Part of #220（完整实现已通过 PR #221 合并到 `dev`）。

## 测试说明

PR #221 已通过前后端构建、CI、CodeRabbit 审查与本地验证：后端完整测试 288/288，前端测试 113 通过、1 个既有跳过项，前端生产构建成功。合并后继续在部署环境验证论坛发帖、图片上传、图片展示和私有 Bucket 访问。

## 数据库与部署影响

不修改数据库表结构，不需要数据库迁移，不需要新增 GitHub Secret；生产环境使用 `OSS_PUBLIC_ENDPOINT`（缺省为 `oss-cn-shanghai.aliyuncs.com`）生成签名 URL。
