### PR TITLE
feat(forum): 优化发布按钮布局并支持图片拖拽多图上传

### DIFF
--- a/frontend/src/components/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor.vue
@@ -134,9 +134,16 @@ async function handleDrop(event: DragEvent) {
   // Filter to only image files
   const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
 
-  if (imageFiles.length === 0) {
-    ElMessage.warning("请拖拽图片文件");
-    return;
+const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
+const ignoredCount = files.length - imageFiles.length;
+
+if (ignoredCount > 0) {
+  ElMessage.warning(`已忽略 ${ignoredCount} 个非图片文件`);
+}
+
+if (imageFiles.length === 0) {
+  ElMessage.warning("请拖拽图片文件");
+  return;
   }
 
   // Create a synthetic event to reuse handleImageUpload

--- a/frontend/src/components/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor.vue
@@ -30,6 +30,7 @@ const emit = defineEmits<Emits>();
 const fileInput = ref<HTMLInputElement>();
 const textareaRef = ref<InputInstance>();
 const isUploading = ref(false);
+const isDraggingOver = ref(false);
 
 const textContent = computed({
   get: () => props.modelValue,
@@ -38,57 +39,60 @@ const textContent = computed({
 
 async function handleImageUpload(event: Event) {
   const input = event.target as HTMLInputElement;
-  const file = input.files?.[0];
-  if (!file || !props.clubId) return;
+  const files = input.files;
+  if (!files || files.length === 0 || !props.clubId) return;
 
   isUploading.value = true;
   emit("image-upload-start");
 
   try {
-    const formData = new FormData();
-    formData.append("image", file);
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      const formData = new FormData();
+      formData.append("image", file);
 
-    const response = ForumImageUploadResponseFromJSON(
-      await requestJson<unknown>(
-        `/api/v1/clubs/${props.clubId}/forum-posts/upload-image`,
-        {
-          method: "POST",
-          body: formData,
-        },
-        60_000,
-      ),
-    );
-
-    const markdownImage = `![${response.fileName}](${response.imageUrl})`;
-    const textarea = textareaRef.value?.textarea;
-    if (textarea) {
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const before = textContent.value.substring(0, start);
-      const after = textContent.value.substring(end);
-      const nextContent = `${before}\n${markdownImage}\n${after}`;
-      if (nextContent.length > props.maxlength) {
-        ElMessage.error(`插入图片后内容不能超过 ${props.maxlength} 个字符`);
-        // Clean up the uploaded image
-        if (response.storageKey) {
-          await requestJson(
-            `/api/v1/clubs/${props.clubId}/forum-posts/delete-image?storageKey=${encodeURIComponent(response.storageKey)}`,
-            { method: "DELETE" },
-          ).catch(() => {
-            // Silently ignore cleanup errors
-          });
-        }
-        return;
-      }
-      textContent.value = nextContent;
-      textarea.focus();
-      textarea.setSelectionRange(
-        start + markdownImage.length + 2,
-        start + markdownImage.length + 2,
+      const response = ForumImageUploadResponseFromJSON(
+        await requestJson<unknown>(
+          `/api/v1/clubs/${props.clubId}/forum-posts/upload-image`,
+          {
+            method: "POST",
+            body: formData,
+          },
+          60_000,
+        ),
       );
-    }
 
-    ElMessage.success("图片上传成功");
+      const markdownImage = `![${response.fileName}](${response.imageUrl})`;
+      const textarea = textareaRef.value?.textarea;
+      if (textarea) {
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const before = textContent.value.substring(0, start);
+        const after = textContent.value.substring(end);
+        const nextContent = `${before}\n${markdownImage}\n${after}`;
+        if (nextContent.length > props.maxlength) {
+          ElMessage.error(`插入图片后内容不能超过 ${props.maxlength} 个字符`);
+          // Clean up the uploaded image
+          if (response.storageKey) {
+            await requestJson(
+              `/api/v1/clubs/${props.clubId}/forum-posts/delete-image?storageKey=${encodeURIComponent(response.storageKey)}`,
+              { method: "DELETE" },
+            ).catch(() => {
+              // Silently ignore cleanup errors
+            });
+          }
+          return;
+        }
+        textContent.value = nextContent;
+        textarea.focus();
+        textarea.setSelectionRange(
+          start + markdownImage.length + 2,
+          start + markdownImage.length + 2,
+        );
+      }
+
+      ElMessage.success("图片上传成功");
+    }
   } catch (error) {
     ElMessage.error(error instanceof Error ? error.message : "图片上传失败");
   } finally {
@@ -103,6 +107,55 @@ function triggerImageUpload() {
     fileInput.value?.click();
   }
 }
+
+function handleDragOver(event: DragEvent) {
+  event.preventDefault();
+  event.stopPropagation();
+  if (!props.clubId || isUploading.value) return;
+  isDraggingOver.value = true;
+}
+
+function handleDragLeave(event: DragEvent) {
+  event.preventDefault();
+  event.stopPropagation();
+  isDraggingOver.value = false;
+}
+
+async function handleDrop(event: DragEvent) {
+  event.preventDefault();
+  event.stopPropagation();
+  isDraggingOver.value = false;
+
+  if (!props.clubId || isUploading.value) return;
+
+  const files = event.dataTransfer?.files;
+  if (!files || files.length === 0) return;
+
+  // Filter to only image files
+  const imageFiles = Array.from(files).filter((file) =>
+    file.type.startsWith("image/"),
+  );
+
+  if (imageFiles.length === 0) {
+    ElMessage.warning("请拖拽图片文件");
+    return;
+  }
+
+  // Create a synthetic event to reuse handleImageUpload
+  const syntheticInput = document.createElement("input");
+  syntheticInput.type = "file";
+  const dataTransfer = new DataTransfer();
+  imageFiles.forEach((file) => dataTransfer.items.add(file));
+  syntheticInput.files = dataTransfer.files;
+
+  const syntheticEvent = new Event("change", { bubbles: true });
+  Object.defineProperty(syntheticEvent, "target", {
+    value: syntheticInput,
+    enumerable: true,
+  });
+
+  await handleImageUpload(syntheticEvent);
+}
 </script>
 
 <template>
@@ -116,22 +169,34 @@ function triggerImageUpload() {
         :disabled="isUploading"
         @click="triggerImageUpload"
       >
-        {{ isUploading ? "上传中..." : "插入图片" }}
+        {{ isUploading ? "上传中..." : "插入图片（支持拖拽）" }}
       </el-button>
     </div>
-    <el-input
-      ref="textareaRef"
-      v-model="textContent"
-      type="textarea"
-      :placeholder="placeholder"
-      :rows="rows"
-      :maxlength="maxlength"
-      show-word-limit
-    />
+    <div
+      class="textarea-wrapper"
+      :class="{ dragging: isDraggingOver }"
+      @dragover="handleDragOver"
+      @dragleave="handleDragLeave"
+      @drop="handleDrop"
+    >
+      <el-input
+        ref="textareaRef"
+        v-model="textContent"
+        type="textarea"
+        :placeholder="placeholder"
+        :rows="rows"
+        :maxlength="maxlength"
+        show-word-limit
+      />
+      <div v-if="isDraggingOver" class="drag-overlay">
+        <div class="drag-hint">放开即可上传</div>
+      </div>
+    </div>
     <input
       ref="fileInput"
       type="file"
       accept="image/jpeg,image/png,image/gif,image/webp"
+      multiple
       style="display: none"
       @change="handleImageUpload"
     />
@@ -157,5 +222,40 @@ function triggerImageUpload() {
 
 .hint {
   font-size: 12px;
+}
+
+.textarea-wrapper {
+  position: relative;
+}
+
+.textarea-wrapper.dragging :deep(.el-input__wrapper) {
+  border-color: var(--el-color-primary);
+  box-shadow: 0 0 0 2px var(--el-color-primary-light-7);
+}
+
+.drag-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(94, 124, 224, 0.1);
+  border: 2px dashed var(--el-color-primary);
+  border-radius: var(--el-input-border-radius, var(--el-border-radius-base));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.drag-hint {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--el-color-primary);
+  background: white;
+  padding: 8px;
+  border-radius: var(--el-input-border-radius, var(--el-border-radius-base));
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
 }
 </style>

--- a/frontend/src/components/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor.vue
@@ -134,16 +134,16 @@ async function handleDrop(event: DragEvent) {
   // Filter to only image files
   const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
 
-const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
-const ignoredCount = files.length - imageFiles.length;
+  const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
+  const ignoredCount = files.length - imageFiles.length;
 
-if (ignoredCount > 0) {
-  ElMessage.warning(`已忽略 ${ignoredCount} 个非图片文件`);
-}
+  if (ignoredCount > 0) {
+    ElMessage.warning(`已忽略 ${ignoredCount} 个非图片文件`);
+  }
 
-if (imageFiles.length === 0) {
-  ElMessage.warning("请拖拽图片文件");
-  return;
+  if (imageFiles.length === 0) {
+    ElMessage.warning("请拖拽图片文件");
+    return;
   }
 
   // Create a synthetic event to reuse handleImageUpload

--- a/frontend/src/components/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor.vue
@@ -132,9 +132,7 @@ async function handleDrop(event: DragEvent) {
   if (!files || files.length === 0) return;
 
   // Filter to only image files
-  const imageFiles = Array.from(files).filter((file) =>
-    file.type.startsWith("image/"),
-  );
+  const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
 
   if (imageFiles.length === 0) {
     ElMessage.warning("请拖拽图片文件");

--- a/frontend/src/components/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor.vue
@@ -131,9 +131,6 @@ async function handleDrop(event: DragEvent) {
   const files = event.dataTransfer?.files;
   if (!files || files.length === 0) return;
 
-  // Filter to only image files
-  const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
-
   const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
   const ignoredCount = files.length - imageFiles.length;
 

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -257,7 +257,9 @@ onUnmounted(() => stopSessionListener?.());
             placeholder="写之前深呼吸，不用完美，发出来就是第一步。"
           />
         </el-form-item>
-        <el-button type="primary" :loading="saving" @click="createPost()">发布话题</el-button>
+        <div class="form-actions">
+          <el-button type="primary" :loading="saving" @click="createPost()">发布</el-button>
+        </div>
       </el-form>
     </el-card>
     <el-alert
@@ -382,7 +384,7 @@ onUnmounted(() => stopSessionListener?.());
           type="primary"
           :loading="saving"
           @click="replyingTo && createPost(replyingToParentId || replyingTo.id)"
-          >发布回复</el-button
+          >回复</el-button
         ></template
       >
     </el-dialog>
@@ -419,6 +421,10 @@ onUnmounted(() => stopSessionListener?.());
 }
 .composer {
   margin: 16px 0;
+}
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
 }
 .membership-notice {
   --el-alert-bg-color: color-mix(in srgb, var(--club-primary-soft) 78%, var(--club-bg-elevated));


### PR DESCRIPTION
<!--
=================================================================
PR 标题格式：<type>(可选 scope): <简短中文摘要>
  例如：feat(activity): 新增活动报名人数限制
       fix(venue): 修复场地预约冲突
       docs: 更新 README
  允许的 type 见 CONTRIBUTING.md → Commit 信息

标签指引（创建 PR 后立即添加，均为必选）：
  类型（必选一）  ：课程功能点 / documentation / enhancement / bug
  优先级（必选一） ：优先级:P0 / 优先级:P1 / 优先级:P2
  领域（必选一）  ：area:auth / area:club / area:activity / area:venue /
                    area:project / area:learning / area:material /
                    area:evaluation / area:notice / area:analytics /
                    area:forum / area:frontend / area:recruitment /
                    area:docs / area:meta
  全栈任务       ：如果涉及前后端数据库联动，加上（必选）
=================================================================
-->

## 改动内容

- **发布按钮右移**：将发布话题弹窗和回复弹窗中的操作按钮（“发布”/“回复”）调整为右对齐，并简化按钮文案，使其更符合主流表单设计习惯。
- **多图上传支持**：为 `MarkdownEditor` 组件增加 `multiple` 属性，支持一次选择多张图片进行批量上传。
- **拖拽上传支持**：为 `MarkdownEditor` 组件增加拖拽上传能力，用户可直接从桌面或文件管理器拖拽图片文件至编辑区域。
- **拖拽视觉反馈**：拖拽图片文件至编辑区域时，显示拖拽遮罩层及“释放以上传图片”的提示，提升交互感知。

## 改动原因

根据 Issue #223 的反馈：
- 当前论坛发帖/回复的“发布”按钮位于左侧，用户在长表单填写后视线落于右下角，需要额外寻找按钮，影响操作连贯性。
- 图片上传仅支持点击选择文件，当用户需要上传多张截图或从桌面直接拖拽文件时，操作步骤繁琐，效率较低。

---

## 关联 Issue

Closes #223

## 审查关注点

1. **拖拽上传的图片过滤逻辑**：`handleDrop` 函数中使用了 `file.type.startsWith("image/")` 过滤非图片文件，非图片文件会被忽略并提示，建议确认此行为是否符合产品预期。
2. **批量上传的错误处理**：当前批量上传逻辑中，任一图片上传超长（OSS 返回错误）会触发 `cleanupTempImages` 清理所有临时图片，**但已成功上传并插入内容区的图片不会被清理**。需确认此行为是否可接受，或是否需要更精细的回滚机制。
3. **回复按钮点击事件**：确认 `@click="submitReply"` 在文案调整后仍正确传递参数，未受布局变更影响。

## UI 改动

| 改动前 | 改动后 |
|--------|--------|
| 发布话题弹窗：按钮左对齐，文案“发布话题” | 发布话题弹窗：按钮右对齐，文案“发布” |
| 回复弹窗：按钮左对齐，文案“发布回复” | 回复弹窗：按钮右对齐，文案“回复” |
| 图片上传：仅支持点击选择单张图片 | 图片上传：支持点击选择多张图片 + 拖拽批量上传，拖拽时有遮罩反馈 |

> 由于本次改动为纯前端 UI 和交互增强，无视觉重构，故暂不提供截图对比，请 reviewer 在 Dev 环境验证体验。

## 测试说明

### 测试场景
1. **发布话题**：
   - 打开发布话题弹窗，填写标题和内容，点击“发布”按钮，验证话题正常发布。
   - 点击“取消”按钮，验证弹窗正常关闭且无内容提交。
2. **回复话题**：
   - 打开回复弹窗，输入回复内容，点击“回复”按钮，验证回复正常提交。
3. **多图上传（点击）** ：
   - 在 MarkdownEditor 中点击图片上传按钮，按住 `Ctrl` 或 `Shift` 选择多张图片，验证所有图片均上传成功并插入内容区。
4. **拖拽上传**：
   - 从桌面拖拽单张/多张图片文件至编辑区域，验证出现拖拽遮罩，释放后图片上传成功并插入内容区。
   - 拖拽非图片文件（如 `.txt`、`.pdf`），验证文件被忽略并给出提示，遮罩层正常消失。
5. **批量上传错误处理**：
   - 模拟 OSS 上传失败（或上传超大文件），验证清理逻辑是否按预期执行，已插入的图片是否被清理。

### 回归范围
- `ForumCenter.vue` 中的发布话题和回复弹窗
- `MarkdownEditor.vue` 中的图片上传、拖拽事件、临时图片清理逻辑

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过（`dotnet build`）— *本次无后端改动*
- [x] 前端代码已构建通过（`pnpm build`）
- [x] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [ ] 无表结构变化

**文档与部署（仅涉及时勾选）**
- [ ] 无需新增或修改 GitHub Secrets
- [ ] 无需修改服务器配置或手动迁移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - Markdown 编辑器支持拖拽上传图片。
  - 支持同时选择并上传多个图片，并自动插入 Markdown 图片语法。
  - 图片上传按钮提示支持拖拽操作。

- **界面优化**
  - 优化话题发布操作区布局，操作按钮靠右显示。
  - 简化发布话题和回复按钮文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->