### PR TITLE
fix(forum): 清理无可用社团时的讨论状态

### DIFF
--- a/frontend/src/forumClubScope.test.ts
+++ b/frontend/src/forumClubScope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Club } from "./api/models";
 import { filterForumClubs, isActiveForumClub } from "./forumClubScope";
+import forumCenterSource from "./views/ForumCenter.vue?raw";
 
 const club = (id: number, status: string | null, auditStatus: string | null): Club => ({
   id,
@@ -32,5 +33,12 @@ describe("forum club scope", () => {
   it("rejects missing statuses instead of exposing an unverified club", () => {
     expect(isActiveForumClub(club(1, null, "approved"))).toBe(false);
     expect(isActiveForumClub(club(2, "active", null))).toBe(false);
+  });
+
+  it("clears stale forum state when no approved active club remains", () => {
+    expect(filterForumClubs([club(1, "pending", "pending")])).toEqual([]);
+    expect(forumCenterSource).toContain("if (availableClubs.length === 0)");
+    expect(forumCenterSource).toContain("topics.value = []");
+    expect(forumCenterSource).toContain("loadError.value = null");
   });
 });

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -80,6 +80,14 @@ async function loadClubs() {
         })
         .map((membership) => membership.clubId),
     );
+    if (availableClubs.length === 0) {
+      postsRequestVersion++;
+      selectedClubId.value = undefined;
+      topics.value = [];
+      loadError.value = null;
+      loading.value = false;
+      return;
+    }
     if (!availableClubs.some((club) => club.id === selectedClubId.value)) {
       selectedClubId.value = availableClubs[0]?.id;
     }


### PR DESCRIPTION
## 改动内容

- 当讨论区筛选后没有任何已审核且正在运营的社团时，清空旧的帖子和错误状态。
- 递增请求版本并停止加载状态，避免旧社团请求返回后重新显示过期内容。
- 增加无可用社团的前端回归断言。

## 改动原因

首个论坛筛选修复已经隐藏待审核社团，但当账号没有任何可用社团时，旧的 `topics` 可能残留在页面上。该补丁完善空状态，保持选择框、帖子列表和提示状态一致。

## 关联 Issue

Part of #28

## 审查关注点

- 只有 `availableClubs.length === 0` 时清空状态；存在可用社团时保留原来的选择和加载流程。
- 不修改后端接口、数据库结构或权限校验。

## UI 改动

| 改动前 | 改动后 |
|--------|--------|
| 没有可用社团时可能保留旧帖子 | 没有可用社团时帖子和错误状态立即清空 |

## 测试说明

- Vitest：`120 passed | 1 skipped`。
- `npm run build`：通过，退出码 0。
- 3 个相关文件的 Prettier 检查通过。

---

### 检查清单

**代码质量**
- [x] 后端代码未改动
- [x] 前端代码已构建通过
- [x] 已本地回归测试

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
