### PR TITLE
fix(auth): 隐藏已解散社团的当前身份

### DIFF
--- a/backend.Tests/ClubVisibilityTests.cs
+++ b/backend.Tests/ClubVisibilityTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
 using ClubHub.Api.Services;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ClubHub.Api.Tests;
@@ -127,5 +128,81 @@ public sealed class ClubVisibilityTests : IClassFixture<ClubHubWebApplicationFac
             .ToArray();
         Assert.Contains("成员可见运营社团", names);
         Assert.DoesNotContain("成员不可见解散社团", names);
+    }
+
+    [Fact]
+    public async Task SessionRoles_ExcludeRolesScopedToInactiveClubs()
+    {
+        var baseId = 9_302_000 + Interlocked.Increment(ref _sequence) * 10;
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        var authService = scope.ServiceProvider.GetRequiredService<AuthService>();
+        await authService.InitializeBaseRolesAsync();
+
+        var now = DateTime.UtcNow;
+        var activeClubId = baseId + 1;
+        var inactiveClubId = baseId + 2;
+        var user = new User
+        {
+            UserId = baseId,
+            Username = $"session-role-user-{baseId}",
+            PasswordHash = "unused",
+            RealName = "会话角色测试用户",
+            AccountStatus = "normal",
+            CreatedAt = now
+        };
+        db.Users.Add(user);
+        db.Clubs.AddRange(
+            new Club
+            {
+                ClubId = activeClubId,
+                ClubName = "会话运营社团",
+                AuditStatus = "approved",
+                ClubStatus = "active",
+                CreatedAt = now
+            },
+            new Club
+            {
+                ClubId = inactiveClubId,
+                ClubName = "会话已解散社团",
+                AuditStatus = "approved",
+                ClubStatus = "inactive",
+                CreatedAt = now
+            });
+
+        var memberRole = await db.Roles.SingleAsync(role => role.RoleCode == "CLUB_MEMBER");
+        var leaderRole = await db.Roles.SingleAsync(role => role.RoleCode == "CLUB_LEADER");
+        db.UserRoles.AddRange(
+            new UserRole
+            {
+                UserRoleId = baseId + 3,
+                UserId = user.UserId,
+                RoleId = memberRole.RoleId,
+                ClubId = activeClubId,
+                AssignedAt = now
+            },
+            new UserRole
+            {
+                UserRoleId = baseId + 4,
+                UserId = user.UserId,
+                RoleId = leaderRole.RoleId,
+                ClubId = inactiveClubId,
+                AssignedAt = now
+            });
+        await db.SaveChangesAsync();
+
+        var session = await authService.GetSessionAsync(user.UserId, "test-token");
+
+        Assert.True(session.Succeeded, session.ErrorMessage);
+        Assert.Contains(session.Value!.Roles, role => role.ClubId == activeClubId);
+        Assert.DoesNotContain(session.Value.Roles, role => role.ClubId == inactiveClubId);
+
+        var permissionRoles = await authService.GetPermissionRolesAsync(user.UserId);
+        Assert.Contains(permissionRoles, role => role.ClubId == activeClubId);
+        Assert.DoesNotContain(permissionRoles, role => role.ClubId == inactiveClubId);
+
+        Assert.Equal(
+            2,
+            await db.UserRoles.CountAsync(role => role.UserId == user.UserId));
     }
 }

--- a/backend.Tests/ClubVisibilityTests.cs
+++ b/backend.Tests/ClubVisibilityTests.cs
@@ -204,5 +204,43 @@ public sealed class ClubVisibilityTests : IClassFixture<ClubHubWebApplicationFac
         Assert.Equal(
             2,
             await db.UserRoles.CountAsync(role => role.UserId == user.UserId));
+
+        var cachedInactiveRole = new AuthRole(
+            leaderRole.RoleId,
+            leaderRole.RoleCode,
+            leaderRole.RoleName,
+            "会话已解散社团负责人",
+            leaderRole.RoleScope,
+            inactiveClubId,
+            [inactiveClubId],
+            AuthService.GetRolePermissions(leaderRole.RoleCode),
+            leaderRole.PermissionDesc);
+        var cachedAuthService = new AuthService(
+            db,
+            scope.ServiceProvider.GetRequiredService<AuthTokenService>(),
+            scope.ServiceProvider.GetRequiredService<IAuthSessionService>(),
+            new FixedPermissionSnapshotCache(new PermissionSnapshot(user.UserId, [cachedInactiveRole])));
+
+        var filteredCachedRoles = await cachedAuthService.GetPermissionRolesAsync(user.UserId);
+        Assert.DoesNotContain(filteredCachedRoles, role => role.ClubId == inactiveClubId);
+    }
+
+    private sealed class FixedPermissionSnapshotCache(PermissionSnapshot snapshot)
+        : IPermissionSnapshotCache
+    {
+        public Task<PermissionSnapshot> GetOrCreateAsync(
+            int userId,
+            Func<Task<PermissionSnapshot>> factory,
+            CancellationToken cancellationToken = default) => Task.FromResult(snapshot);
+
+        public Task<AccountStatusSnapshot> GetAccountStatusAsync(
+            int userId,
+            Func<Task<AccountStatusSnapshot>> factory,
+            CancellationToken cancellationToken = default) => factory();
+
+        public Task InvalidateAsync(
+            int userId,
+            bool requiredForSafety,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/backend/Services/AuthService.cs
+++ b/backend/Services/AuthService.cs
@@ -650,7 +650,8 @@ public class AuthService
             async () => new PermissionSnapshot(
                 userId,
                 await GetRawAuthRolesAsync(userId)));
-        return BuildPermissionRoles(snapshot.Roles);
+        var currentRoles = await FilterOperationalClubRolesAsync(snapshot.Roles);
+        return BuildPermissionRoles(currentRoles);
     }
 
     private async Task<IReadOnlyList<AuthRole>> GetRawAuthRolesAsync(int userId)
@@ -667,6 +668,29 @@ public class AuthService
             .Where(ur => ur.Role is not null &&
                          (ur.ClubId is null || IsOperationalClub(ur.Club)))
             .Select(ur => ToAuthRole(ur.Role!, ur.ClubId))
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<AuthRole>> FilterOperationalClubRolesAsync(
+        IReadOnlyList<AuthRole> roles)
+    {
+        var clubIds = roles
+            .Where(role => role.ClubId is not null)
+            .Select(role => role.ClubId!.Value)
+            .Distinct()
+            .ToList();
+        if (clubIds.Count == 0) return roles;
+
+        var operationalClubIds = (await _db.Clubs
+                .AsNoTracking()
+                .Where(club => clubIds.Contains(club.ClubId))
+                .ToListAsync())
+            .Where(IsOperationalClub)
+            .Select(club => club.ClubId)
+            .ToHashSet();
+
+        return roles
+            .Where(role => role.ClubId is null || operationalClubIds.Contains(role.ClubId.Value))
             .ToList();
     }
 
@@ -1043,7 +1067,7 @@ public class AuthService
 
         var status = NormalizeText(club.ClubStatus).ToLowerInvariant();
         var auditStatus = NormalizeText(club.AuditStatus).ToLowerInvariant();
-        return (status is "" or ClubActive or "normal" or "enabled" or "运营中" or "正常") &&
+        return (status is ClubActive or "normal" or "enabled" or "运营中" or "正常") &&
                (auditStatus is "" or AuditApproved or "已通过");
     }
 

--- a/backend/Services/AuthService.cs
+++ b/backend/Services/AuthService.cs
@@ -16,6 +16,8 @@ public class AuthService
     private const string ClubOfficerRole = "CLUB_OFFICER";
     private const string ClubLeaderRole = "CLUB_LEADER";
     private const string AdvisorRole = "ADVISOR";
+    private const string AuditApproved = "approved";
+    private const string ClubActive = "active";
     private const string VenueAdminRole = "VENUE_ADMIN";
     private const string SystemAdminRole = "SYSTEM_ADMIN";
     private const int StudentNoLength = 7;
@@ -655,13 +657,15 @@ public class AuthService
     {
         var userRoles = await _db.UserRoles
             .Include(ur => ur.Role)
+            .Include(ur => ur.Club)
             .Where(ur => ur.UserId == userId)
             .OrderBy(ur => ur.RoleId)
             .ThenBy(ur => ur.ClubId)
             .ToListAsync();
 
         return userRoles
-            .Where(ur => ur.Role is not null)
+            .Where(ur => ur.Role is not null &&
+                         (ur.ClubId is null || IsOperationalClub(ur.Club)))
             .Select(ur => ToAuthRole(ur.Role!, ur.ClubId))
             .ToList();
     }
@@ -1031,6 +1035,16 @@ public class AuthService
     {
         var normalized = NormalizeText(user.AccountStatus).ToLowerInvariant();
         return normalized is "active" or NormalStatus or "enabled" or "在任" or "正常";
+    }
+
+    private static bool IsOperationalClub(ClubHub.Api.Data.Entities.Club? club)
+    {
+        if (club is null) return false;
+
+        var status = NormalizeText(club.ClubStatus).ToLowerInvariant();
+        var auditStatus = NormalizeText(club.AuditStatus).ToLowerInvariant();
+        return (status is "" or ClubActive or "normal" or "enabled" or "运营中" or "正常") &&
+               (auditStatus is "" or AuditApproved or "已通过");
     }
 
     private static bool IsUniqueConstraintViolation(DbUpdateException ex)


### PR DESCRIPTION
## 改动内容

- 认证角色汇总只保留运营中且审核通过社团的社团级角色。
- 社团历史成员与角色记录继续保留，不修改数据库结构或业务数据。
- 增加回归测试，验证运营社团角色保留、已解散社团角色和权限范围排除，并覆盖权限缓存中的过期角色。

## 改动原因

解散社团后，历史成员任期和角色需要保留用于追溯，但不应继续作为普通用户的当前身份或有效社团权限。此前社团列表已过滤该状态，运营工作台身份卡片仍直接展示会话返回的全部社团角色。

---

## 关联 Issue

Part of #237

## 审查关注点

- 已解散社团的历史 `USER_ROLES` 是否保留，同时不再进入认证角色和权限角色。
- 兼容旧数据中空值或 `normal`/`enabled` 状态的社团记录。
- 回归测试是否覆盖有效与已解散社团的区分。

## UI 改动

身份卡片和顶部角色提示会随会话角色汇总自动隐藏已解散社团身份；无布局改动。

## 测试说明

- `dotnet test backend.Tests/ClubHub.Api.Tests.csproj --configuration Release --no-restore`：311 个通过。
- 针对 `ClubVisibilityTests` 的回归测试通过。
- `git diff --check` 通过。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过（由后端测试构建验证）
- [ ] 前端代码已构建通过（本次仅修改后端认证逻辑）
- [ ] 已本地手工测试主要场景

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets（请在 PR 描述中注明）

