### PR TITLE
fix(auth): 启动时刷新缓存角色

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -4,10 +4,20 @@ import { createMemoryHistory, createRouter } from "vue-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App.vue";
 
-vi.mock("./authSession", () => ({
+const mocks = vi.hoisted(() => ({
   clearSession: vi.fn(),
   onSessionChange: vi.fn(() => () => undefined),
-  readAuth: vi.fn(() => null),
+  readAuth: vi.fn(() => null as unknown),
+  saveAuth: vi.fn(),
+  refreshAuthSession: vi.fn(),
+  logoutCurrentSession: vi.fn(),
+}));
+
+vi.mock("./authSession", () => ({
+  clearSession: mocks.clearSession,
+  onSessionChange: mocks.onSessionChange,
+  readAuth: mocks.readAuth,
+  saveAuth: mocks.saveAuth,
 }));
 
 vi.mock("./composables/useTheme", () => ({
@@ -15,7 +25,10 @@ vi.mock("./composables/useTheme", () => ({
 }));
 
 vi.mock("./apiClient", () => ({
-  apiClient: { logoutCurrentSession: vi.fn() },
+  apiClient: {
+    logoutCurrentSession: mocks.logoutCurrentSession,
+    refreshAuthSession: mocks.refreshAuthSession,
+  },
 }));
 
 vi.mock("./components/shell/AppShell.vue", () => ({
@@ -25,6 +38,12 @@ vi.mock("./components/shell/AppShell.vue", () => ({
 let mountedApp: VueApp<Element> | null = null;
 
 beforeEach(() => {
+  mocks.readAuth.mockReset();
+  mocks.readAuth.mockReturnValue(null);
+  mocks.saveAuth.mockReset();
+  mocks.refreshAuthSession.mockReset();
+  mocks.onSessionChange.mockReset();
+  mocks.onSessionChange.mockReturnValue(() => undefined);
   vi.stubGlobal(
     "fetch",
     vi.fn(async () => ({ ok: true })),
@@ -76,5 +95,63 @@ describe("应用会话恢复", () => {
       expect(host.textContent).toContain("登录页面");
     });
     expect(protectedMounted).not.toHaveBeenCalled();
+  });
+
+  it("启动时从服务端刷新缓存角色，避免展示过期社团身份", async () => {
+    const staleAuth = {
+      token: "stale-token",
+      user: { id: 8, username: "club_admin", realName: "王夫人", accountStatus: "normal" },
+      roles: [
+        {
+          id: 6,
+          code: "ADVISOR",
+          name: "指导老师",
+          displayName: "图灵社指导老师",
+          scope: "club",
+          clubId: 1000003,
+          clubIds: [1000003],
+          permissions: ["club:internal:view"],
+        },
+      ],
+      permissions: ["club:internal:view"],
+    };
+    const currentAuth = {
+      ...staleAuth,
+      token: "current-token",
+      roles: [
+        {
+          ...staleAuth.roles[0],
+          code: "CLUB_ADMIN",
+          name: "社团管理员",
+          displayName: "社团管理员",
+          scope: "system",
+          clubId: null,
+          clubIds: [],
+          permissions: ["club:review"],
+        },
+      ],
+      permissions: ["club:review"],
+    };
+    mocks.readAuth.mockReturnValue(staleAuth);
+    mocks.refreshAuthSession.mockResolvedValue(currentAuth);
+
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: "/dashboard", component: { template: "<div />" } }],
+    });
+    await router.push("/dashboard");
+    await router.isReady();
+
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    mountedApp = createApp(App);
+    mountedApp.use(ElementPlus);
+    mountedApp.use(router);
+    mountedApp.mount(host);
+
+    await vi.waitFor(() => {
+      expect(mocks.refreshAuthSession).toHaveBeenCalledOnce();
+      expect(mocks.saveAuth).toHaveBeenCalledWith(currentAuth);
+    });
   });
 });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,13 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import zhCn from "element-plus/es/locale/lang/zh-cn";
 import { ElMessage } from "element-plus";
-import { type AuthResponse, clearSession, onSessionChange, readAuth } from "./authSession";
+import {
+  type AuthResponse,
+  clearSession,
+  onSessionChange,
+  readAuth,
+  saveAuth,
+} from "./authSession";
 import { apiClient } from "./apiClient";
 import { buildNavigationGroups, resolveActiveNavigation } from "./navigation";
 import { initializeTheme } from "./composables/useTheme";
@@ -49,6 +55,23 @@ function refreshSession() {
   sessionResolved.value = true;
 }
 
+async function refreshStoredSession() {
+  if (!readAuth()) {
+    refreshSession();
+    return;
+  }
+
+  try {
+    const refreshedAuth = await apiClient.refreshAuthSession();
+    saveAuth(refreshedAuth);
+  } catch {
+    // Keep a cached session during a transient network failure. A 401 response
+    // is handled by apiClient and clears the session before this fallback runs.
+  }
+
+  refreshSession();
+}
+
 async function checkHealth() {
   healthChecking.value = true;
   try {
@@ -73,9 +96,9 @@ async function logout() {
 }
 
 onMounted(() => {
-  refreshSession();
-  checkHealth();
   stopSessionListener = onSessionChange(refreshSession);
+  void refreshStoredSession();
+  checkHealth();
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
## 改动内容

- 应用启动时，如果浏览器存在缓存登录态，调用 `/api/v1/auth/session` 重新读取当前用户和角色。
- 成功刷新后覆盖本地缓存，避免角色或社团范围在数据库变更后继续沿用旧值。
- 服务端暂时不可用时保留已有缓存；无效会话仍由现有 401 处理清理。
- 增加回归测试，模拟王夫人缓存的“图灵社指导老师”角色被服务端当前“社团管理员”角色替换。

## 改动原因

工作台此前只读取 `localStorage` 中的登录响应。角色或社团状态发生变化后，已经打开过页面的浏览器会继续显示旧身份，即使当前数据库已经没有对应的 `USER_ROLES` 记录。当前数据库只读审计确认王夫人没有指导老师角色，因此需要在应用恢复阶段同步服务端会话。

## 关联 Issue

Part of #7

## 审查关注点

- 登录成功后的现有保存流程不变，只补充应用启动时的会话刷新。
- 401 仍由 `apiClient` 的统一处理清除会话并跳转登录；网络异常不会误清除缓存。
- 不修改数据库结构、角色分配接口或自动生成代码。

## UI 改动

| 改动前 | 改动后 |
|--------|--------|
| 工作台直接显示旧的缓存身份 | 打开应用后先以服务端当前角色更新身份 |

## 测试说明

- Vitest：`121 passed | 1 skipped`。
- `npm run build`：通过，退出码 0。
- `App.vue`、`App.test.ts` 的 Prettier 检查通过。

---

### 检查清单

**代码质量**
- [x] 后端代码未改动
- [x] 前端代码已构建通过
- [x] 已本地回归测试

**数据库（仅涉及时勾选）**
- [x] 无表结构变化


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 应用启动时会自动刷新已保存的登录会话，并持久化最新认证信息。
  - 会话刷新失败或认证失效时，仍会保留本地缓存会话，减少意外退出登录的情况。
  - 优化启动流程，确保会话状态监听及时生效。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->