### PR TITLE
fix(forum): 过滤未生效社团

### DIFF
--- a/frontend/src/forumClubScope.test.ts
+++ b/frontend/src/forumClubScope.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { Club } from "./api/models";
+import { filterForumClubs, isActiveForumClub } from "./forumClubScope";
+
+const club = (id: number, status: string | null, auditStatus: string | null): Club => ({
+  id,
+  name: `Club ${id}`,
+  status,
+  auditStatus,
+  statusText: status ?? "",
+  auditStatusText: auditStatus ?? "",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+});
+
+describe("forum club scope", () => {
+  it("keeps only approved clubs that are currently active", () => {
+    const clubs = [
+      club(1, "active", "approved"),
+      club(2, "pending", "pending"),
+      club(3, "active", "pending"),
+      club(4, "inactive", "approved"),
+      club(5, "rejected", "rejected"),
+    ];
+
+    expect(filterForumClubs(clubs).map((item) => item.id)).toEqual([1]);
+  });
+
+  it("normalizes status casing and surrounding whitespace", () => {
+    expect(isActiveForumClub(club(1, " Active ", " APPROVED "))).toBe(true);
+  });
+
+  it("rejects missing statuses instead of exposing an unverified club", () => {
+    expect(isActiveForumClub(club(1, null, "approved"))).toBe(false);
+    expect(isActiveForumClub(club(2, "active", null))).toBe(false);
+  });
+});

--- a/frontend/src/forumClubScope.ts
+++ b/frontend/src/forumClubScope.ts
@@ -1,0 +1,11 @@
+import type { Club } from "./api/models";
+
+const normalizeStatus = (value?: string | null) => value?.trim().toLowerCase() ?? "";
+
+export function isActiveForumClub(club: Pick<Club, "status" | "auditStatus">): boolean {
+  return normalizeStatus(club.status) === "active" && normalizeStatus(club.auditStatus) === "approved";
+}
+
+export function filterForumClubs(clubs: Club[]): Club[] {
+  return clubs.filter(isActiveForumClub);
+}

--- a/frontend/src/forumClubScope.ts
+++ b/frontend/src/forumClubScope.ts
@@ -3,7 +3,9 @@ import type { Club } from "./api/models";
 const normalizeStatus = (value?: string | null) => value?.trim().toLowerCase() ?? "";
 
 export function isActiveForumClub(club: Pick<Club, "status" | "auditStatus">): boolean {
-  return normalizeStatus(club.status) === "active" && normalizeStatus(club.auditStatus) === "approved";
+  return (
+    normalizeStatus(club.status) === "active" && normalizeStatus(club.auditStatus) === "approved"
+  );
 }
 
 export function filterForumClubs(clubs: Club[]): Club[] {

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -7,6 +7,7 @@ import { ForumPostFromJSON } from "../api/models";
 import { onSessionChange, readAuth } from "../authSession";
 import { formatBeijingDateTime } from "../beijingTime";
 import { requestJson } from "../composables/useApiRequest";
+import { filterForumClubs } from "../forumClubScope";
 import MarkdownEditor from "../components/MarkdownEditor.vue";
 import MarkdownRenderer from "../components/MarkdownRenderer.vue";
 import ReplyItem from "../components/ReplyItem.vue";
@@ -67,7 +68,8 @@ async function loadClubs() {
       requestJson<UserSummary[]>("/api/v1/users"),
     ]);
     if (clubResult.status === "rejected") throw clubResult.reason;
-    clubs.value = clubResult.value;
+    const availableClubs = filterForumClubs(clubResult.value);
+    clubs.value = availableClubs;
     const users = userResult.status === "fulfilled" ? userResult.value : [];
     const currentUser = users.find((user) => user.id === auth.value?.user.id);
     currentMemberClubIds.value = new Set(
@@ -78,7 +80,9 @@ async function loadClubs() {
         })
         .map((membership) => membership.clubId),
     );
-    selectedClubId.value ??= clubs.value[0]?.id;
+    if (!availableClubs.some((club) => club.id === selectedClubId.value)) {
+      selectedClubId.value = availableClubs[0]?.id;
+    }
   } catch (error) {
     ElMessage.error(error instanceof Error ? error.message : "社团列表加载失败");
   }


### PR DESCRIPTION
## 改动内容

- 讨论区社团下拉框现在只显示审核状态为 `approved` 且运营状态为 `active` 的社团。
- 将社团状态判断抽到 `frontend/src/forumClubScope.ts`，统一处理大小写和首尾空白。
- 当刷新后当前社团不再可用时，自动切换到第一个可用社团，避免继续请求已过滤的社团。
- 增加前端回归测试，覆盖待审核、驳回、停用和状态大小写/空白场景。

## 改动原因

`/api/v1/clubs` 为了让申请人查看自己的申请，会返回申请人自己的待审核社团。讨论区之前直接把该结果全部放入选择框，因此提交过“图灵社”申请的账号会看到一个尚未运营的社团，并在进入讨论区时得到无权限结果。

## 关联 Issue

Part of #28

## 审查关注点

- 讨论区只过滤展示选项，后端 `ForumPostsController` 的成员和权限校验保持不变。
- 状态字段使用 API `Club.status`（对应 `CLUB_STATUS`）和 `Club.auditStatus`（对应 `AUDIT_STATUS`）。
- 刷新社团列表后不会保留已经被过滤掉的旧选择。

## UI 改动

| 改动前 | 改动后 |
|--------|--------|
| 下拉框包含当前账号自己的待审核社团 | 下拉框只包含已审核且正在运营的社团 |

## 测试说明

- `pnpm test -- --run`：运行前端 Vitest 回归测试。
- `pnpm run build`：验证 Vue/TypeScript 生产构建。
- `pnpm run format:ci`：验证格式检查。

---

### 检查清单

**代码质量**
- [x] 后端代码未改动
- [x] 前端代码已构建通过（`npm run build`；使用已安装依赖执行同等脚本）
- [x] 已本地手工检查主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新

本地结果：Vitest `119 passed | 1 skipped`，Vite 生产构建退出码为 0，3 个改动文件的 Prettier 检查通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 论坛中心现在仅显示状态为“活跃”且审核通过的俱乐部。
  - 系统会自动规范化状态信息中的大小写和首尾空格，确保筛选结果一致。

- **问题修复**
  - 当当前选中的俱乐部不再符合展示条件时，系统会自动切换至列表中的第一个可用俱乐部。
  - 状态或审核信息缺失的俱乐部不会被展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->