### PR TITLE
chore(release): 同步 dev 到 main

### DIFF
--- a/frontend/src/forumClubScope.test.ts
+++ b/frontend/src/forumClubScope.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { Club } from "./api/models";
+import { filterForumClubs, isActiveForumClub } from "./forumClubScope";
+
+const club = (id: number, status: string | null, auditStatus: string | null): Club => ({
+  id,
+  name: `Club ${id}`,
+  status,
+  auditStatus,
+  statusText: status ?? "",
+  auditStatusText: auditStatus ?? "",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+});
+
+describe("forum club scope", () => {
+  it("keeps only approved clubs that are currently active", () => {
+    const clubs = [
+      club(1, "active", "approved"),
+      club(2, "pending", "pending"),
+      club(3, "active", "pending"),
+      club(4, "inactive", "approved"),
+      club(5, "rejected", "rejected"),
+    ];
+
+    expect(filterForumClubs(clubs).map((item) => item.id)).toEqual([1]);
+  });
+
+  it("normalizes status casing and surrounding whitespace", () => {
+    expect(isActiveForumClub(club(1, " Active ", " APPROVED "))).toBe(true);
+  });
+
+  it("rejects missing statuses instead of exposing an unverified club", () => {
+    expect(isActiveForumClub(club(1, null, "approved"))).toBe(false);
+    expect(isActiveForumClub(club(2, "active", null))).toBe(false);
+  });
+});

--- a/frontend/src/forumClubScope.ts
+++ b/frontend/src/forumClubScope.ts
@@ -1,0 +1,11 @@
+import type { Club } from "./api/models";
+
+const normalizeStatus = (value?: string | null) => value?.trim().toLowerCase() ?? "";
+
+export function isActiveForumClub(club: Pick<Club, "status" | "auditStatus">): boolean {
+  return normalizeStatus(club.status) === "active" && normalizeStatus(club.auditStatus) === "approved";
+}
+
+export function filterForumClubs(clubs: Club[]): Club[] {
+  return clubs.filter(isActiveForumClub);
+}

--- a/frontend/src/forumClubScope.ts
+++ b/frontend/src/forumClubScope.ts
@@ -3,7 +3,9 @@ import type { Club } from "./api/models";
 const normalizeStatus = (value?: string | null) => value?.trim().toLowerCase() ?? "";
 
 export function isActiveForumClub(club: Pick<Club, "status" | "auditStatus">): boolean {
-  return normalizeStatus(club.status) === "active" && normalizeStatus(club.auditStatus) === "approved";
+  return (
+    normalizeStatus(club.status) === "active" && normalizeStatus(club.auditStatus) === "approved"
+  );
 }
 
 export function filterForumClubs(clubs: Club[]): Club[] {

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -7,6 +7,7 @@ import { ForumPostFromJSON } from "../api/models";
 import { onSessionChange, readAuth } from "../authSession";
 import { formatBeijingDateTime } from "../beijingTime";
 import { requestJson } from "../composables/useApiRequest";
+import { filterForumClubs } from "../forumClubScope";
 import MarkdownEditor from "../components/MarkdownEditor.vue";
 import MarkdownRenderer from "../components/MarkdownRenderer.vue";
 import ReplyItem from "../components/ReplyItem.vue";
@@ -67,7 +68,8 @@ async function loadClubs() {
       requestJson<UserSummary[]>("/api/v1/users"),
     ]);
     if (clubResult.status === "rejected") throw clubResult.reason;
-    clubs.value = clubResult.value;
+    const availableClubs = filterForumClubs(clubResult.value);
+    clubs.value = availableClubs;
     const users = userResult.status === "fulfilled" ? userResult.value : [];
     const currentUser = users.find((user) => user.id === auth.value?.user.id);
     currentMemberClubIds.value = new Set(
@@ -78,7 +80,9 @@ async function loadClubs() {
         })
         .map((membership) => membership.clubId),
     );
-    selectedClubId.value ??= clubs.value[0]?.id;
+    if (!availableClubs.some((club) => club.id === selectedClubId.value)) {
+      selectedClubId.value = availableClubs[0]?.id;
+    }
   } catch (error) {
     ElMessage.error(error instanceof Error ? error.message : "社团列表加载失败");
   }


### PR DESCRIPTION
## Release

同步当前 `dev` 到 `main`，发布本次阶段性答辩版本。

本次相对 `main` 的主要有效改动包括：

- 合入 PR #226：讨论区只展示已审核且正在运营的社团，避免待审核社团进入论坛选择框。
- 同步 `dev` 当前已通过 CI 的论坛、数据库和答辩版本改动。

当前 `dev` 已包含合并提交 `ccbc8321`。合并后继续由 `main` 的 CI/CD 流程执行验证与部署。

## 关联 Issue

Part of #28

## 测试说明

PR #226 已通过前端 Vitest、前端生产构建、项目结构校验、pre-commit 和代码质量门禁；本 PR 仅做 `dev → main` 阶段性同步，不新增代码。

### 检查清单

- [x] `dev` 上的变更已通过 CI
- [x] 无数据库表结构变更
- [x] 无新增配置或 Secret
