### PR TITLE
chore(release): 发布已解散社团身份修复

### DIFF
--- a/backend.Tests/ClubVisibilityTests.cs
+++ b/backend.Tests/ClubVisibilityTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using ClubHub.Api.Data;
 using ClubHub.Api.Data.Entities;
 using ClubHub.Api.Services;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ClubHub.Api.Tests;
@@ -127,5 +128,81 @@ public sealed class ClubVisibilityTests : IClassFixture<ClubHubWebApplicationFac
             .ToArray();
         Assert.Contains("成员可见运营社团", names);
         Assert.DoesNotContain("成员不可见解散社团", names);
+    }
+
+    [Fact]
+    public async Task SessionRoles_ExcludeRolesScopedToInactiveClubs()
+    {
+        var baseId = 9_302_000 + Interlocked.Increment(ref _sequence) * 10;
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClubHubDbContext>();
+        var authService = scope.ServiceProvider.GetRequiredService<AuthService>();
+        await authService.InitializeBaseRolesAsync();
+
+        var now = DateTime.UtcNow;
+        var activeClubId = baseId + 1;
+        var inactiveClubId = baseId + 2;
+        var user = new User
+        {
+            UserId = baseId,
+            Username = $"session-role-user-{baseId}",
+            PasswordHash = "unused",
+            RealName = "会话角色测试用户",
+            AccountStatus = "normal",
+            CreatedAt = now
+        };
+        db.Users.Add(user);
+        db.Clubs.AddRange(
+            new Club
+            {
+                ClubId = activeClubId,
+                ClubName = "会话运营社团",
+                AuditStatus = "approved",
+                ClubStatus = "active",
+                CreatedAt = now
+            },
+            new Club
+            {
+                ClubId = inactiveClubId,
+                ClubName = "会话已解散社团",
+                AuditStatus = "approved",
+                ClubStatus = "inactive",
+                CreatedAt = now
+            });
+
+        var memberRole = await db.Roles.SingleAsync(role => role.RoleCode == "CLUB_MEMBER");
+        var leaderRole = await db.Roles.SingleAsync(role => role.RoleCode == "CLUB_LEADER");
+        db.UserRoles.AddRange(
+            new UserRole
+            {
+                UserRoleId = baseId + 3,
+                UserId = user.UserId,
+                RoleId = memberRole.RoleId,
+                ClubId = activeClubId,
+                AssignedAt = now
+            },
+            new UserRole
+            {
+                UserRoleId = baseId + 4,
+                UserId = user.UserId,
+                RoleId = leaderRole.RoleId,
+                ClubId = inactiveClubId,
+                AssignedAt = now
+            });
+        await db.SaveChangesAsync();
+
+        var session = await authService.GetSessionAsync(user.UserId, "test-token");
+
+        Assert.True(session.Succeeded, session.ErrorMessage);
+        Assert.Contains(session.Value!.Roles, role => role.ClubId == activeClubId);
+        Assert.DoesNotContain(session.Value.Roles, role => role.ClubId == inactiveClubId);
+
+        var permissionRoles = await authService.GetPermissionRolesAsync(user.UserId);
+        Assert.Contains(permissionRoles, role => role.ClubId == activeClubId);
+        Assert.DoesNotContain(permissionRoles, role => role.ClubId == inactiveClubId);
+
+        Assert.Equal(
+            2,
+            await db.UserRoles.CountAsync(role => role.UserId == user.UserId));
     }
 }

--- a/backend.Tests/ClubVisibilityTests.cs
+++ b/backend.Tests/ClubVisibilityTests.cs
@@ -204,5 +204,43 @@ public sealed class ClubVisibilityTests : IClassFixture<ClubHubWebApplicationFac
         Assert.Equal(
             2,
             await db.UserRoles.CountAsync(role => role.UserId == user.UserId));
+
+        var cachedInactiveRole = new AuthRole(
+            leaderRole.RoleId,
+            leaderRole.RoleCode,
+            leaderRole.RoleName,
+            "会话已解散社团负责人",
+            leaderRole.RoleScope,
+            inactiveClubId,
+            [inactiveClubId],
+            AuthService.GetRolePermissions(leaderRole.RoleCode),
+            leaderRole.PermissionDesc);
+        var cachedAuthService = new AuthService(
+            db,
+            scope.ServiceProvider.GetRequiredService<AuthTokenService>(),
+            scope.ServiceProvider.GetRequiredService<IAuthSessionService>(),
+            new FixedPermissionSnapshotCache(new PermissionSnapshot(user.UserId, [cachedInactiveRole])));
+
+        var filteredCachedRoles = await cachedAuthService.GetPermissionRolesAsync(user.UserId);
+        Assert.DoesNotContain(filteredCachedRoles, role => role.ClubId == inactiveClubId);
+    }
+
+    private sealed class FixedPermissionSnapshotCache(PermissionSnapshot snapshot)
+        : IPermissionSnapshotCache
+    {
+        public Task<PermissionSnapshot> GetOrCreateAsync(
+            int userId,
+            Func<Task<PermissionSnapshot>> factory,
+            CancellationToken cancellationToken = default) => Task.FromResult(snapshot);
+
+        public Task<AccountStatusSnapshot> GetAccountStatusAsync(
+            int userId,
+            Func<Task<AccountStatusSnapshot>> factory,
+            CancellationToken cancellationToken = default) => factory();
+
+        public Task InvalidateAsync(
+            int userId,
+            bool requiredForSafety,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/backend/Services/AuthService.cs
+++ b/backend/Services/AuthService.cs
@@ -650,7 +650,8 @@ public class AuthService
             async () => new PermissionSnapshot(
                 userId,
                 await GetRawAuthRolesAsync(userId)));
-        return BuildPermissionRoles(snapshot.Roles);
+        var currentRoles = await FilterOperationalClubRolesAsync(snapshot.Roles);
+        return BuildPermissionRoles(currentRoles);
     }
 
     private async Task<IReadOnlyList<AuthRole>> GetRawAuthRolesAsync(int userId)
@@ -667,6 +668,29 @@ public class AuthService
             .Where(ur => ur.Role is not null &&
                          (ur.ClubId is null || IsOperationalClub(ur.Club)))
             .Select(ur => ToAuthRole(ur.Role!, ur.ClubId))
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<AuthRole>> FilterOperationalClubRolesAsync(
+        IReadOnlyList<AuthRole> roles)
+    {
+        var clubIds = roles
+            .Where(role => role.ClubId is not null)
+            .Select(role => role.ClubId!.Value)
+            .Distinct()
+            .ToList();
+        if (clubIds.Count == 0) return roles;
+
+        var operationalClubIds = (await _db.Clubs
+                .AsNoTracking()
+                .Where(club => clubIds.Contains(club.ClubId))
+                .ToListAsync())
+            .Where(IsOperationalClub)
+            .Select(club => club.ClubId)
+            .ToHashSet();
+
+        return roles
+            .Where(role => role.ClubId is null || operationalClubIds.Contains(role.ClubId.Value))
             .ToList();
     }
 
@@ -1043,7 +1067,7 @@ public class AuthService
 
         var status = NormalizeText(club.ClubStatus).ToLowerInvariant();
         var auditStatus = NormalizeText(club.AuditStatus).ToLowerInvariant();
-        return (status is "" or ClubActive or "normal" or "enabled" or "运营中" or "正常") &&
+        return (status is ClubActive or "normal" or "enabled" or "运营中" or "正常") &&
                (auditStatus is "" or AuditApproved or "已通过");
     }
 

--- a/backend/Services/AuthService.cs
+++ b/backend/Services/AuthService.cs
@@ -16,6 +16,8 @@ public class AuthService
     private const string ClubOfficerRole = "CLUB_OFFICER";
     private const string ClubLeaderRole = "CLUB_LEADER";
     private const string AdvisorRole = "ADVISOR";
+    private const string AuditApproved = "approved";
+    private const string ClubActive = "active";
     private const string VenueAdminRole = "VENUE_ADMIN";
     private const string SystemAdminRole = "SYSTEM_ADMIN";
     private const int StudentNoLength = 7;
@@ -655,13 +657,15 @@ public class AuthService
     {
         var userRoles = await _db.UserRoles
             .Include(ur => ur.Role)
+            .Include(ur => ur.Club)
             .Where(ur => ur.UserId == userId)
             .OrderBy(ur => ur.RoleId)
             .ThenBy(ur => ur.ClubId)
             .ToListAsync();
 
         return userRoles
-            .Where(ur => ur.Role is not null)
+            .Where(ur => ur.Role is not null &&
+                         (ur.ClubId is null || IsOperationalClub(ur.Club)))
             .Select(ur => ToAuthRole(ur.Role!, ur.ClubId))
             .ToList();
     }
@@ -1031,6 +1035,16 @@ public class AuthService
     {
         var normalized = NormalizeText(user.AccountStatus).ToLowerInvariant();
         return normalized is "active" or NormalStatus or "enabled" or "在任" or "正常";
+    }
+
+    private static bool IsOperationalClub(ClubHub.Api.Data.Entities.Club? club)
+    {
+        if (club is null) return false;
+
+        var status = NormalizeText(club.ClubStatus).ToLowerInvariant();
+        var auditStatus = NormalizeText(club.AuditStatus).ToLowerInvariant();
+        return (status is "" or ClubActive or "normal" or "enabled" or "运营中" or "正常") &&
+               (auditStatus is "" or AuditApproved or "已通过");
     }
 
     private static bool IsUniqueConstraintViolation(DbUpdateException ex)


### PR DESCRIPTION
## 改动内容

- 将已解散社团的社团级角色从认证会话和权限角色汇总中排除。
- 权限快照命中缓存后按当前社团状态复核，避免解散后继续使用过期的社团权限。
- 保留历史成员、任期和 `USER_ROLES` 数据，未增加数据库迁移。

## 改动原因

发布 PR #240 在 `dev` 已完成验证，修复运营工作台仍显示“测试社团成员/负责人”的问题，并保证解散社团的历史记录可追溯。

---

## 关联 Issue

Part of #237

## 审查关注点

- `dev` 中的认证角色过滤和权限缓存复核是否完整进入阶段性稳定版本。
- 不删除历史成员或角色记录，不改变数据库结构。

## UI 改动

普通用户重新加载或刷新会话后，工作台身份卡片和顶部角色提示不再显示已解散社团身份。

## 测试说明

- `dev` PR #240 的 CI、代码质量门禁全部通过。
- 后端本地测试：311 个通过。
- 回归测试验证运营社团角色保留、已解散社团角色排除、历史 `UserRole` 记录保留和缓存角色过滤。

---

### 检查清单

**代码质量**
- [x] 后端代码已构建通过
- [ ] 前端代码已构建通过（本发布仅含后端改动）
- [x] 已完成本地回归测试

**数据库（仅涉及时勾选）**
- [x] 无表结构变化
- [ ] 表结构变更已写入 `database/`
- [ ] 种子数据、视图、索引、触发器、存储过程已同步

**文档与部署（仅涉及时勾选）**
- [ ] 课程文档已同步更新
- [ ] 需要新增或修改 GitHub Secrets
