### PR TITLE
chore(release): 同步 dev 到 main

### DIFF
--- a/frontend/src/forumClubScope.test.ts
+++ b/frontend/src/forumClubScope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Club } from "./api/models";
 import { filterForumClubs, isActiveForumClub } from "./forumClubScope";
+import forumCenterSource from "./views/ForumCenter.vue?raw";
 
 const club = (id: number, status: string | null, auditStatus: string | null): Club => ({
   id,
@@ -32,5 +33,12 @@ describe("forum club scope", () => {
   it("rejects missing statuses instead of exposing an unverified club", () => {
     expect(isActiveForumClub(club(1, null, "approved"))).toBe(false);
     expect(isActiveForumClub(club(2, "active", null))).toBe(false);
+  });
+
+  it("clears stale forum state when no approved active club remains", () => {
+    expect(filterForumClubs([club(1, "pending", "pending")])).toEqual([]);
+    expect(forumCenterSource).toContain("if (availableClubs.length === 0)");
+    expect(forumCenterSource).toContain("topics.value = []");
+    expect(forumCenterSource).toContain("loadError.value = null");
   });
 });

--- a/frontend/src/views/ForumCenter.vue
+++ b/frontend/src/views/ForumCenter.vue
@@ -80,6 +80,14 @@ async function loadClubs() {
         })
         .map((membership) => membership.clubId),
     );
+    if (availableClubs.length === 0) {
+      postsRequestVersion++;
+      selectedClubId.value = undefined;
+      topics.value = [];
+      loadError.value = null;
+      loading.value = false;
+      return;
+    }
     if (!availableClubs.some((club) => club.id === selectedClubId.value)) {
       selectedClubId.value = availableClubs[0]?.id;
     }


### PR DESCRIPTION
## Release

同步当前 `dev` 到 `main`，发布论坛社团筛选修复的阶段性版本。

本次相对 `main` 的主要改动：

- PR #226：讨论区只展示审核通过且正在运营的社团，避免待审核社团进入论坛选择框。
- PR #228：无可用社团时清空旧帖子和错误状态，避免空状态残留。

当前 `dev` 已包含合并提交 `34898a7b`。合并后继续由 `main` 的 CI/CD 流程执行验证与部署。

## 关联 Issue

Part of #28

## 测试说明

PR #228 已通过前端 Vitest（120 passed、1 skipped）、前端生产构建、项目结构校验、pre-commit 和代码质量门禁。本 PR 仅做 `dev → main` 阶段性同步，不新增代码。

### 检查清单

- [x] `dev` 上的变更已通过 CI
- [x] 无数据库表结构变更
- [x] 无新增配置或 Secret
